### PR TITLE
Add AWS Bedrock ExternalModel support

### DIFF
--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -2,7 +2,7 @@
 
 NOTE: This phase requires a completed MaaS installation (through xref:04-rhoai-config.adoc[Phase 4]) and at least one local model deployed (xref:05-maas-models.adoc[Phase 5]) to validate the gateway is functional.
 
-The `ExternalModel` CRD lets you expose third-party LLM APIs (OpenAI, Google Gemini, Azure OpenAI, etc.) through the MaaS gateway. External models get the same API key management, authentication, rate limiting, and usage tracking as locally-served models - your consumers use a single gateway endpoint regardless of where the model runs.
+The `ExternalModel` CRD lets you expose third-party LLM APIs (OpenAI, AWS Bedrock, Google Gemini, Azure OpenAI, etc.) through the MaaS gateway. External models get the same API key management, authentication, rate limiting, and usage tracking as locally-served models - your consumers use a single gateway endpoint regardless of where the model runs.
 
 == How It Works
 
@@ -132,7 +132,7 @@ The setup script handles all of the above in a single command:
     --external-model-api-key "$OPENAI_API_KEY"
 ----
 
-The `--external-model-provider` flag selects which provider manifests to deploy (default: `openai`).
+The `--external-model-provider` flag selects which provider manifests to deploy (`openai`, `gemini`, or `bedrock`; default: `openai`).
 
 == Other Providers
 
@@ -151,6 +151,123 @@ To deploy with Gemini (registration only, inference will 404):
     --with-external-models \
     --external-model-provider gemini \
     --external-model-api-key "$GEMINI_API_KEY"
+----
+
+[[aws-bedrock]]
+=== AWS Bedrock
+
+Manifests for AWS Bedrock (`openai.gpt-oss-20b` via the Mantle endpoint) are included under `manifests/08-external-models/bedrock/`. Bedrock uses the `bedrock-openai` provider, which routes through the OpenAI-compatible Mantle API - no request body translation is needed.
+
+WARNING: Use `bedrock-mantle.<region>.api.aws`, *not* `bedrock-runtime.<region>.amazonaws.com`. The BBR translator uses `/v1/chat/completions`, which is only available on the Mantle endpoint. Using `bedrock-runtime` will result in 404 errors.
+
+==== Prerequisites
+
+Bedrock requires a *Bedrock API Key* (ABSK key), not standard AWS access keys. Create one via IAM service-specific credentials:
+
+[source,bash]
+----
+# Create an IAM user for Bedrock API access
+aws iam create-user --user-name bedrock-api-user
+
+# Attach Bedrock access policy
+aws iam attach-user-policy \
+    --user-name bedrock-api-user \
+    --policy-arn arn:aws:iam::aws:policy/AmazonBedrockLimitedAccess
+
+# Generate a long-term ABSK key (up to 90 days)
+aws iam create-service-specific-credential \
+    --user-name bedrock-api-user \
+    --service-name bedrock.amazonaws.com \
+    --credential-age-days 90
+----
+
+The output contains a `ServiceSpecificCredential.ServicePassword` field starting with `ABSK` - this is the API key to use.
+
+TIP: Verify the ABSK key works before deploying: `curl -s "https://bedrock-mantle.us-east-2.api.aws/v1/models" -H "Authorization: Bearer $BEDROCK_API_KEY" | python3 -m json.tool`
+
+==== Manual Deployment
+
+Create the namespace if it does not already exist (shared with other external model providers):
+
+[source,bash]
+----
+oc apply -f manifests/08-external-models/bedrock/namespace.yaml
+----
+
+Create the credential Secret (never stored in manifests):
+
+[source,bash]
+----
+oc create secret generic bedrock-api-key \
+    --from-literal=api-key="$BEDROCK_API_KEY" \
+    -n external-models \
+    --dry-run=client -o yaml | oc apply -f -
+
+oc label secret bedrock-api-key -n external-models \
+    inference.networking.k8s.io/bbr-managed=true --overwrite
+----
+
+Apply the ExternalModel and MaaS governance resources:
+
+[source,bash]
+----
+oc apply -k manifests/08-external-models/bedrock/model/
+oc apply -k manifests/08-external-models/bedrock/maas/
+----
+
+The ExternalModel CR:
+
+[source,yaml]
+----
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: aws-gpt-oss-20b
+  namespace: external-models
+spec:
+  provider: bedrock-openai
+  targetModel: openai.gpt-oss-20b
+  endpoint: bedrock-mantle.us-east-2.api.aws
+  credentialRef:
+    name: bedrock-api-key
+----
+
+NOTE: The `endpoint` must match your AWS region. Replace `us-east-2` with your region if different.
+
+Verify the model reaches Ready:
+
+[source,bash]
+----
+oc get maasmodelref aws-gpt-oss-20b -n external-models
+# Expected: PHASE = Ready
+----
+
+Test inference:
+
+[source,bash]
+----
+MAAS_GW="https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')"
+
+API_KEY=$(curl -sk -X POST "${MAAS_GW}/maas-api/v1/api-keys" \
+    -H "Authorization: Bearer $(oc whoami -t)" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "bedrock-test", "subscription": "bedrock-free", "expiresIn": "1h"}' \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])")
+
+curl -sk "${MAAS_GW}/external-models/aws-gpt-oss-20b/v1/chat/completions" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{"model": "openai.gpt-oss-20b", "messages": [{"role": "user", "content": "Say hello in 3 words."}], "max_tokens": 20}'
+----
+
+==== Automated Deployment
+
+[source,bash]
+----
+./scripts/setup-maas.sh --from-phase 8 \
+    --with-external-models \
+    --external-model-provider bedrock \
+    --external-model-api-key "$BEDROCK_API_KEY"
 ----
 
 [[known-issues]]
