### PR TITLE
fix: pin RHCL to v1.3.4 to avoid v1.4.0 WASM issues

### DIFF
--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -14,7 +14,7 @@ TIP: All file paths and `oc apply` commands in this guide are relative to the li
 | `redhat-ods-operator`
 | Core RHOAI platform, model serving, dashboards, pipelines
 
-| Red Hat Connectivity Link (`rhcl-operator`)
+| Red Hat Connectivity Link (`rhcl-operator`) ^1^
 | `openshift-operators`
 | API gateway policies, authentication (Authorino) and rate limiting (Limitador) for MaaS endpoints
 
@@ -30,6 +30,8 @@ TIP: All file paths and `oc apply` commands in this guide are relative to the li
 | `openshift-lws-operator`
 | Coordinates multi-replica workloads for distributed inference and training
 |===
+
+^1^ RHCL is pinned to v1.3.4. Version 1.4.0 has known issues with WASM plugin loading that cause gateway errors and break the RHOAI model UI. The subscription uses `Manual` install plan approval to prevent auto-upgrade. This pin will be removed once the upstream fix ships.
 
 === Optional GPU Operators
 
@@ -81,6 +83,25 @@ oc apply -k manifests/01-prerequisites/operators/
 ----
 
 This installs all five required operator subscriptions. OLM will resolve and install each operator automatically.
+
+=== Step 1b: Approve RHCL Install Plan
+
+The RHCL operator uses `Manual` install plan approval to pin version 1.3.4. After applying the subscriptions, approve the pending install plan so OLM can install it:
+
+[source,bash]
+----
+# Wait for the install plan to appear (takes ~10s)
+sleep 10
+
+# Approve all pending install plans in openshift-operators
+oc get installplan -n openshift-operators --no-headers \
+  -o custom-columns='NAME:.metadata.name,APPROVED:.spec.approved' | \
+  grep false | awk '{print $1}' | \
+  xargs -I{} oc patch installplan {} -n openshift-operators \
+    --type=merge -p '{"spec":{"approved":true}}'
+----
+
+NOTE: Only the RHCL operator has a pending install plan (other operators use `Automatic` approval). This step is required because RHCL is pinned to v1.3.4 to avoid known WASM plugin issues in v1.4.0.
 
 === Step 2 (Optional): Install GPU Operators
 
@@ -235,13 +256,15 @@ NAMESPACE                NAME                                                   
 cert-manager-operator    openshift-cert-manager-operator                                                        cert-manager-operator.v1.19.0                      AtLatestKnown
 metallb-system           metallb-operator                                                                       metallb-operator.v4.20.0-...                       AtLatestKnown
 openshift-lws-operator   leader-worker-set                                                                      leader-worker-set.v1.0.0                           AtLatestKnown
-openshift-operators      authorino-operator-stable-redhat-operators-openshift-marketplace                       authorino-operator.v1.4.0                          AtLatestKnown
-openshift-operators      dns-operator-stable-redhat-operators-openshift-marketplace                             dns-operator.v1.4.0                                AtLatestKnown
-openshift-operators      limitador-operator-stable-redhat-operators-openshift-marketplace                       limitador-operator.v1.4.0                          AtLatestKnown
-openshift-operators      rhcl-operator                                                                          rhcl-operator.v1.4.0                               AtLatestKnown
+openshift-operators      authorino-operator-stable-redhat-operators-openshift-marketplace                       authorino-operator.v1.3.1                          AtLatestKnown
+openshift-operators      dns-operator-stable-redhat-operators-openshift-marketplace                             dns-operator.v1.3.1                                AtLatestKnown
+openshift-operators      limitador-operator-stable-redhat-operators-openshift-marketplace                       limitador-operator.v1.3.1                          AtLatestKnown
+openshift-operators      rhcl-operator                                                                          rhcl-operator.v1.4.0                               UpgradePending
 openshift-operators      servicemeshoperator3                                                                   servicemeshoperator3.v3.3.3                        AtLatestKnown
 redhat-ods-operator      rhods-operator                                                                         rhods-operator.3.4.0                               AtLatestKnown
 ----
+
+TIP: The RHCL subscription shows `UpgradePending` with `currentCSV: v1.4.0` because OLM sees the upgrade but it is blocked by Manual approval. The *installed* version is v1.3.4. Verify with: `oc get csv -n openshift-operators rhcl-operator.v1.3.4 -o jsonpath='{.status.phase}'` (should return `Succeeded`).
 
 == Appendix
 

--- a/manifests/01-prerequisites/operators/connectivity-link/subscription.yaml
+++ b/manifests/01-prerequisites/operators/connectivity-link/subscription.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: rhcl-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  startingCSV: rhcl-operator.v1.3.4

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -253,6 +253,22 @@ if should_run 1; then
         run_cmd oc apply -k "$MANIFESTS_DIR/01-prerequisites/operators/"
         log_info "Operator subscriptions applied"
 
+        log_info "Approving RHCL install plan (pinned to v1.3.4, Manual approval)..."
+        if [ "$DRY_RUN" = false ]; then
+            for attempt in $(seq 1 30); do
+                PENDING=$(oc get installplan -n openshift-operators --no-headers 2>/dev/null | grep -v "true" | awk '{print $1}')
+                if [ -n "$PENDING" ]; then
+                    echo "$PENDING" | xargs -I{} oc patch installplan {} -n openshift-operators \
+                        --type=merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+                    log_info "  Install plan(s) approved"
+                    break
+                fi
+                sleep 2
+            done
+        else
+            log_info "[DRY RUN] Would approve RHCL install plan"
+        fi
+
         log_info "Waiting for operator CSVs (this may take 2-5 minutes)..."
         if [ "$DRY_RUN" = false ]; then
             for ns_label in \


### PR DESCRIPTION
## Summary

- Pin RHCL operator to v1.3.4 via `startingCSV` + `Manual` install plan approval
- RHCL 1.4.0 has known WASM plugin loading issues that cause gateway errors and break the RHOAI model UI
- Add Step 1b in prerequisites docs for install plan approval
- Update `setup-maas.sh` to auto-approve the RHCL install plan in Phase 1

## Test plan

- [x] Validated on cluster-5hlwg (SNO, platform=None, OCP 4.20.24)
- [x] RHCL v1.3.4 installed, v1.4.0 upgrade blocked (UpgradePending)
- [x] 15/15 E2E verification tests passed (health, API key, models, inference, auth, rate limiting)
- [x] Gateway pod: 0 restarts, 2Gi memory, no WASM errors
- [x] Sub-operators: authorino v1.3.1, limitador v1.3.1, dns v1.3.1