### PR TITLE
fix: update broken reference links in observability guide

### DIFF
--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -64,6 +64,6 @@ oc get telemetry.telemetry.istio.io latency-per-subscription -n openshift-ingres
 
 == References
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/monitoring/cluster-observability-operator[Cluster Observability Operator documentation]
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2-latest/html/monitoring_data_science_models/index[RHOAI Observability dashboard]
-* link:https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/telemetrypolicy/[Kuadrant TelemetryPolicy]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/1-latest[Cluster Observability Operator documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html-single/govern_llm_access_with_models-as-a-service/index#maas-observability_maas-deploy[RHOAI Observability dashboard]
+* link:https://docs.kuadrant.io/dev/kuadrant-operator/doc/reference/telemetrypolicy/[Kuadrant TelemetryPolicy]


### PR DESCRIPTION
Updated three broken/outdated reference links in Phase 7 (Observability):

- **COO**: pointed to OCP 4.17 monitoring subsection → now points to standalone COO product docs (1-latest)
- **RHOAI Observability**: pointed to outdated 2.x `monitoring_data_science_models` → now points to RHOAI 3.4 MaaS observability section
- **Kuadrant TelemetryPolicy**: pointed to `latest` path → now uses `dev` path for the extension API reference