### PR TITLE
fix: update expected outputs to match RHOAI 3.4.0 / RHCL 1.4.0

### DIFF
--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -227,17 +227,20 @@ oc get subscriptions.operators.coreos.com -A \
 
 Expected Results:
 
+NOTE: Exact CSV versions will vary depending on when you install. The versions below were current as of June 2026.
+
 [source]
 ----
 NAMESPACE                NAME                                                                                   CSV                                                STATE
 cert-manager-operator    openshift-cert-manager-operator                                                        cert-manager-operator.v1.19.0                      AtLatestKnown
-metallb-system           metallb-operator                                                                       metallb-operator.v4.20.0-202605260442              AtLatestKnown
+metallb-system           metallb-operator                                                                       metallb-operator.v4.20.0-...                       AtLatestKnown
 openshift-lws-operator   leader-worker-set                                                                      leader-worker-set.v1.0.0                           AtLatestKnown
-openshift-operators      authorino-operator-stable-redhat-operators-openshift-marketplace                       authorino-operator.v1.3.1                          AtLatestKnown
-openshift-operators      limitador-operator-stable-redhat-operators-openshift-marketplace                       limitador-operator.v1.3.1                          AtLatestKnown
-openshift-operators      rhcl-operator                                                                          rhcl-operator.v1.3.4                               AtLatestKnown
+openshift-operators      authorino-operator-stable-redhat-operators-openshift-marketplace                       authorino-operator.v1.4.0                          AtLatestKnown
+openshift-operators      dns-operator-stable-redhat-operators-openshift-marketplace                             dns-operator.v1.4.0                                AtLatestKnown
+openshift-operators      limitador-operator-stable-redhat-operators-openshift-marketplace                       limitador-operator.v1.4.0                          AtLatestKnown
+openshift-operators      rhcl-operator                                                                          rhcl-operator.v1.4.0                               AtLatestKnown
 openshift-operators      servicemeshoperator3                                                                   servicemeshoperator3.v3.3.3                        AtLatestKnown
-
+redhat-ods-operator      rhods-operator                                                                         rhods-operator.3.4.0                               AtLatestKnown
 ----
 
 = Appendix:

--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -286,8 +286,8 @@ Expected output:
 
 [source]
 ----
-NAME                          HOST/PORT                              PATH   SERVICES                                   PORT    TERMINATION   WILDCARD
-maas-default-gateway-https   maas.apps.                    maas-default-gateway-openshift-default     https   passthrough   None
+NAME                         HOST/PORT                              PATH   SERVICES                                 PORT    TERMINATION            WILDCARD
+maas-default-gateway-https   maas.apps.<cluster-domain>                    maas-default-gateway-openshift-default   https   passthrough/Redirect   None
 ----
 
 
@@ -359,7 +359,8 @@ $ CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.s
 $ echo $CLUSTER_DOMAIN
 apps.`<your cluster name>`.`<your domain>`
 curl -vsk https://maas.${CLUSTER_DOMAIN} 2>&1 | grep -E "SSL connection|Connected"
-* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / x25519 / RSASSA-PSS
+* Connected to maas.apps.<cluster-domain> (...) port 443
+* SSL connection using TLSv1.3 / ...    <-- exact cipher varies by client
 ----
 
 == References

--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -18,8 +18,8 @@ Expected output:
 
 [source]
 ----
-NAME                DISPLAY                    VERSION   REPLICA   PHASE       AGE
-rhods-operator       Red Hat OpenShift AI       3.4.0     1         Succeeded   25m
+NAME                     DISPLAY                 VERSION   REPLACES               PHASE
+rhods-operator.3.4.0     Red Hat OpenShift AI    3.4.0     rhods-operator.3.3.2   Succeeded
 ----
 
 == Apply

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -147,14 +147,15 @@ MAAS_URL="maas.${CLUSTER_DOMAIN}"
 API_KEY=$(curl -sk -X POST "https://${MAAS_URL}/maas-api/v1/api-keys" \
   -H "Authorization: Bearer $(oc whoami -t)" \
   -H "Content-Type: application/json" \
-  -d '{"name": "test-key"}' | jq -r '.key')
+  -d '{"name": "test-key", "subscription": "simulator-subscription", "expiresIn": "1h"}' \
+  | jq -r '.key')
 
 # List available models
-curl -sk "https://${MAAS_URL}/maas-api/v1/models" \
+curl -sk "https://${MAAS_URL}/v1/models" \
   -H "Authorization: Bearer ${API_KEY}"
 
 # Get the model endpoint URL from the listing
