### PR TITLE
fix: remove misleading Quick start section from Phase 3 manual page

### DIFF
--- a/content/modules/ROOT/pages/03-maas-platform.adoc
+++ b/content/modules/ROOT/pages/03-maas-platform.adoc
@@ -15,14 +15,7 @@ The MaaS platform requires a PostgreSQL database before the RHOAI operator can f
 . *PostgreSQL database* - stores API key metadata (hashed tokens, subscription bindings, expiration, revocation state).
 . *PostgreSQL secrets* - `postgres-creds` (DB credentials) and `maas-db-config` (connection URL consumed by maas-api).
 
-== Quick start (automated)
-
-The `scripts/setup-maas.sh` script handles all of the above in a single command:
-
-[source,bash]
-----
-./scripts/setup-maas.sh
-----
+TIP: If you prefer the fully automated path, see xref:quick-start.adoc[Automated Setup]. To run only this phase automatically: `./scripts/setup-maas.sh --from-phase 3`
 
 == Manual setup
 


### PR DESCRIPTION
## Summary

The Phase 3 (MaaS Platform) manual page had a "Quick start (automated)" section containing a bare `./scripts/setup-maas.sh` command. This is confusing because:

- `setup-maas.sh` runs **all 7 phases**, not just Phase 3
- A reader following the manual step-by-step path sees this and doesn't know if it replaces just this phase or the entire guide
- The automated path already has its own dedicated page (Automated Setup)

Replaced with a one-line TIP that cross-references the Automated Setup page and shows `--from-phase 3` for running only this phase.

## Test plan

- [x] Verified no other phase pages have this pattern (only 03-maas-platform had it)
- [x] Cross-reference to quick-start.adoc is correct