### PR TITLE
feat: add Phase 8 External Models (OpenAI + Gemini)

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -14,6 +14,9 @@
 .Observability
 * xref:07-observability.adoc[Phase 7: Observability]
 
+.External Models
+* xref:08-external-models.adoc[Phase 8: External Models]
+
 .Reference
 * xref:08-architecture.adoc[Architecture & Request Flow]
 

--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -88,4 +88,4 @@ manifests/07-observability/
 
 == Next step
 
-Proceed to xref:08-architecture.adoc[Architecture & Request Flow].
+Proceed to xref:08-external-models.adoc[Phase 8: External Models].

--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -1,0 +1,226 @@
+= Phase 8: External Models (Optional)
+
+NOTE: This phase requires a completed MaaS installation (through xref:04-rhoai-config.adoc[Phase 4]) and at least one local model deployed (xref:05-maas-models.adoc[Phase 5]) to validate the gateway is functional.
+
+The `ExternalModel` CRD lets you expose third-party LLM APIs (OpenAI, Google Gemini, Azure OpenAI, etc.) through the MaaS gateway. External models get the same API key management, authentication, rate limiting, and usage tracking as locally-served models - your consumers use a single gateway endpoint regardless of where the model runs.
+
+== How It Works
+
+An external model deployment requires five resources:
+
+. *Secret* - stores the provider API key. Must have the label `inference.networking.k8s.io/bbr-managed=true` so the BBR ext-proc can inject the credential into upstream requests.
+
+. *ExternalModel* - defines the provider, target model, endpoint, and credential reference. The BBR (Backend Binding Resolver) handles path rewriting and authentication header injection.
+
+. *MaaSModelRef* - registers the external model in the MaaS catalog so it appears in the API and can be governed.
+
+. *MaaSAuthPolicy* - grants access to specific users or groups.
+
+. *MaaSSubscription* - sets rate limits (tokens per hour) and priority.
+
+== Step 1: Create the Namespace and Secret
+
+The external models live in their own namespace, separate from the MaaS platform and local models:
+
+[source,bash]
+----
+oc apply -f manifests/08-external-models/openai/namespace.yaml
+----
+
+Create the provider credential Secret. This is done imperatively (never stored in manifests):
+
+[source,bash]
+----
+oc create secret generic openai-api-key \
+    --from-literal=api-key="$OPENAI_API_KEY" \
+    -n external-models \
+    --dry-run=client -o yaml | oc apply -f -
+
+oc label secret openai-api-key -n external-models \
+    inference.networking.k8s.io/bbr-managed=true --overwrite
+----
+
+IMPORTANT: The `inference.networking.k8s.io/bbr-managed=true` label is required. Without it, the BBR ext-proc will not inject the API key into upstream requests and the provider will reject calls with 401.
+
+== Step 2: Apply the ExternalModel CR
+
+[source,bash]
+----
+oc apply -k manifests/08-external-models/openai/model/
+----
+
+This creates the `ExternalModel` resource:
+
+[source,yaml]
+----
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: gpt-4o-mini
+  namespace: external-models
+spec:
+  provider: openai
+  targetModel: gpt-4o-mini
+  endpoint: api.openai.com
+  credentialRef:
+    name: openai-api-key
+----
+
+== Step 3: Apply MaaS Governance
+
+[source,bash]
+----
+oc apply -k manifests/08-external-models/openai/maas/
+----
+
+This creates three resources:
+
+* `MaaSModelRef` - registers `gpt-4o-mini` in the MaaS catalog
+* `MaaSAuthPolicy` - grants all authenticated users access
+* `MaaSSubscription` - sets a free tier with 10,000 tokens/hour rate limit
+
+== Verification
+
+Check the MaaSModelRef reaches `Ready`:
+
+[source,bash]
+----
+oc get maasmodelref gpt-4o-mini -n external-models
+# Expected: PHASE = Ready
+----
+
+Check the model appears in the MaaS API:
+
+[source,bash]
+----
+MAAS_GW="https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')"
+curl -sk "${MAAS_GW}/maas-api/v1/models" \
+    -H "Authorization: Bearer $(oc whoami -t)" | python3 -m json.tool
+----
+
+Create an API key and test inference:
+
+[source,bash]
+----
+# Create an API key bound to the openai-free subscription
+API_KEY=$(curl -sk -X POST "${MAAS_GW}/maas-api/v1/api-keys" \
+    -H "Authorization: Bearer $(oc whoami -t)" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "openai-test", "subscription": "openai-free", "expiresIn": "1h"}' \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])")
+
+# Test inference
+curl -sk "${MAAS_GW}/external-models/gpt-4o-mini/v1/chat/completions" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Say hello in 3 words."}], "max_tokens": 20}'
+----
+
+A successful response contains a `choices` array with the model's reply.
+
+WARNING: There is a known platform bug where the BBR ext-proc filter is never inserted into the Envoy filter chain due to an EnvoyFilter match mismatch. If inference returns 404, see the <<known-issues>> section below. This is tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68594[RHOAIENG-68594].
+
+== Automated Setup
+
+The setup script handles all of the above in a single command:
+
+[source,bash]
+----
+./scripts/setup-maas.sh --from-phase 8 \
+    --with-external-models \
+    --external-model-provider openai \
+    --external-model-api-key "$OPENAI_API_KEY"
+----
+
+The `--external-model-provider` flag selects which provider manifests to deploy (default: `openai`).
+
+== Other Providers
+
+[[google-gemini]]
+=== Google Gemini
+
+Manifests for Google Gemini (`gemini-2.5-flash`) are included under `manifests/08-external-models/gemini/`. To deploy Gemini instead of OpenAI, use `--external-model-provider gemini`.
+
+WARNING: There is a known incompatibility between the Gemini API and the BBR `openai` provider translator. The BBR hardcodes the upstream path to `/v1/chat/completions`, but Gemini's OpenAI-compatible endpoint requires `/v1beta/openai/chat/completions`. This means ExternalModel registration and MaaS governance will work correctly, but inference requests will return HTTP 404 from Google's API. This is tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68592[RHOAIENG-68592] and link:https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/260[upstream issue #260]. Once a `gemini` provider translator is added to the BBR, Gemini external models will work end-to-end.
+
+To deploy with Gemini (registration only, inference will 404):
+
+[source,bash]
+----
+./scripts/setup-maas.sh --from-phase 8 \
+    --with-external-models \
+    --external-model-provider gemini \
+    --external-model-api-key "$GEMINI_API_KEY"
+----
+
+[[known-issues]]
+== Known Issues
+
+=== ext-proc filter not inserted (RHOAIENG-68594)
+
+The `payload-processing` EnvoyFilter matches on a WasmPlugin-style filter name (`extensions.istio.io/wasmplugin/...`), but Kuadrant creates the Wasm filter with the generic name `envoy.filters.http.wasm`. The match fails, so the BBR ext-proc is never added to the Envoy filter chain. Without ext-proc, there is no path rewriting and no credential injection - inference returns 404 or 401 from the upstream provider.
+
+This affects all external model providers. A temporary workaround (reverted by the MaaS controller within seconds):
+
+[source,bash]
+----
+oc patch envoyfilter payload-processing -n openshift-ingress --type='json' \
+  -p='[{"op": "replace", "path": "/spec/configPatches/0/match/listener/filterChain/filter/subFilter/name", "value": "envoy.filters.http.wasm"}]'
+----
+
+Tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68594[RHOAIENG-68594].
+
+=== Gemini path incompatibility (RHOAIENG-68592)
+
+The BBR `openai` provider hardcodes the upstream path to `/v1/chat/completions`, but Gemini requires `/v1beta/openai/chat/completions`. See the <<google-gemini,Google Gemini>> section above for details. Tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68592[RHOAIENG-68592].
+
+== Appendix
+
+=== Directory Structure
+
+[source]
+----
+manifests/08-external-models/
+  openai/
+    kustomization.yaml           # Top-level: namespace + model + maas
+    namespace.yaml               # external-models namespace
+    model/
+      kustomization.yaml
+      external-model.yaml        # ExternalModel CR (gpt-4o-mini)
+    maas/
+      kustomization.yaml
+      maas-model.yaml            # MaaSModelRef
+      maas-auth-policy.yaml      # MaaSAuthPolicy (system:authenticated)
+      maas-subscription.yaml     # MaaSSubscription (10k tokens/hour)
+  gemini/
+    kustomization.yaml
+    namespace.yaml
+    model/
+      kustomization.yaml
+      external-model.yaml        # ExternalModel CR (gemini-2.5-flash)
+    maas/
+      kustomization.yaml
+      maas-model.yaml
+      maas-auth-policy.yaml
+      maas-subscription.yaml
+----
+
+=== Supported Providers
+
+The `provider` field in the ExternalModel spec maps to a BBR payload translator. Currently supported values:
+
+* `openai` - OpenAI API (`api.openai.com`)
+* `anthropic` - Anthropic API
+* `azure-openai` - Azure OpenAI Service
+* `bedrock-openai` - AWS Bedrock (OpenAI-compatible)
+
+== References
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html-single/govern_llm_access_with_models-as-a-service/index#maas-external-model_maas-deploy[RHOAI ExternalModel documentation]
+* link:https://github.com/opendatahub-io/ai-gateway-payload-processing[BBR (ai-gateway-payload-processing) repository]
+* link:https://redhat.atlassian.net/browse/RHOAIENG-68594[RHOAIENG-68594 - ext-proc EnvoyFilter match mismatch (all providers)]
+* link:https://redhat.atlassian.net/browse/RHOAIENG-68592[RHOAIENG-68592 - Gemini BBR path incompatibility]
+
+== Next step
+
+Proceed to xref:08-architecture.adoc[Architecture & Request Flow].

--- a/manifests/08-external-models/gemini/kustomization.yaml
+++ b/manifests/08-external-models/gemini/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - model
+  - maas

--- a/manifests/08-external-models/gemini/maas/kustomization.yaml
+++ b/manifests/08-external-models/gemini/maas/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - maas-model.yaml
+  - maas-auth-policy.yaml
+  - maas-subscription.yaml

--- a/manifests/08-external-models/gemini/maas/maas-auth-policy.yaml
+++ b/manifests/08-external-models/gemini/maas/maas-auth-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: gemini-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Gemini Access"
+    openshift.io/description: "Grants all authenticated users access to the Gemini external model"
+spec:
+  modelRefs:
+    - name: gemini-2-5-flash
+      namespace: external-models
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []

--- a/manifests/08-external-models/gemini/maas/maas-model.yaml
+++ b/manifests/08-external-models/gemini/maas/maas-model.yaml
@@ -1,0 +1,12 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: gemini-2-5-flash
+  namespace: external-models
+  annotations:
+    openshift.io/display-name: "Gemini 2.5 Flash"
+    openshift.io/description: "Google Gemini 2.5 Flash via OpenAI-compatible API"
+spec:
+  modelRef:
+    kind: ExternalModel
+    name: gemini-2-5-flash

--- a/manifests/08-external-models/gemini/maas/maas-subscription.yaml
+++ b/manifests/08-external-models/gemini/maas/maas-subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: gemini-free
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Gemini Free Tier"
+    openshift.io/description: "Free tier: 10000 tokens/hour for all authenticated users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: gemini-2-5-flash
+      namespace: external-models
+      tokenRateLimits:
+        - limit: 10000
+          window: 1h
+  priority: 10

--- a/manifests/08-external-models/gemini/model/external-model.yaml
+++ b/manifests/08-external-models/gemini/model/external-model.yaml
@@ -1,0 +1,11 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: gemini-2-5-flash
+  namespace: external-models
+spec:
+  provider: openai
+  targetModel: gemini-2.5-flash
+  endpoint: generativelanguage.googleapis.com
+  credentialRef:
+    name: gemini-api-key

--- a/manifests/08-external-models/gemini/model/kustomization.yaml
+++ b/manifests/08-external-models/gemini/model/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-model.yaml

--- a/manifests/08-external-models/gemini/namespace.yaml
+++ b/manifests/08-external-models/gemini/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-models
+  labels:
+    opendatahub.io/generated-namespace: "true"

--- a/manifests/08-external-models/openai/kustomization.yaml
+++ b/manifests/08-external-models/openai/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - model
+  - maas

--- a/manifests/08-external-models/openai/maas/kustomization.yaml
+++ b/manifests/08-external-models/openai/maas/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - maas-model.yaml
+  - maas-auth-policy.yaml
+  - maas-subscription.yaml

--- a/manifests/08-external-models/openai/maas/maas-auth-policy.yaml
+++ b/manifests/08-external-models/openai/maas/maas-auth-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: openai-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "OpenAI Access"
+    openshift.io/description: "Grants all authenticated users access to the OpenAI external model"
+spec:
+  modelRefs:
+    - name: gpt-4o-mini
+      namespace: external-models
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []

--- a/manifests/08-external-models/openai/maas/maas-model.yaml
+++ b/manifests/08-external-models/openai/maas/maas-model.yaml
@@ -1,0 +1,12 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: gpt-4o-mini
+  namespace: external-models
+  annotations:
+    openshift.io/display-name: "GPT-4o Mini"
+    openshift.io/description: "OpenAI GPT-4o Mini via OpenAI-compatible API"
+spec:
+  modelRef:
+    kind: ExternalModel
+    name: gpt-4o-mini

--- a/manifests/08-external-models/openai/maas/maas-subscription.yaml
+++ b/manifests/08-external-models/openai/maas/maas-subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: openai-free
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "OpenAI Free Tier"
+    openshift.io/description: "Free tier: 10000 tokens/hour for all authenticated users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: gpt-4o-mini
+      namespace: external-models
+      tokenRateLimits:
+        - limit: 10000
+          window: 1h
+  priority: 10

--- a/manifests/08-external-models/openai/model/external-model.yaml
+++ b/manifests/08-external-models/openai/model/external-model.yaml
@@ -1,0 +1,11 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: gpt-4o-mini
+  namespace: external-models
+spec:
+  provider: openai
+  targetModel: gpt-4o-mini
+  endpoint: api.openai.com
+  credentialRef:
+    name: openai-api-key

--- a/manifests/08-external-models/openai/model/kustomization.yaml
+++ b/manifests/08-external-models/openai/model/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-model.yaml

--- a/manifests/08-external-models/openai/namespace.yaml
+++ b/manifests/08-external-models/openai/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-models
+  labels:
+    opendatahub.io/generated-namespace: "true"

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -11,6 +11,7 @@
 #   Phase 5: Deploy model  - auto-detect GPU, apply model Kustomize
 #   Phase 6: Verify  - run 6-phase E2E verification
 #   Phase 7: Observability (optional)  - COO + Gateway telemetry
+#   Phase 8: External models (optional) - deploy ExternalModel (e.g. OpenAI, Gemini)
 #
 # Each phase is idempotent  - re-running skips what's already done.
 #
@@ -23,6 +24,8 @@
 #   --skip-models        Skip Phase 5 (model deployment)
 #   --skip-verify        Skip Phase 6 (verification)
 #   --with-observability Also run Phase 7 (COO + telemetry)
+#   --with-external-models Also run Phase 8 (ExternalModel deployment)
+#   --external-model-api-key <key>  API key for external provider (or EXTERNAL_MODEL_API_KEY env var)
 #   --dry-run            Preview without applying
 #   -h, --help           Show this help message
 #
@@ -53,6 +56,9 @@ FROM_PHASE=0
 SKIP_MODELS=false
 SKIP_VERIFY=false
 WITH_OBSERVABILITY=false
+WITH_EXTERNAL_MODELS=false
+EXTERNAL_MODEL_PROVIDER="${EXTERNAL_MODEL_PROVIDER:-openai}"
+EXTERNAL_MODEL_API_KEY="${EXTERNAL_MODEL_API_KEY:-}"
 DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
@@ -62,6 +68,9 @@ while [[ $# -gt 0 ]]; do
         --skip-models) SKIP_MODELS=true; shift ;;
         --skip-verify) SKIP_VERIFY=true; shift ;;
         --with-observability) WITH_OBSERVABILITY=true; shift ;;
