### PR TITLE
docs: update OOMKill sections to use ConfigMap parametersRef fix

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -215,6 +215,15 @@ If MetalLB is installed: Continue to the next step.
 
 *Step 5b:* Create the MaaS Gateway
 
+First, apply the Gateway resource overrides ConfigMap. This sets the gateway proxy memory limit to `2Gi` (the Istio default of `1Gi` is insufficient when Kuadrant Wasm extensions are loaded):
+
+[source,bash]
+----
+oc apply -f manifests/02-platform-config/gateway-resources.yaml
+----
+
+Now create the Gateway. The Gateway template includes `spec.infrastructure.parametersRef` pointing to the ConfigMap above, so Istio applies the `2Gi` limit to the generated Deployment and preserves it across reconciliations.
+
 [source,bash]
 ----
 export CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster \
@@ -252,36 +261,32 @@ oc wait --for=condition=Programmed gateway/maas-default-gateway \
   -n openshift-ingress --timeout=120s
 ----
 
-[WARNING]
+[NOTE]
 ====
-*Gateway Pod OOMKilled (CrashLoopBackOff)*
+*Gateway Pod OOMKill Prevention*
 
-On some clusters, the MaaS gateway pod may enter `CrashLoopBackOff` with `OOMKilled` (exit code 137) shortly after creation. This happens because the Istio Gateway API controller creates the gateway deployment with a default memory limit of `1Gi`, which can be insufficient when Kuadrant Wasm extensions (Authorino auth, Limitador rate limiting) are loaded and compiled at startup.
+The ConfigMap applied in Step 5b overrides the Istio default `1Gi` memory limit to `2Gi` via `spec.infrastructure.parametersRef`. This prevents the gateway pod from being OOMKilled when Kuadrant Wasm extensions (Authorino auth, Limitador rate limiting) are compiled at startup. Unlike `oc patch deployment`, this approach survives Istio reconciliation.
 
-Check the gateway pod status:
-
-[source,bash]
-----
-oc get pods -n openshift-ingress | grep maas-default-gateway
-----
-
-If the pod shows `CrashLoopBackOff` or multiple restarts with `OOMKilled`, increase the memory limit:
+If you deployed the Gateway *without* the ConfigMap (e.g. from an older version of this guide), apply the fix retroactively:
 
 [source,bash]
 ----
-oc patch deployment maas-default-gateway-openshift-default -n openshift-ingress \
-  --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
+oc apply -f manifests/02-platform-config/gateway-resources.yaml
+
+oc patch gateway maas-default-gateway -n openshift-ingress --type=merge -p '{
+  "spec": {
+    "infrastructure": {
+      "parametersRef": {
+        "group": "",
+        "kind": "ConfigMap",
+        "name": "maas-gateway-options"
+      }
+    }
+  }
+}'
 ----
 
-IMPORTANT: The Istio gateway controller will revert this patch within seconds during reconciliation. However, pods that were already created with the 2Gi limit will continue running. If the pods restart for any reason (node drain, scaling, etc.), they will revert to 1Gi and OOMKill again — re-apply the patch in that case. The `data-science-gateway` pod in the same namespace may also need the same fix:
-
-[source,bash]
-----
-oc patch deployment data-science-gateway-data-science-gateway-class -n openshift-ingress \
-  --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
-----
-
-This is a known issue tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68589[RHOAIENG-68589].
+This is tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68589[RHOAIENG-68589].
 ====
 
 *Step 5d:* Create Passthrough Route (Non-Cloud Platforms Only)
@@ -404,7 +409,8 @@ curl -vsk https://maas.${CLUSTER_DOMAIN} 2>&1 | grep -E "SSL connection|Connecte
 [source]
 ----
 manifests/02-platform-config/
-  gateway.yaml.tmpl              # Gateway template (envsubst)
+  gateway-resources.yaml         # ConfigMap: gateway proxy resource overrides (2Gi memory)
+  gateway.yaml.tmpl              # Gateway template (envsubst, references ConfigMap via parametersRef)
   gatewayclass.yaml              # GatewayClass resource
   kustomization.yaml             # Aggregates all subdirectories
   kuadrant/

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -66,30 +66,13 @@ Higher-priority subscriptions take precedence. You can adjust limits, windows, a
 
 == Deploying a Model
 