@@ -198,6 +315,17 @@ manifests/08-external-models/
     model/
       kustomization.yaml
       external-model.yaml        # ExternalModel CR (gemini-2.5-flash)
+    maas/
+      kustomization.yaml
+      maas-model.yaml
+      maas-auth-policy.yaml
+      maas-subscription.yaml
+  bedrock/
+    kustomization.yaml
+    namespace.yaml
+    model/
+      kustomization.yaml
+      external-model.yaml        # ExternalModel CR (openai.gpt-oss-20b via Mantle)
     maas/
       kustomization.yaml
       maas-model.yaml

--- a/manifests/08-external-models/bedrock/kustomization.yaml
+++ b/manifests/08-external-models/bedrock/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - model
+  - maas

--- a/manifests/08-external-models/bedrock/maas/kustomization.yaml
+++ b/manifests/08-external-models/bedrock/maas/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - maas-model.yaml
+  - maas-auth-policy.yaml
+  - maas-subscription.yaml

--- a/manifests/08-external-models/bedrock/maas/maas-auth-policy.yaml
+++ b/manifests/08-external-models/bedrock/maas/maas-auth-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: bedrock-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Bedrock Access"
+    openshift.io/description: "Grants all authenticated users access to the AWS Bedrock external model"
+spec:
+  modelRefs:
+    - name: aws-gpt-oss-20b
+      namespace: external-models
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []

--- a/manifests/08-external-models/bedrock/maas/maas-model.yaml
+++ b/manifests/08-external-models/bedrock/maas/maas-model.yaml
@@ -1,0 +1,12 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: aws-gpt-oss-20b
+  namespace: external-models
+  annotations:
+    openshift.io/display-name: "AWS Bedrock GPT-OSS 20B"
+    openshift.io/description: "OpenAI GPT-OSS 20B via AWS Bedrock (OpenAI-compatible Mantle endpoint)"
+spec:
+  modelRef:
+    kind: ExternalModel
+    name: aws-gpt-oss-20b

--- a/manifests/08-external-models/bedrock/maas/maas-subscription.yaml
+++ b/manifests/08-external-models/bedrock/maas/maas-subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: bedrock-free
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Bedrock Free Tier"
+    openshift.io/description: "Free tier: 10000 tokens/hour for all authenticated users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: aws-gpt-oss-20b
+      namespace: external-models
+      tokenRateLimits:
+        - limit: 10000
+          window: 1h
+  priority: 10