+        --with-external-models) WITH_EXTERNAL_MODELS=true; shift ;;
+        --external-model-provider) EXTERNAL_MODEL_PROVIDER="$2"; shift 2 ;;
+        --external-model-api-key) EXTERNAL_MODEL_API_KEY="$2"; shift 2 ;;
         --dry-run) DRY_RUN=true; shift ;;
         -h|--help)
             cat <<'EOF'
@@ -73,10 +82,13 @@ idempotent  - re-running skips what's already done.
 
 Options:
   --model <name>       Model: simulator, granite-tiny-gpu, gpt-oss-20b, auto (default: auto)
-  --from-phase <N>     Start from phase N (0-7, default: 0)
+  --from-phase <N>     Start from phase N (0-8, default: 0)
   --skip-models        Skip Phase 5 (model deployment)
   --skip-verify        Skip Phase 6 (verification)
   --with-observability Also run Phase 7 (COO + Gateway telemetry)
+  --with-external-models Also run Phase 8 (ExternalModel deployment + test)
+  --external-model-provider <p>   Provider: openai (default), gemini (or set EXTERNAL_MODEL_PROVIDER)
+  --external-model-api-key <key>  API key for external provider (or set EXTERNAL_MODEL_API_KEY)
   --dry-run            Preview without applying
   -h, --help           Show this help message
 
