### PR TITLE
fix: standardize end-of-chapter structure across all chapters

### DIFF
--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -243,9 +243,9 @@ openshift-operators      servicemeshoperator3                                   
 redhat-ods-operator      rhods-operator                                                                         rhods-operator.3.4.0                               AtLatestKnown
 ----
 
-= Appendix:
+== Appendix
 
-== Directory Structure
+=== Directory Structure
 
 [source]
 ----
@@ -274,3 +274,7 @@ manifests/01-prerequisites/
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service_maas[RHOAI 3.4 MaaS Official Docs]
 * link:https://opendatahub-io.github.io/models-as-a-service/latest/[Upstream MaaS Documentation]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/installing_and_uninstalling_openshift_ai_self-managed/index[RHOAI 3.4 Installation Guide]
+
+== Next step
+
+Proceed to xref:02-platform-config.adoc[Phase 2: Platform Configuration].

--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -21,7 +21,7 @@ these components expose metrics that User Workload Monitoring can scrape, which 
 
 The Kuadrant operator auto-creates an Authorino instance when reconciling the Kuadrant resource. You'll enable TLS on that Authorino instance in the next step.
 
-[Note:]
+[NOTE]
 ====
 Apply the namespace, service annotation, and Kuadrant CR. Do *not* apply the full kustomization in one shot. The Kuadrant operator auto-creates an Authorino CR when it reconciles the Kuadrant resource, so the Authorino CR must be configured separately via `oc patch` after Kuadrant is ready.
 ====
@@ -401,6 +401,6 @@ curl -vsk https://maas.${CLUSTER_DOMAIN} 2>&1 | grep -E "SSL connection|Connecte
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/monitoring/enabling-monitoring-for-user-defined-projects[OpenShift User Workload Monitoring]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/networking/gateway-api[Gateway API on OpenShift]
 
-== Next Steps
+== Next step
 
 Proceed to xref:03-maas-platform.adoc[Phase 3: MaaS Platform].

--- a/content/modules/ROOT/pages/03-maas-platform.adoc
+++ b/content/modules/ROOT/pages/03-maas-platform.adoc
@@ -139,6 +139,11 @@ On baremetal/OpenStack clusters without a cloud LB controller:
 * See `openshift-gateway-setup/` for MetalLB configuration
 * On cloud clusters, the LB provisions automatically
 
+== References
+
+* link:https://github.com/opendatahub-io/models-as-a-service/blob/main/docs/content/install/maas-setup.md[MaaS Setup (upstream)]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service_maas[RHOAI 3.4 MaaS Official Docs]
+
 == Next step
 
 Proceed to xref:04-rhoai-config.adoc[Phase 4: RHOAI Configuration].

--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -163,6 +163,12 @@ oc logs -n redhat-ods-operator deployment/rhods-operator --tail=100
 oc get pods -n redhat-ods-applications
 ----
 
+== References
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service_maas[RHOAI 3.4 MaaS Official Docs]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/installing_and_uninstalling_openshift_ai_self-managed/index[RHOAI 3.4 Installation Guide]
+* link:https://opendatahub-io.github.io/models-as-a-service/latest/[Upstream MaaS Documentation]
+
 == Next step
 
 Proceed to xref:05-maas-models.adoc[Phase 5: Model Deployment].

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -177,7 +177,11 @@ For GPU models, replace the model name with `granite-4-tiny` or `gpt-oss-20b` as
 oc delete -k manifests/05-maas-models/simulator/
 ----
 
-== Further Reading
+== References
 
 * link:https://opendatahub-io.github.io/models-as-a-service/latest/[Upstream MaaS Documentation]
 * link:https://github.com/opendatahub-io/models-as-a-service[MaaS CRD Reference (models-as-a-service repo)]
+
+== Next step
+
+Proceed to xref:06-verification.adoc[Phase 6: Verification].

--- a/content/modules/ROOT/pages/06-verification.adoc
+++ b/content/modules/ROOT/pages/06-verification.adoc
@@ -178,3 +178,7 @@ The Kustomize-deployed simulator uses `simulator-free` and `simulator-premium`. 
 
 * link:https://github.com/opendatahub-io/models-as-a-service[MaaS upstream documentation]
 * link:https://github.com/rh-aiservices-bu/rhoai-nightly/blob/main/scripts/verify-maas.sh[MaaS verification in rhoai-nightly]
+
+== Next step
+
+Proceed to xref:07-observability.adoc[Phase 7: Observability].

--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -67,3 +67,7 @@ oc get telemetry.telemetry.istio.io latency-per-subscription -n openshift-ingres
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/1-latest[Cluster Observability Operator documentation]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html-single/govern_llm_access_with_models-as-a-service/index#maas-observability_maas-deploy[RHOAI Observability dashboard]
 * link:https://docs.kuadrant.io/dev/kuadrant-operator/doc/reference/telemetrypolicy/[Kuadrant TelemetryPolicy]
+
+== Next step
+
+Proceed to xref:08-architecture.adoc[Architecture & Request Flow].


### PR DESCRIPTION
## Summary
- Standardize every chapter (01-08) to end with `References → Next step`
- Add missing References sections to chapters 03 and 04
- Add missing Next step links to chapters 01, 05, 06, and 07
- Rename "Further Reading" → "References" in chapter 05
- Rename "Next Steps" → "Next step" in chapter 02 for consistency
- Fix `[Note:]` → `[NOTE]` admonition format in chapter 02
- Fix `= Appendix:` → `== Appendix` heading level in chapter 01 (eliminates build warning)

## Test plan
- [x] `antora site.yml` builds with zero warnings
- [x] Every chapter 01-07 ends with References + Next step
- [x] Chapter 08 (last page) ends with References only
- [x] All Next step xrefs point to correct next chapter