-MODEL_URL=$(curl -sk "https://${MAAS_URL}/maas-api/v1/models" \
+MODEL_URL=$(curl -sk "https://${MAAS_URL}/v1/models" \
   -H "Authorization: Bearer ${API_KEY}" | jq -r '.data[0].url')
 
 # Send a chat completion request (uses the model-specific URL path)

--- a/content/modules/ROOT/pages/06-verification.adoc
+++ b/content/modules/ROOT/pages/06-verification.adoc
@@ -45,7 +45,7 @@ When all checks pass, the script prints:
 MaaS Verification Summary
 =========================================
 MaaS API URL:  https://maas.<cluster-domain>
-Passed:        10
+Passed:        15
 Failed:        0
 Status:        ALL CHECKS PASSED
 =========================================
@@ -98,15 +98,21 @@ oc get pods -n llm
 DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 HOST="https://maas.${DOMAIN}"
 
-# Create API key
-curl -sk -X POST \
+# Create API key (save the key and model URL for subsequent phases)
+API_KEY=$(curl -sk -X POST \
   -H "Authorization: Bearer $(oc whoami -t)" \
   -H "Content-Type: application/json" \
   -d '{"name":"test","expiresIn":"1h","subscription":"simulator-subscription"}' \
-  "${HOST}/maas-api/v1/api-keys"
+  "${HOST}/maas-api/v1/api-keys" | jq -r '.key')
+echo "API_KEY=${API_KEY}"
 
-# List models (use the key from the previous response)
-curl -sk -H "Authorization: Bearer <API_KEY>" "${HOST}/maas-api/v1/models"
+# List models
+curl -sk -H "Authorization: Bearer ${API_KEY}" "${HOST}/v1/models"
+
+# Get the model endpoint URL
+MODEL_URL=$(curl -sk -H "Authorization: Bearer ${API_KEY}" \
+  "${HOST}/v1/models" | jq -r '.data[0].url')
+echo "MODEL_URL=${MODEL_URL}"
 ----
 
 === Phase 4: Auth enforcement
@@ -117,7 +123,7 @@ curl -sk -H "Authorization: Bearer <API_KEY>" "${HOST}/maas-api/v1/models"
 curl -sk -o /dev/null -w '%{http_code}' \
   -H "Content-Type: application/json" \
   -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Hello"}]}' \
-  "<MODEL_URL>/v1/chat/completions"
+  "${MODEL_URL}/v1/chat/completions"
 ----
 
 === Phase 5: Rate limiting
@@ -127,10 +133,10 @@ curl -sk -o /dev/null -w '%{http_code}' \
 # Send rapid requests and watch for 429
 for i in $(seq 1 16); do
   curl -sk -o /dev/null -w '%{http_code}\n' \
-    -H "Authorization: Bearer <API_KEY>" \
+    -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
     -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Hello, write a long essay"}],"max_tokens":50}' \
-    "<MODEL_URL>/v1/chat/completions"
+    "${MODEL_URL}/v1/chat/completions"
 done
 ----
 


### PR DESCRIPTION
## Summary

Every command and expected output block in the guide was tested against a live cluster (OCP 4.20.24, RHOAI 3.4.0, RHCL 1.4.0). This PR fixes all mismatches found.

### Changes by file

**01-prerequisites.adoc** — CSV versions outdated
- authorino/limitador bumped from 1.3.1 → 1.4.0, rhcl from 1.3.4 → 1.4.0
- Added missing `rhods-operator` and `dns-operator` subscriptions to expected output
- Added NOTE that versions will drift over time

**02-platform-config.adoc** — Route and TLS output mismatches
- Route TERMINATION column shows `passthrough/Redirect` (not bare `passthrough`) because the route template sets `insecureEdgeTerminationPolicy: Redirect`
- TLS cipher string varies by curl/OpenSSL version; replaced exact cipher with generic note

**04-rhoai-config.adoc** — CSV column names wrong
- Column was `REPLICA` but actual `oc get csv` shows `REPLACES`; no `AGE` column in default output

**05-maas-models.adoc** — API key creation fails without subscription
- Added required `subscription` and `expiresIn` fields to the curl command
- Fixed model listing endpoint: `/maas-api/v1/models` (admin/oc-token) → `/v1/models` (API key auth)

**06-verification.adoc** — Pass count and placeholders
- `Passed: 10` → `Passed: 15` (verify.sh actually has 15 checks)
- Replaced `<MODEL_URL>` and `<API_KEY>` static placeholders with working shell variable assignments so readers can copy-paste the full block

## Test plan

- [x] Every command in all 7 phase docs tested on live RHPDS cluster
- [x] Antora site builds without new errors
- [x] Expected outputs match actual cluster output