@@ -89,6 +101,7 @@ Phases:
   5  Deploy model       Auto-detect GPU, apply model Kustomize manifests
   6  Verify             6-phase E2E verification (API, auth, rate limits)
   7  Observability      COO + Gateway telemetry (only with --with-observability)
+  8  External models    ExternalModel + governance (only with --with-external-models)
 
 Auto-detection (--model auto):
   No GPU             -> simulator (CPU-only, ~30s startup)
@@ -223,6 +236,7 @@ should_run 4 && PHASES_TO_RUN="$PHASES_TO_RUN 4"
 should_run 5 && [ "$SKIP_MODELS" = false ] && PHASES_TO_RUN="$PHASES_TO_RUN 5"
 should_run 6 && [ "$SKIP_VERIFY" = false ] && PHASES_TO_RUN="$PHASES_TO_RUN 6"
 should_run 7 && [ "$WITH_OBSERVABILITY" = true ] && PHASES_TO_RUN="$PHASES_TO_RUN 7"
+should_run 8 && [ "$WITH_EXTERNAL_MODELS" = true ] && PHASES_TO_RUN="$PHASES_TO_RUN 8"
 echo ""
 log_info "Phases to run:${PHASES_TO_RUN:- (none)}"
 
@@ -763,6 +777,152 @@ if should_run 7 && [ "$WITH_OBSERVABILITY" = true ]; then
 fi
 
 # =============================================================================
