### PR TITLE
fix: clarify platform detection in Step 3 with a table

### DIFF
--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -91,22 +91,31 @@ If your cluster has GPU nodes (or you plan to add them), install the GPU operato
 oc apply -k manifests/01-prerequisites/gpu/
 ----
 
-=== Step 3 Install MetalLB for Non-Cloud Clusters - Non-Cloud Platforms Only
+=== Step 3: Install MetalLB (Non-Cloud Platforms Only)
 
 NOTE: Read this section carefully!
 
-If your cluster is `baremetal`, `OpenStack`, or a `RHPDS/SNO` environment (i.e. no cloud LB controller), you will need to do some extra configuration to make the Gateway accessible from outside the cluster.
+If your cluster has no cloud load-balancer controller (baremetal, OpenStack, RHPDS/SNO), you need MetalLB to make the Gateway accessible externally.
 
-First, let's determine the platform type of your cluster.
+First, determine your platform type:
 
 [source,bash]
 ----
 oc get infrastructure cluster -o jsonpath='{.status.platform}'
 ----
 
-If the output is `AWS`, `Azure`, `GCP`, or another cloud provider: Skip to Step `Verification` below.
+[cols="1,2", options="header"]
+|===
+| Platform output | What to do
 
-If the output is `None`, `BareMetal`, or `OpenStack`: Your cluster is running on a non-cloud platform and requires `MetalLB` and a `passthrough Route`. Continue below.
+| `AWS`, `Azure`, `GCP` (cloud)
+| *Skip to <<Verification>> below* — no extra configuration needed.
+
+| `None`, `BareMetal`, `OpenStack`
+| *Continue with the steps below* — MetalLB and a passthrough Route are required.
+|===
+
+Install the MetalLB operator:
 
 [source,bash]
 ----


### PR DESCRIPTION
Replaced the TIP + IMPORTANT admonition boxes in the platform detection section with a clean two-column table (platform output → what to do). Added a transition line before the MetalLB install command.

Reduces admonition clutter and makes the cloud vs non-cloud decision easier to scan.