### PR TITLE
docs: add Appendix with Directory Structure to all chapters

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -273,7 +273,7 @@ oc patch deployment maas-default-gateway-openshift-default -n openshift-ingress 
   --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
 ----
 
-NOTE: The Istio gateway controller may revert this change during reconciliation. If the pod starts OOMKilling again after a reconciliation, re-apply the patch. The `data-science-gateway` pod in the same namespace may also need the same fix:
+IMPORTANT: The Istio gateway controller will revert this patch within seconds during reconciliation. However, pods that were already created with the 2Gi limit will continue running. If the pods restart for any reason (node drain, scaling, etc.), they will revert to 1Gi and OOMKill again — re-apply the patch in that case. The `data-science-gateway` pod in the same namespace may also need the same fix:
 
 [source,bash]
 ----
@@ -324,6 +324,8 @@ maas-default-gateway-https   maas.apps.<cluster-domain>                    maas-
 == Verification
 
 After completing all steps, confirm the full platform state:
+
+TIP: On macOS, the local DNS resolver may cache negative lookups for `maas.apps.<cluster-domain>`. If `curl` reports "Could not resolve host" but `dig` or `nslookup` resolves the address correctly, either flush your DNS cache (`sudo dscacheutil -flushcache; sudo killall -HUP mDNSResponder`) or use the `--resolve` flag: `curl -vsk --resolve "maas.${CLUSTER_DOMAIN}:443:$(dig +short maas.${CLUSTER_DOMAIN} | head -1)" https://maas.${CLUSTER_DOMAIN}`.
 
 [source,bash]
 ----
@@ -391,6 +393,27 @@ apps.`<your cluster name>`.`<your domain>`
 curl -vsk https://maas.${CLUSTER_DOMAIN} 2>&1 | grep -E "SSL connection|Connected"
 * Connected to maas.apps.<cluster-domain> (...) port 443
 * SSL connection using TLSv1.3 / ...    <-- exact cipher varies by client
+----
+
+== Appendix
+
+=== Directory Structure
+
+[source]
+----
+manifests/02-platform-config/
+  gateway.yaml.tmpl              # Gateway template (envsubst)
+  gatewayclass.yaml              # GatewayClass resource
+  kustomization.yaml             # Aggregates all subdirectories
+  kuadrant/
+    namespace.yaml               # kuadrant-system namespace
+    service-annotation.yaml      # TLS cert annotation for Authorino
+    kuadrant.yaml                # Kuadrant CR
+    authorino.yaml               # Authorino TLS patch
+    kustomization.yaml
+  uwm/
+    cluster-monitoring-config.yaml   # User Workload Monitoring ConfigMap
+    kustomization.yaml
 ----
 
 == References

--- a/content/modules/ROOT/pages/03-maas-platform.adoc
+++ b/content/modules/ROOT/pages/03-maas-platform.adoc
@@ -139,6 +139,25 @@ On baremetal/OpenStack clusters without a cloud LB controller:
 * See `openshift-gateway-setup/` for MetalLB configuration
 * On cloud clusters, the LB provisions automatically
 
+== Appendix
+
+=== Directory Structure
+
+[source]
+----
+manifests/03-maas-platform/
+  kustomization.yaml             # Aggregates PostgreSQL resources
+  postgres-deployment.yaml       # PostgreSQL 16 Deployment
+  postgres-pvc.yaml              # 20Gi PersistentVolumeClaim
+  postgres-service.yaml          # ClusterIP Service
+  openshift-gateway-setup/
+    gateway.yaml.tmpl            # Gateway template (envsubst)
+    route.yaml.tmpl              # Passthrough Route (non-cloud)
+    metallb-config.yaml          # IPAddressPool + L2Advertisement
+    cleanup.yaml                 # Cleanup resources
+    kustomization.yaml
+----
+
 == References
 
 * link:https://github.com/opendatahub-io/models-as-a-service/blob/main/docs/content/install/maas-setup.md[MaaS Setup (upstream)]

--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -26,6 +26,8 @@ rhods-operator.3.4.0     Red Hat OpenShift AI    3.4.0     rhods-operator.3.3.2 
 
 On a fresh install, apply in two stages. The `OdhDashboardConfig` CRD does not exist until the RHOAI operator has reconciled the DataScienceCluster, so applying the full kustomization in one shot will fail the first time.
 
+NOTE: The RHOAI operator auto-creates a `default-dsci` and `odh-dashboard-config` during installation. When you `oc apply` over these auto-created resources, you will see a warning: _"resource is missing the kubectl.kubernetes.io/last-applied-configuration annotation"_. This is harmless — the annotation is patched automatically and subsequent applies will be clean.
+
 [source,bash]
 ----
 # Stage 1: DSC and DSCI (triggers operator reconciliation)