+# Phase 8: External Models (Optional)
+# =============================================================================
+if should_run 8 && [ "$WITH_EXTERNAL_MODELS" = true ]; then
+    log_phase 8 "External Models (provider: ${EXTERNAL_MODEL_PROVIDER})"
+
+    if [ -z "$EXTERNAL_MODEL_API_KEY" ]; then
+        log_warn "No external model API key provided (use --external-model-api-key or EXTERNAL_MODEL_API_KEY env var)"
+        log_warn "Skipping Phase 8"
+    else
+        EXTMODEL_NS="external-models"
+
+        case "$EXTERNAL_MODEL_PROVIDER" in
+            openai)
+                EXTMODEL_NAME="gpt-4o-mini"
+                EXTMODEL_SECRET="openai-api-key"
+                EXTMODEL_SUBSCRIPTION="openai-free"
+                EXTMODEL_TARGET_MODEL="gpt-4o-mini"
+                ;;
+            gemini)
+                EXTMODEL_NAME="gemini-2-5-flash"
+                EXTMODEL_SECRET="gemini-api-key"
+                EXTMODEL_SUBSCRIPTION="gemini-free"
+                EXTMODEL_TARGET_MODEL="gemini-2.5-flash"
+                ;;
+            *)
+                log_warn "Unknown provider '${EXTERNAL_MODEL_PROVIDER}' (supported: openai, gemini)"
+                log_warn "Skipping Phase 8"
+                EXTERNAL_MODEL_API_KEY=""
+                ;;
+        esac
+
+        if [ -n "$EXTERNAL_MODEL_API_KEY" ]; then
+            PROVIDER_DIR="$MANIFESTS_DIR/08-external-models/${EXTERNAL_MODEL_PROVIDER}"
+
+            if [ ! -d "$PROVIDER_DIR" ]; then
+                log_warn "Manifest directory not found: $PROVIDER_DIR"
+                log_warn "Skipping Phase 8"
+            else
+                # Create namespace
+                log_step "Creating external-models namespace..."
+                if oc get namespace "$EXTMODEL_NS" &>/dev/null; then
+                    log_info "Namespace $EXTMODEL_NS already exists"
+                else
+                    run_cmd oc apply -f "${PROVIDER_DIR}/namespace.yaml"
+                fi
+
+                log_step "Creating provider credential Secret..."
+                if [ "$DRY_RUN" = true ]; then
+                    log_info "[DRY RUN] Would create Secret ${EXTMODEL_SECRET} in $EXTMODEL_NS"
+                else
+                    oc create secret generic "$EXTMODEL_SECRET" \
+                        --from-literal=api-key="$EXTERNAL_MODEL_API_KEY" \
+                        -n "$EXTMODEL_NS" \
+                        --dry-run=client -o yaml | oc apply -f - 2>/dev/null
+                    oc label secret "$EXTMODEL_SECRET" -n "$EXTMODEL_NS" \
+                        inference.networking.k8s.io/bbr-managed=true --overwrite 2>/dev/null
+                    log_info "Secret ${EXTMODEL_SECRET} created/updated (bbr-managed label applied)"
+                fi
+
+                log_step "Applying ExternalModel CR..."
+                run_cmd oc apply -k "${PROVIDER_DIR}/model/"
+
+                log_step "Applying MaaS governance (MaaSModelRef, AuthPolicy, Subscription)..."
+                run_cmd oc apply -k "${PROVIDER_DIR}/maas/"
+
+                if [ "$DRY_RUN" = false ]; then
+                    log_info "Waiting for MaaSModelRef phase=Ready..."
+                    TIMEOUT=180
+                    ELAPSED=0
+                    while [ $ELAPSED -lt $TIMEOUT ]; do
+                        MODELREF_PHASE=$(oc get maasmodelref "$EXTMODEL_NAME" -n "$EXTMODEL_NS" \
+                            -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+                        [ "$MODELREF_PHASE" = "Ready" ] && break
+                        sleep 5
+                        ELAPSED=$((ELAPSED + 5))
+                    done
+                    if [ "${MODELREF_PHASE:-}" = "Ready" ]; then
+                        log_info "MaaSModelRef: Ready"
+                    else
+                        log_warn "MaaSModelRef not Ready after ${TIMEOUT}s (phase: ${MODELREF_PHASE:-unknown})"
+                    fi
+
+                    MAAS_GW="https://maas.${CLUSTER_DOMAIN}"
+                    OC_TOKEN=$(oc whoami -t 2>/dev/null || echo "")
+                    if [ -n "$OC_TOKEN" ]; then
+                        MODEL_READY=$(curl -sk "${MAAS_GW}/maas-api/v1/models" \
+                            -H "Authorization: Bearer ${OC_TOKEN}" 2>/dev/null \
+                            | grep -o "\"id\":\"${EXTMODEL_NAME}\"" || echo "")
+                        if [ -n "$MODEL_READY" ]; then
+                            log_info "Model ${EXTMODEL_NAME} visible in MaaS API (ready)"
+                        else
+                            log_warn "Model ${EXTMODEL_NAME} not yet visible in MaaS API"
+                        fi
+
+                        log_step "Testing ${EXTERNAL_MODEL_PROVIDER} inference through MaaS gateway..."
+                        log_info "Creating ephemeral API key for testing..."
+                        API_KEY_RESPONSE=$(curl -sk -X POST "${MAAS_GW}/maas-api/v1/api-keys" \
+                            -H "Authorization: Bearer ${OC_TOKEN}" \
+                            -H "Content-Type: application/json" \
+                            -d "{\"name\": \"phase8-test\", \"subscription\": \"${EXTMODEL_SUBSCRIPTION}\", \"expiresIn\": \"1h\", \"ephemeral\": true}" 2>/dev/null || echo "")
+
+                        TEST_API_KEY=$(echo "$API_KEY_RESPONSE" | grep -o '"key":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+                        if [ -n "$TEST_API_KEY" ]; then
+                            log_info "Ephemeral API key created"
+
+                            INFERENCE_RESPONSE=$(curl -sk -X POST \
+                                "${MAAS_GW}/external-models/${EXTMODEL_NAME}/v1/chat/completions" \
+                                -H "Authorization: Bearer ${TEST_API_KEY}" \
+                                -H "Content-Type: application/json" \
+                                -d "{\"model\": \"${EXTMODEL_TARGET_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say hello in exactly 3 words.\"}], \"max_tokens\": 20}" \
+                                --max-time 30 2>/dev/null || echo "")
+
+                            if echo "$INFERENCE_RESPONSE" | grep -q '"choices"'; then
+                                REPLY_TEXT=$(echo "$INFERENCE_RESPONSE" | grep -o '"content":"[^"]*"' | head -1 | cut -d'"' -f4)
+                                log_info "${EXTERNAL_MODEL_PROVIDER} inference SUCCESS: ${REPLY_TEXT}"
+                            else
+                                HTTP_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST \
+                                    "${MAAS_GW}/external-models/${EXTMODEL_NAME}/v1/chat/completions" \
+                                    -H "Authorization: Bearer ${TEST_API_KEY}" \
+                                    -H "Content-Type: application/json" \
+                                    -d "{\"model\": \"${EXTMODEL_TARGET_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hi\"}], \"max_tokens\": 5}" \
+                                    --max-time 15 2>/dev/null || echo "000")
+                                log_warn "${EXTERNAL_MODEL_PROVIDER} inference returned HTTP ${HTTP_CODE} - model is registered and governed but inference routing may need BBR ext-proc propagation"
+                            fi
+
+                            TEST_KEY_ID=$(echo "$API_KEY_RESPONSE" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+                            if [ -n "$TEST_KEY_ID" ]; then
+                                curl -sk -X DELETE "${MAAS_GW}/maas-api/v1/api-keys/${TEST_KEY_ID}" \
+                                    -H "Authorization: Bearer ${OC_TOKEN}" &>/dev/null || true
+                            fi
+                        else
+                            log_warn "Could not create API key for testing (response: $(echo "$API_KEY_RESPONSE" | head -c 200))"
+                        fi
+                    else
+                        log_warn "No OC token available - skipping API verification"
+                    fi
+                fi
+
+                log_info "External models deployment complete (provider: ${EXTERNAL_MODEL_PROVIDER})"
+            fi
+        fi
+    fi
+fi
+
+# =============================================================================
 # Final Summary
 # =============================================================================
 echo ""
@@ -789,8 +949,15 @@ else
     log_info "Health:        HTTP ${HEALTH}"
 
     if [ "$SKIP_MODELS" = false ] && [ "$HAS_MODELS" = true ] || oc get llminferenceservice -n llm &>/dev/null 2>&1; then
-        log_info "Models:"
+        log_info "Models (local):"
         oc get llminferenceservice -n llm --no-headers 2>/dev/null | while read -r line; do
+            log_info "  $line"
+        done
+    fi
+
+    if oc get externalmodel -n external-models &>/dev/null 2>&1; then
+        log_info "Models (external):"
+        oc get externalmodel -n external-models --no-headers 2>/dev/null | while read -r line; do
             log_info "  $line"
         done
     fi
@@ -800,6 +967,7 @@ else
     [ "$SKIP_MODELS" = true ] && log_info "  Deploy models:      ./scripts/deploy-model.sh --model auto"
     [ "$SKIP_VERIFY" = true ] && log_info "  Run verification:   ./scripts/verify-maas.sh"
     [ "$WITH_OBSERVABILITY" = false ] && log_info "  Add observability:  $0 --from-phase 7 --with-observability"
+    [ "$WITH_EXTERNAL_MODELS" = false ] && log_info "  Add external models: $0 --from-phase 8 --with-external-models --external-model-provider openai --external-model-api-key <KEY>"
     log_info "  RHOAI Dashboard:    https://$(oc get route rhods-dashboard -n redhat-ods-applications -o jsonpath='{.spec.host}' 2>/dev/null || echo '<dashboard-route>')"
 fi
 


### PR DESCRIPTION
## Summary

- Add ExternalModel manifests for OpenAI (gpt-4o-mini) and Gemini (gemini-2.5-flash) under `manifests/08-external-models/`
- Add `--external-model-provider` flag to `setup-maas.sh` with provider-aware Phase 8 (default: openai, also supports gemini)
- Add `08-external-models.adoc` documentation with step-by-step walkthrough, known issues (RHOAIENG-68594, RHOAIENG-68592), and automated setup
- Update nav.adoc and 07-observability.adoc cross-references

## Test plan

- [x] Both kustomize dirs render: `oc kustomize manifests/08-external-models/openai/` and `gemini/`
- [x] Antora site builds with no new warnings
- [x] All xrefs and anchors resolve in rendered HTML
- [x] OpenAI ExternalModel deployed on cluster, MaaSModelRef Ready, inference verified (HTTP 200)
- [x] Script Phase 8 variable names match manifest resource names
- [ ] Verify `--external-model-provider gemini` deploys gemini manifests (registration only, inference will 404 per RHOAIENG-68592)