### PR TITLE
fix: increase Phase 1 CSV wait timeout from 600s to 900s

### DIFF
--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -252,8 +252,8 @@ if should_run 1; then
                 label="${ns_label#* }"
                 log_info "  Waiting for CSV in $ns..."
                 oc wait csv -n "$ns" -l "$label=" \
-                    --for=jsonpath='{.status.phase}'=Succeeded --timeout=600s 2>/dev/null || \
-                    { log_error "  CSV in $ns did not reach Succeeded within 600s — aborting (re-run with --from-phase 1 after manual check)"; exit 1; }
+                    --for=jsonpath='{.status.phase}'=Succeeded --timeout=900s 2>/dev/null || \
+                    { log_error "  CSV in $ns did not reach Succeeded within 900s — aborting (re-run with --from-phase 1 after manual check)"; exit 1; }
             done
         fi
         log_info "All operator CSVs ready"


### PR DESCRIPTION
## Summary
- Increases the operator CSV wait timeout in Phase 1 from 600s to 900s
- On SNO clusters (platform=None), RHOAI bundle unpacking can take ~660s, causing a false abort
- Tested end-to-end on RHPDS SNO cluster (cluster-nckqr) — 15/15 verification checks passed after this fix

## Test plan
- [x] Tested on fresh RHPDS SNO cluster (platform=None, no GPU)
- [x] Full script run: all 7 phases completed successfully
- [x] Verification: 15/15 checks passed (infra, API, auth, rate limiting)
- [x] Idempotency: re-run correctly skipped completed phases