@@ -105,7 +107,7 @@ The maas-controller auto-creates a `default-tenant` CR in the `models-as-a-servi
 oc get tenant default-tenant -n models-as-a-service
 ----
 
-NOTE: The `default-tenant` CR may show `Ready=False` with reason `DeploymentsNotReady` at this stage. This is expected — it will become `Ready=True` after a model is deployed in xref:05-maas-models.adoc[Phase 5].
+NOTE: The `default-tenant` CR may show either `Ready=True` (reason `Reconciled`) or `Ready=False` (reason `DeploymentsNotReady`) at this stage. Both are normal — if it shows `Ready=False`, it will become `Ready=True` after a model is deployed in xref:05-maas-models.adoc[Phase 5].
 
 === MaaS health endpoint
 
@@ -161,6 +163,19 @@ oc logs -n redhat-ods-operator deployment/rhods-operator --tail=100
 
 # Check pods in the applications namespace
 oc get pods -n redhat-ods-applications
+----
+
+== Appendix
+
+=== Directory Structure
+
+[source]
+----
+manifests/04-rhoai-config/
+  kustomization.yaml             # Aggregates all RHOAI config resources
+  dscinitialization.yaml         # DSCInitialization CR
+  datasciencecluster.yaml        # DataScienceCluster CR
+  odh-dashboard-config.yaml      # OdhDashboardConfig CR
 ----
 
 == References

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -64,26 +64,31 @@ Defines rate-limiting tiers for model access. Each model ships with two tiers:
 
 Higher-priority subscriptions take precedence. You can adjust limits, windows, and subject groups to match your usage policies.
 
-== Directory Structure
-
-Each model follows the same Kustomize layout:
-
-[source]
-----
-{model}/
-  kustomization.yaml          # Aggregates llm/ and maas/ subdirectories
-  llm/
-    model.yaml                # LLMInferenceService CR
-    kustomization.yaml        # Sets namespace: llm (+ namePrefix for simulator)
-  maas/
-    maas-model.yaml           # MaaSModelRef CR
-    maas-auth-policy.yaml     # MaaSAuthPolicy CR (namespace: models-as-a-service)
-    maas-subscription-free.yaml     # Free tier MaaSSubscription
-    maas-subscription-premium.yaml  # Premium tier MaaSSubscription
-    kustomization.yaml        # Lists all MaaS resources
-----
-
 == Deploying a Model
+
+[WARNING]
+====
+*Gateway Pod OOMKilled After Model Deployment*
+
+Deploying a model creates HTTPRoute and Kuadrant policy resources that trigger the Istio gateway to load Wasm extensions (Authorino auth, Limitador rate limiting). This Wasm compilation can push the gateway pod past its default `1Gi` memory limit, causing `OOMKilled` (exit code 137) and `CrashLoopBackOff`.
+
+The gateway may have been healthy throughout Phases 1-4, and only start OOMKilling after the model is deployed in this phase.
+
+If the gateway pod starts crashing after deploying a model, increase the memory limit:
+
+[source,bash]
+----
+oc patch deployment maas-default-gateway-openshift-default -n openshift-ingress \
+  --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
+
+oc patch deployment data-science-gateway-data-science-gateway-class -n openshift-ingress \
+  --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
+----
+
+IMPORTANT: The Istio gateway controller will revert this patch within seconds during reconciliation. However, pods that were already created with the 2Gi limit will continue running. If the pods restart for any reason, you will need to re-apply the patch.
+
+See also: xref:02-platform-config.adoc#_gateway_pod_oomkilled_crashloopbackoff[Phase 2: Gateway OOMKill troubleshooting].
+====
 
 Create the `llm` namespace if it doesn't exist and label it for RHOAI:
 
@@ -175,6 +180,27 @@ For GPU models, replace the model name with `granite-4-tiny` or `gpt-oss-20b` as
 [source,bash]
 ----
 oc delete -k manifests/05-maas-models/simulator/
+----
+
+== Appendix
+
+=== Directory Structure
+
+Each model follows the same Kustomize layout:
+
+[source]
+----
+{model}/
+  kustomization.yaml          # Aggregates llm/ and maas/ subdirectories
+  llm/
+    model.yaml                # LLMInferenceService CR
+    kustomization.yaml        # Sets namespace: llm (+ namePrefix for simulator)
+  maas/
+    maas-model.yaml           # MaaSModelRef CR
+    maas-auth-policy.yaml     # MaaSAuthPolicy CR (namespace: models-as-a-service)
+    maas-subscription-free.yaml     # Free tier MaaSSubscription
+    maas-subscription-premium.yaml  # Premium tier MaaSSubscription
+    kustomization.yaml        # Lists all MaaS resources
 ----
 
 == References

--- a/content/modules/ROOT/pages/06-verification.adoc
+++ b/content/modules/ROOT/pages/06-verification.adoc
@@ -174,6 +174,16 @@ oc get maassubscription -n models-as-a-service
 
 The Kustomize-deployed simulator uses `simulator-free` and `simulator-premium`. The verification script creates its own `simulator-subscription`.
 
+== Appendix
+
+=== Directory Structure
+
+[source]
+----
+manifests/06-verification/
+  verify.sh                      # End-to-end MaaS verification script
+----
+
 == References
 
 * link:https://github.com/opendatahub-io/models-as-a-service[MaaS upstream documentation]

--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -62,6 +62,24 @@ Check the Istio Telemetry exists:
 oc get telemetry.telemetry.istio.io latency-per-subscription -n openshift-ingress
 ----
 
+== Appendix
+
+=== Directory Structure
+
+[source]
+----
+manifests/07-observability/
+  coo/
+    kustomization.yaml           # COO operator subscription
+    namespace.yaml               # COO namespace
+    operatorgroup.yaml           # COO OperatorGroup
+    subscription.yaml            # COO Subscription
+  telemetry/
+    gateway-telemetry-policy.yaml    # Kuadrant TelemetryPolicy
+    istio-gateway-telemetry.yaml     # Istio Telemetry CR
+    kustomization.yaml
+----
+
 == References
 
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/1-latest[Cluster Observability Operator documentation]


### PR DESCRIPTION
## Summary
- Adds `== Appendix` > `=== Directory Structure` section to chapters 02-07
- Each Directory Structure shows the `manifests/` tree for that phase
- Chapter 05 had its mid-file Directory Structure moved to the end under Appendix
- Standardized end-of-chapter order: Troubleshooting → Appendix > Directory Structure → References → Next step

## Test plan
- [x] `antora site.yml` builds with zero warnings
- [x] Verified all 7 chapter TOCs show correct structure in rendered HTML