### PR TITLE
fix: add RHOAIENG-68589 reference to gateway OOMKill warnings

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -280,6 +280,8 @@ IMPORTANT: The Istio gateway controller will revert this patch within seconds du
 oc patch deployment data-science-gateway-data-science-gateway-class -n openshift-ingress \
   --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
 ----
+
+This is a known issue tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68589[RHOAIENG-68589].
 ====
 
 *Step 5d:* Create Passthrough Route (Non-Cloud Platforms Only)

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -87,6 +87,8 @@ oc patch deployment data-science-gateway-data-science-gateway-class -n openshift
 
 IMPORTANT: The Istio gateway controller will revert this patch within seconds during reconciliation. However, pods that were already created with the 2Gi limit will continue running. If the pods restart for any reason, you will need to re-apply the patch.
 
+This is a known issue tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68589[RHOAIENG-68589].
+
 See also: xref:02-platform-config.adoc#_gateway_pod_oomkilled_crashloopbackoff[Phase 2: Gateway OOMKill troubleshooting].
 ====
 


### PR DESCRIPTION
## Summary
- Adds a link to [RHOAIENG-68589](https://redhat.atlassian.net/browse/RHOAIENG-68589) in both gateway OOMKill warning blocks so readers can track the upstream fix
- Phase 2 (`02-platform-config.adoc`) and Phase 5 (`05-maas-models.adoc`) both updated

## Test plan
- [ ] Verify AsciiDoc renders correctly on the published site