### PR TITLE
fix: persistent gateway memory limit via ConfigMap parametersRef

### DIFF
--- a/manifests/02-platform-config/gateway-resources.yaml
+++ b/manifests/02-platform-config/gateway-resources.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maas-gateway-options
+  namespace: openshift-ingress
+data:
+  deployment: |
+    spec:
+      template:
+        spec:
+          containers:
+          - name: istio-proxy
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: "2"
+                memory: 2Gi

--- a/manifests/02-platform-config/gateway.yaml.tmpl
+++ b/manifests/02-platform-config/gateway.yaml.tmpl
@@ -8,6 +8,11 @@ metadata:
     security.opendatahub.io/authorino-tls-bootstrap: "true"
 spec:
   gatewayClassName: openshift-default
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: maas-gateway-options
   listeners:
    - name: http
      hostname: maas.${CLUSTER_DOMAIN}

--- a/manifests/06-verification/verify.sh
+++ b/manifests/06-verification/verify.sh
@@ -138,7 +138,7 @@ fi
 # =============================================================================
 check_and_fix_gateway_oom() {
     local deploy_name="$1"
-    local restarts crash_reason mem_limit
+    local restarts crash_reason mem_limit params_ref
 
     restarts=$(oc get pods -n openshift-ingress -l "gateway.networking.k8s.io/gateway-name=maas-default-gateway" \
         -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' 2>/dev/null || echo "0")
@@ -150,9 +150,37 @@ check_and_fix_gateway_oom() {
             -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>/dev/null || echo "")
 
         if [ "$mem_limit" = "1Gi" ]; then
-            log_warn "Gateway pod has OOMKilled ($restarts restarts). Patching memory limit from 1Gi to 2Gi..."
-            oc patch deployment "$deploy_name" -n openshift-ingress \
-                --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]' 2>/dev/null || true
+            log_warn "Gateway pod has OOMKilled ($restarts restarts). Applying persistent 2Gi memory limit via ConfigMap..."
+            # Create the ConfigMap with 2Gi limit (idempotent)
+            cat <<'GWEOF' | oc apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maas-gateway-options
+  namespace: openshift-ingress
+data:
+  deployment: |
+    spec:
+      template:
+        spec:
+          containers:
+          - name: istio-proxy
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: "2"
+                memory: 2Gi
+GWEOF
+            # Hook ConfigMap into Gateway via parametersRef (survives Istio reconciliation)
+            params_ref=$(oc get gateway maas-default-gateway -n openshift-ingress \
+                -o jsonpath='{.spec.infrastructure.parametersRef.name}' 2>/dev/null || echo "")
+            if [ "$params_ref" != "maas-gateway-options" ]; then
+                oc patch gateway maas-default-gateway -n openshift-ingress --type=merge -p '{
+                  "spec": {"infrastructure": {"parametersRef": {"group": "", "kind": "ConfigMap", "name": "maas-gateway-options"}}}
+                }' 2>/dev/null || true
+            fi
 
             log_info "Waiting for gateway pod to stabilize..."
             sleep 10

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -374,6 +374,8 @@ if should_run 2; then
         fi
         log_info "Rendering with CLUSTER_DOMAIN=${CLUSTER_DOMAIN}, CERT_NAME=${CERT_NAME}"
         export CLUSTER_DOMAIN CERT_NAME
+        # Apply gateway resource ConfigMap first (sets 2Gi memory limit via parametersRef)
+        run_cmd oc apply -f "$MANIFESTS_DIR/02-platform-config/gateway-resources.yaml"
         if [ "$DRY_RUN" = true ]; then
             log_info "[DRY RUN] envsubst < gateway.yaml.tmpl | oc apply -f -"
         else
@@ -511,6 +513,7 @@ if should_run 3; then
     if ! oc get gateway maas-default-gateway -n openshift-ingress &>/dev/null 2>&1; then
         log_step "Rendering and applying Gateway (not created in Phase 2)..."
         export CLUSTER_DOMAIN CERT_NAME
+        run_cmd oc apply -f "$MANIFESTS_DIR/02-platform-config/gateway-resources.yaml"
         if [ "$DRY_RUN" = true ]; then
             log_info "[DRY RUN] envsubst < gateway.yaml.tmpl | oc apply -f -"
         else


### PR DESCRIPTION
## Summary

- Replaces the temporary `oc patch deployment` workaround for gateway OOMKill (RHOAIENG-68589) with a persistent fix
- Uses Istio 1.26's `spec.infrastructure.parametersRef` on the Gateway CR to set 2Gi memory via ConfigMap
- Unlike direct deployment patches, this survives Istio reconciliation

## What changed

- **New:** `manifests/02-platform-config/gateway-resources.yaml` - ConfigMap with 2Gi memory limit for the istio-proxy container
- **Updated:** `manifests/02-platform-config/gateway.yaml.tmpl` - added `spec.infrastructure.parametersRef` pointing to the ConfigMap
- **Updated:** `scripts/setup-maas.sh` - apply ConfigMap before Gateway in Phase 2 and Phase 3
- **Updated:** `manifests/06-verification/verify.sh` - `check_and_fix_gateway_oom()` now creates ConfigMap + patches Gateway instead of patching the Deployment directly

## Test plan

- [x] ConfigMap applies cleanly (`oc apply -f gateway-resources.yaml`)
- [x] Gateway template renders valid YAML with parametersRef
- [x] Deployment picks up 2Gi memory limit after apply
- [x] Limit persists through Istio reconciliation (verified on OCP 4.20.24 / SM 3.3.3)
- [x] Gateway stays Accepted/Programmed with Kuadrant policies attached
- [x] Pod runs with 0 restarts at 2Gi limit

Tested on: OCP 4.20.24, RHOAI 3.4.0, RHCL 1.4.0, Service Mesh 3.3.3

Ref: RHOAIENG-68589