-[WARNING]
+[NOTE]
 ====
-*Gateway Pod OOMKilled After Model Deployment*
+*Gateway Pod OOMKill*
 
-Deploying a model creates HTTPRoute and Kuadrant policy resources that trigger the Istio gateway to load Wasm extensions (Authorino auth, Limitador rate limiting). This Wasm compilation can push the gateway pod past its default `1Gi` memory limit, causing `OOMKilled` (exit code 137) and `CrashLoopBackOff`.
+Deploying a model triggers the Istio gateway to load Kuadrant Wasm extensions, which can push the pod past the default `1Gi` memory limit. If you applied the `gateway-resources.yaml` ConfigMap in xref:02-platform-config.adoc#_gateway_pod_oomkill_prevention[Phase 2 Step 5b], this is already handled (the limit is set to `2Gi` via `parametersRef`).
 
-The gateway may have been healthy throughout Phases 1-4, and only start OOMKilling after the model is deployed in this phase.
-
-If the gateway pod starts crashing after deploying a model, increase the memory limit:
-
-[source,bash]
-----
-oc patch deployment maas-default-gateway-openshift-default -n openshift-ingress \
-  --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
-
-oc patch deployment data-science-gateway-data-science-gateway-class -n openshift-ingress \
-  --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
-----
-
-IMPORTANT: The Istio gateway controller will revert this patch within seconds during reconciliation. However, pods that were already created with the 2Gi limit will continue running. If the pods restart for any reason, you will need to re-apply the patch.
-
-This is a known issue tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68589[RHOAIENG-68589].
-
-See also: xref:02-platform-config.adoc#_gateway_pod_oomkilled_crashloopbackoff[Phase 2: Gateway OOMKill troubleshooting].
+If the gateway pod starts OOMKilling after deploying a model, see xref:02-platform-config.adoc#_gateway_pod_oomkill_prevention[Phase 2: Gateway OOMKill Prevention] for the fix.
 ====
 
 Create the `llm` namespace if it doesn't exist and label it for RHOAI:

--- a/content/modules/ROOT/pages/06-verification.adoc
+++ b/content/modules/ROOT/pages/06-verification.adoc
@@ -151,17 +151,26 @@ If the verification script fails at Phase 1 (health endpoint unreachable) or Pha
 oc get pods -n openshift-ingress | grep maas-default-gateway
 ----
 
-If the pod shows `CrashLoopBackOff` with multiple restarts, the Kuadrant Wasm extensions may exceed the default `1Gi` memory limit. Patch the deployment:
+If the pod shows `CrashLoopBackOff` with multiple restarts, the Kuadrant Wasm extensions may exceed the default `1Gi` memory limit. Apply the ConfigMap fix from xref:02-platform-config.adoc#_gateway_pod_oomkill_prevention[Phase 2 Step 5b]:
 
 [source,bash]
 ----
-oc patch deployment maas-default-gateway-openshift-default -n openshift-ingress \
-  --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
+oc apply -f manifests/02-platform-config/gateway-resources.yaml
+
+oc patch gateway maas-default-gateway -n openshift-ingress --type=merge -p '{
+  "spec": {
+    "infrastructure": {
+      "parametersRef": {
+        "group": "",
+        "kind": "ConfigMap",
+        "name": "maas-gateway-options"
+      }
+    }
+  }
+}'
 ----
 
 Wait for the pod to stabilize, then re-run the script.
-
-NOTE: The verification script (v2+) automatically detects and patches this issue. If running an older version, apply the patch manually.
 
 === Wrong subscription name in API key creation
 


### PR DESCRIPTION
## Summary
- Replace `oc patch deployment` workaround (reverted by Istio reconciliation) with the persistent ConfigMap + `parametersRef` approach
- Add `gateway-resources.yaml` apply step to Phase 2 Step 5b before gateway creation
- Simplify OOMKill warnings in Phase 5 and Phase 6 to cross-reference Phase 2
- Update Appendix directory structure to include `gateway-resources.yaml`

Ref: RHOAIENG-68589