### PR TITLE
fix: address bugs found during end-to-end testing on RHOAI 3.4.0

### DIFF
--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -78,6 +78,7 @@ oc get crd | grep maas.opendatahub.io
 
 Expected CRDs:
 
+* externalmodels.maas.opendatahub.io
 * maasauthpolicies.maas.opendatahub.io
 * maasmodelrefs.maas.opendatahub.io
 * maassubscriptions.maas.opendatahub.io

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -85,11 +85,12 @@ Each model follows the same Kustomize layout:
 
 == Deploying a Model
 
-Create the `llm` namespace if it doesn't exist:
+Create the `llm` namespace if it doesn't exist and label it for RHOAI:
 
 [source,bash]
 ----
 oc create namespace llm
+oc label namespace llm opendatahub.io/generated-namespace=true --overwrite
 ----
 
 Deploy the simulator (no GPU required):

--- a/manifests/06-verification/verify.sh
+++ b/manifests/06-verification/verify.sh
@@ -248,7 +248,9 @@ log_step "Phase 2: Deploy simulator model and MaaS resources"
 
 # Create namespaces
 oc create namespace "$MODEL_NS" --dry-run=client -o yaml | oc apply -f - 2>/dev/null
+oc label namespace "$MODEL_NS" opendatahub.io/generated-namespace=true --overwrite 2>/dev/null || true
 oc create namespace "$MAAS_NS" --dry-run=client -o yaml | oc apply -f - 2>/dev/null
+oc label namespace "$MAAS_NS" opendatahub.io/generated-namespace=true --overwrite 2>/dev/null || true
 log_info "Ensured namespaces: $MODEL_NS, $MAAS_NS"
 
 # Deploy LLMInferenceService (simulator model)

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -253,7 +253,7 @@ if should_run 1; then
                 log_info "  Waiting for CSV in $ns..."
                 oc wait csv -n "$ns" -l "$label=" \
                     --for=jsonpath='{.status.phase}'=Succeeded --timeout=600s 2>/dev/null || \
-                    log_warn "  CSV in $ns did not reach Succeeded within 600s"
+                    { log_error "  CSV in $ns did not reach Succeeded within 600s — aborting (re-run with --from-phase 1 after manual check)"; exit 1; }
             done
         fi
         log_info "All operator CSVs ready"
@@ -283,9 +283,9 @@ if should_run 2; then
                     -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || echo "")
                 if echo "$KUADRANT_MSG" | grep -i "MissingDependency" >/dev/null 2>&1; then
                     log_warn "Kuadrant reports MissingDependency (Istio race)  - restarting operator pod..."
-                    oc delete pod -n openshift-operators -l app.kubernetes.io/name=kuadrant-operator-controller-manager 2>/dev/null || \
-                        oc delete pod -n openshift-operators -l control-plane=controller-manager 2>/dev/null || \
-                        oc delete pod -n openshift-operators $(oc get pods -n openshift-operators --no-headers 2>/dev/null | grep kuadrant-operator | awk '{print $1}' | head -1) 2>/dev/null || true
+                    oc delete pod -n openshift-operators \
+                        $(oc get pods -n openshift-operators --no-headers 2>/dev/null | grep kuadrant-operator | awk '{print $1}' | head -1) 2>/dev/null || \
+                        oc delete pod -n openshift-operators -l control-plane=controller-manager,app=kuadrant 2>/dev/null || true
                     log_info "Operator pod restarted, waiting for Kuadrant Ready..."
                 fi
                 oc wait --for=condition=Ready kuadrant/kuadrant -n kuadrant-system --timeout=180s 2>/dev/null || \
@@ -563,6 +563,16 @@ if should_run 4; then
 
         log_step "Applying OdhDashboardConfig..."
         run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/odh-dashboard-config.yaml"