--- a/manifests/08-external-models/bedrock/model/external-model.yaml
+++ b/manifests/08-external-models/bedrock/model/external-model.yaml
@@ -1,0 +1,11 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: aws-gpt-oss-20b
+  namespace: external-models
+spec:
+  provider: bedrock-openai
+  targetModel: openai.gpt-oss-20b
+  endpoint: bedrock-mantle.us-east-2.api.aws
+  credentialRef:
+    name: bedrock-api-key

--- a/manifests/08-external-models/bedrock/model/kustomization.yaml
+++ b/manifests/08-external-models/bedrock/model/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-model.yaml

--- a/manifests/08-external-models/bedrock/namespace.yaml
+++ b/manifests/08-external-models/bedrock/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-models
+  labels:
+    opendatahub.io/generated-namespace: "true"

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -87,7 +87,7 @@ Options:
   --skip-verify        Skip Phase 6 (verification)
   --with-observability Also run Phase 7 (COO + Gateway telemetry)
   --with-external-models Also run Phase 8 (ExternalModel deployment + test)
-  --external-model-provider <p>   Provider: openai (default), gemini (or set EXTERNAL_MODEL_PROVIDER)
+  --external-model-provider <p>   Provider: openai (default), gemini, bedrock (or set EXTERNAL_MODEL_PROVIDER)
   --external-model-api-key <key>  API key for external provider (or set EXTERNAL_MODEL_API_KEY)
   --dry-run            Preview without applying
   -h, --help           Show this help message
@@ -801,8 +801,14 @@ if should_run 8 && [ "$WITH_EXTERNAL_MODELS" = true ]; then
                 EXTMODEL_SUBSCRIPTION="gemini-free"
                 EXTMODEL_TARGET_MODEL="gemini-2.5-flash"
                 ;;
+            bedrock)
+                EXTMODEL_NAME="aws-gpt-oss-20b"
+                EXTMODEL_SECRET="bedrock-api-key"
+                EXTMODEL_SUBSCRIPTION="bedrock-free"
+                EXTMODEL_TARGET_MODEL="openai.gpt-oss-20b"
+                ;;
             *)
-                log_warn "Unknown provider '${EXTERNAL_MODEL_PROVIDER}' (supported: openai, gemini)"
+                log_warn "Unknown provider '${EXTERNAL_MODEL_PROVIDER}' (supported: openai, gemini, bedrock)"
                 log_warn "Skipping Phase 8"
                 EXTERNAL_MODEL_API_KEY=""
                 ;;


### PR DESCRIPTION
## Summary

- Add Kustomize manifests for AWS Bedrock ExternalModel (`openai.gpt-oss-20b` via the `bedrock-openai` provider and Mantle endpoint) under `manifests/08-external-models/bedrock/`
- Add AWS Bedrock documentation section to Phase 8 (08-external-models.adoc) covering ABSK key prerequisites, manual deployment, verification, and automated setup
- Add `bedrock` provider case to `setup-maas.sh` Phase 8 automation

## Details

The Bedrock manifests follow the same structure as `openai/` and `gemini/`:
- ExternalModel CR with `provider: bedrock-openai`, `endpoint: bedrock-mantle.us-east-2.api.aws`
- MaaSModelRef, MaaSAuthPolicy, MaaSSubscription for catalog registration, access, and rate limiting
- No API keys in manifests - secret created imperatively (same pattern as other providers)

Validated end-to-end on a live cluster: MaaS API key -> gateway -> BBR ext-proc -> Bedrock Mantle -> model response.

## Test plan

- [ ] `kustomize build manifests/08-external-models/bedrock/` renders 5 valid resources
- [ ] No plaintext API keys in any manifest file
- [ ] `setup-maas.sh --help` shows `bedrock` in provider list
- [ ] `setup-maas.sh --from-phase 8 --with-external-models --external-model-provider bedrock --external-model-api-key $KEY` deploys successfully
- [ ] Inference through MaaS gateway returns valid response from Bedrock