### PR TITLE
fix: clean up redundancies and typos from PRs #4 and #8

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -345,7 +345,7 @@ maas-default-gateway   openshift-default   10.10.10.10   True         13m
 $ oc get route maas-default-gateway-https -n openshift-ingress -o jsonpath='{.status.ingress[0].conditions[?(@.type=="Admitted")].status}'
 True
 
-$ CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')n}')
+$ CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
 $ echo $CLUSTER_DOMAIN
 apps.`<your cluster name>`.`<your domain>`
 curl -vsk https://maas.${CLUSTER_DOMAIN} 2>&1 | grep -E "SSL connection|Connected"

--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -32,7 +32,7 @@ On a fresh install, apply in two stages. The `OdhDashboardConfig` CRD does not e
 oc apply -f manifests/04-rhoai-config/dscinitialization.yaml
 ----
 
-Wait until the DCSI is created (this step must complete before creating the DSC):
+Wait until the DSCI is created (this step must complete before creating the DSC):
 
 [source,bash]
 ----
@@ -47,7 +47,7 @@ Create the Data Science Cluster:
 oc apply -f manifests/04-rhoai-config/datasciencecluster.yaml
 ----
 
-The DataScienceCluster reconciles multiple components. Wait for `KServe` and the `Model Controller` (MaaS) to reach Ready: +
+The DataScienceCluster reconciles multiple components. Wait for `KServe` and the `Model Controller` (MaaS) to reach Ready:
 
 [source,bash]
 ----
@@ -55,7 +55,7 @@ oc wait --for=jsonpath='{.status.phase}'=Ready \
   datasciencecluster/default-dsc --timeout=600s
 ----
 
-With the Data Science Cluster created we can not apply the dashboard configuration:
+With the Data Science Cluster created we can now apply the dashboard configuration:
 
 [source,bash]
 ----
@@ -113,13 +113,6 @@ NOTE: The `default-tenant` CR may show `Ready=False` with reason `DeploymentsNot
 CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
 curl -sk "https://maas.${CLUSTER_DOMAIN}/maas-api/health"
 # Expected: {"status":"healthy"}
-----
-
-=== Check DSCInitialization
-
-[source,bash]
-----
-oc get dscinitializations default-dsci -o jsonpath='{.status.conditions}' | jq .
 ----
 
 === Check OdhDashboardConfig flags


### PR DESCRIPTION
Follow-up cleanup after PRs #4 and #8.

**Module 4 (`04-rhoai-config.adoc`):**
- Removed redundant "Check DSCInitialization" verify section — we already `oc wait` for DSCI Ready in the Apply section
- Fixed typo: `DCSI` → `DSCI`
- Fixed typo: "we can not apply" → "we can now apply"
- Removed stray AsciiDoc line continuation (`+`)

**Module 2 (`02-platform-config.adoc`):**
- Fixed copy-paste artifact: `'{.spec.domain}')n}')` → `'{.spec.domain}')`