### PR TITLE
docs: add Phase 8 External Models to index page

### DIFF
--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -78,6 +78,17 @@ Each phase has step-by-step instructions, status gates, and troubleshooting.
 | 5 min
 |===
 
+=== External Models
+
+[cols="1,3,1", options="header"]
+|===
+| Phase | Description | Time
+
+| xref:08-external-models.adoc[8. External Models] _(optional)_
+| Expose third-party LLM APIs (OpenAI, Bedrock, Gemini) through the MaaS gateway
+| 5-10 min
+|===
+
 == Automated Setup
 
 For end-to-end deployment using a single script, see the xref:quick-start.adoc[Automated Setup] page.


### PR DESCRIPTION
## Summary
- Adds the missing Phase 8 (External Models) section to the index page, after Observability
- External Models was added in PR #21 but the index was not updated

## Test plan
- [ ] Verify the index page renders the new table row correctly