+        if [ "$DRY_RUN" = false ]; then
+            for _attempt in 1 2 3; do
+                sleep 10
+                MAAS_FLAG=$(oc get odhdashboardconfig odh-dashboard-config -n "$NAMESPACE" \
+                    -o jsonpath='{.spec.dashboardConfig.modelAsService}' 2>/dev/null || echo "")
+                if [ "$MAAS_FLAG" = "true" ]; then break; fi
+                log_warn "Dashboard config flags overridden by operator — re-applying (attempt $_attempt)..."
+                oc apply -f "$MANIFESTS_DIR/04-rhoai-config/odh-dashboard-config.yaml" 2>/dev/null || true
+            done
+        fi
         log_info "Dashboard config applied"
     fi
 
@@ -658,6 +668,7 @@ if should_run 5 && [ "$SKIP_MODELS" = false ]; then
         if ! oc get namespace llm &>/dev/null; then
             run_cmd oc create namespace llm
         fi
+        oc label namespace llm opendatahub.io/generated-namespace=true --overwrite 2>/dev/null || true
         run_cmd oc apply -k "$MODEL_DIR/"
         log_info "Model manifests applied"
 
@@ -764,7 +775,7 @@ if [ "$DRY_RUN" = true ]; then
     log_info "Status:        DRY RUN  - no changes applied"
 else
     # Gather final state
-    RHOAI_VERSION=$(oc get csv -n redhat-ods-operator --no-headers 2>/dev/null | grep rhods | awk '{print $2}' || echo "unknown")
+    RHOAI_VERSION=$(oc get csv -n redhat-ods-operator -l operators.coreos.com/rhods-operator.redhat-ods-operator= -o jsonpath='{.items[0].spec.version}' 2>/dev/null || echo "unknown")
     GW_STATUS=$(oc get gateway maas-default-gateway -n openshift-ingress \
         -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null || echo "Unknown")
     API_READY=$(oc get deployment maas-api -n "$NAMESPACE" \


### PR DESCRIPTION
## Summary

Fixes #1 — end-to-end testing on a fresh RHPDS cluster (OCP 4.20.24, RHOAI 3.4.0, platform type `None`) found 5 script bugs and 2 doc inaccuracies.

### Script fixes (`setup-maas.sh`)

- **Phase 1 CSV timeout**: now aborts (`exit 1`) instead of `log_warn` + continue, which caused guaranteed Phase 2 failures on slow clusters
- **Kuadrant pod restart**: the label `app.kubernetes.io/name=kuadrant-operator-controller-manager` didn't match actual pods; `oc delete pod -l <non-matching>` exits 0 silently, so the `||` fallback chain never triggered. Now uses `grep kuadrant-operator` as primary method
- **ODH namespace label**: `oc create namespace llm` now adds `opendatahub.io/generated-namespace=true` so the namespace appears in RHOAI Dashboard
- **RHOAI version parsing**: `awk '{print $2}'` returned "Red" from "Red Hat OpenShift AI 3.4.0"; now uses `jsonpath` for the version field
- **OdhDashboardConfig race**: verifies `modelAsService=true` persisted after apply and re-applies up to 3 times if the RHOAI operator overwrote it during reconciliation

### Verification script (`verify.sh`)

- Adds ODH namespace labels when creating test namespaces (same fix as setup-maas.sh)

### Documentation

- Added missing `externalmodels.maas.opendatahub.io` CRD to Phase 4 expected CRD list
- Added `oc label namespace llm opendatahub.io/generated-namespace=true` to Phase 5 manual instructions

## Test plan

- [x] Tested full `setup-maas.sh --model simulator` run on RHPDS cluster (OCP 4.20.24, RHOAI 3.4.0)
- [x] First run achieved 15/15 verification pass
- [x] Verified `test-inference.sh` convenience script works
- [x] Confirmed ODH label fix resolves Issue #1 Bug 3
- [x] Confirmed Kuadrant restart fix resolves Issue #1 Bug 2