### PR TITLE
fix: add GPU operand instances (ClusterPolicy + NFD)

### DIFF
--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -112,6 +112,51 @@ If your cluster has GPU nodes (or you plan to add them), install the GPU operato
 oc apply -k manifests/01-prerequisites/gpu/
 ----
 
+=== Step 2b (Optional): Create GPU Operand Instances
+
+After the GPU operator CSVs have succeeded (see <<Verification>> below), create the operand instances that configure NFD and the GPU driver stack.
+
+IMPORTANT: The operators must be fully installed before applying these resources - the CRDs they define do not exist until the operators are ready. Wait for both CSVs to succeed first.
+
+[source,bash]
+----
+# Wait for GPU operator CSVs to succeed
+oc wait csv -n openshift-nfd -l operators.coreos.com/nfd.openshift-nfd="" \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=600s
+
+oc wait csv -n nvidia-gpu-operator -l operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator="" \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=600s
+----
+
+Create the NFD NodeFeatureDiscovery instance (scans nodes for GPU hardware) and the NVIDIA ClusterPolicy (installs drivers, device plugin, monitoring):
+
+[source,bash]
+----
+oc apply -k manifests/01-prerequisites/gpu/instances/
+----
+
+Wait for the ClusterPolicy to reach `ready` state (this takes 5-10 minutes as the GPU operator installs NVIDIA drivers on GPU nodes):
+
+[source,bash]
+----
+oc wait clusterpolicy gpu-cluster-policy \
+  --for=jsonpath='{.status.state}'=ready --timeout=600s
+----
+
+Verify GPU resources are available:
+
+[source,bash]
+----
+# Check NFD labeled GPU nodes
+oc get nodes -l feature.node.kubernetes.io/pci-10de.present=true
+
+# Check GPU operator pods
+oc get pods -n nvidia-gpu-operator
+
+# Check nvidia.com/gpu resources on GPU nodes
+oc get nodes -l nvidia.com/gpu.present=true
+----
+
 === Step 3: Install MetalLB (Non-Cloud Platforms Only)
 
 NOTE: Read this section carefully!
@@ -281,9 +326,13 @@ manifests/01-prerequisites/
     rhoai-operator/
     service-mesh/
   gpu/
-    kustomization.yaml          # aggregates NFD + NVIDIA
+    kustomization.yaml          # aggregates NFD + NVIDIA operator subscriptions
     nfd/
     nvidia-operator/
+    instances/
+      kustomization.yaml        # aggregates NFD + GPU operand instances
+      nodefeaturediscovery.yaml  # NFD NodeFeatureDiscovery CR
+      cluster-policy.yaml       # NVIDIA GPU ClusterPolicy CR
   metallb/
     kustomization.yaml          # MetalLB namespace + operatorgroup + subscription
     namespace.yaml

--- a/manifests/01-prerequisites/gpu/instances/cluster-policy.yaml
+++ b/manifests/01-prerequisites/gpu/instances/cluster-policy.yaml
@@ -1,0 +1,92 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  operator:
+    use_ocp_driver_toolkit: true
+  cdi:
+    enabled: false
+    nriPluginEnabled: false
+  sandboxWorkloads:
+    enabled: false
+    defaultWorkload: container
+    mode: kubevirt
+  driver:
+    enabled: true
+    useNvidiaDriverCRD: false
+    kernelModuleType: auto
+    upgradePolicy:
+      autoUpgrade: true
+      drain:
+        deleteEmptyDir: false
+        enable: false
+        force: false
+        timeoutSeconds: 300
+      maxParallelUpgrades: 1
+      maxUnavailable: 25%
+      podDeletion:
+        deleteEmptyDir: false
+        force: false
+        timeoutSeconds: 300
+      waitForCompletion:
+        timeoutSeconds: 0
+    repoConfig:
+      configMapName: ''
+    certConfig:
+      name: ''
+    licensingConfig:
+      nlsEnabled: true
+      secretName: ''
+    virtualTopology:
+      config: ''
+    kernelModuleConfig:
+      name: ''
+  dcgmExporter:
+    enabled: true
+    config:
+      name: ''
+    serviceMonitor:
+      enabled: true
+  dcgm:
+    enabled: true
+  daemonsets:
+    updateStrategy: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: '1'
+  devicePlugin:
+    enabled: true
+    config:
+      name: ''
+      default: ''
+  mps:
+    root: /run/nvidia/mps
+  gfd:
+    enabled: true
+  migManager:
+    enabled: true
+  nodeStatusExporter:
+    enabled: true
+  mig:
+    strategy: single
+  toolkit:
+    enabled: true
+  validator:
+    plugin:
+      env: []
+  vgpuManager:
+    enabled: false
+  vgpuDeviceManager:
+    enabled: true
+  sandboxDevicePlugin:
+    enabled: true
+  kataSandboxDevicePlugin:
+    enabled: true
+  vfioManager:
+    enabled: true
+  ccManager:
+    enabled: true
+  gds:
+    enabled: false
+  gdrcopy:
+    enabled: false

--- a/manifests/01-prerequisites/gpu/instances/kustomization.yaml
+++ b/manifests/01-prerequisites/gpu/instances/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - nodefeaturediscovery.yaml
+  - cluster-policy.yaml

--- a/manifests/01-prerequisites/gpu/instances/nodefeaturediscovery.yaml
+++ b/manifests/01-prerequisites/gpu/instances/nodefeaturediscovery.yaml
@@ -1,0 +1,23 @@
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  workerConfig:
+    configData: |
+      core:
+        sleepInterval: 60s
+      sources:
+        pci:
+          deviceClassWhitelist:
+            - "0200"
+            - "03"
+            - "12"
+          deviceLabelFields:
+            - "vendor"
+  operand:
+    imagePullPolicy: IfNotPresent
+    servicePort: 12000
+  customConfig:
+    configData: ""


### PR DESCRIPTION
## Summary

- Add `manifests/01-prerequisites/gpu/instances/` with ClusterPolicy and NodeFeatureDiscovery CRs that must be created after the GPU operators are installed
- Update `01-prerequisites.adoc` with Step 2b documenting the wait-apply-verify flow for GPU operand instances
- Without these CRs, the GPU operator does not install drivers and GPU models fail to load

## Test plan

- [x] Applied on RHPDS SNO cluster (cluster-pjkgj, platform=None, OCP 4.20)
- [x] `oc apply -k manifests/01-prerequisites/gpu/instances/` creates both CRs cleanly
- [x] ClusterPolicy reaches `ready` state (no GPU hardware on test cluster - shows "No GPU node found, watching for new nodes")
- [x] NFD instance deploys worker DaemonSet and labels nodes with PCI device info
- [x] Full Phase 1 walkthrough passed (all operator CSVs Succeeded, all CRDs present, MetalLB configured)

Fixes #28, Fixes #29