### PR TITLE
fix: pin COO to v1.4.0, add Tempo/OpenTelemetry manifests, document HF Xet workaround

### DIFF
--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -90,6 +90,24 @@ Deploy the simulator (no GPU required):
 oc apply -k manifests/05-maas-models/simulator/
 ----
 
+[NOTE]
+====
+*HuggingFace Xet Download Hang*
+
+The simulator uses `hf://sshleifer/tiny-gpt2` as its model URI. HuggingFace has migrated model storage to the Xet protocol, which can cause the KServe storage-initializer init container to hang indefinitely during download. If the model pod is stuck in `Init:0/1` for more than 5 minutes, apply this workaround:
+
+[source,bash]
+----
+oc patch deployment facebook-opt-125m-simulated-kserve -n llm \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/initContainers/0/env/-","value":{"name":"HF_HUB_DISABLE_XET","value":"1"}}]'
+----
+
+This disables the Xet protocol and falls back to standard HTTP downloads. The patched pod should complete init within 30 seconds. Note that KServe may revert this patch on reconciliation, so reapply if the model is redeployed.
+
+GPU models using OCI modelcar images (granite-tiny-gpu, gpt-oss-20b) are *not* affected by this issue since they do not download from HuggingFace.
+====
+
 Or deploy a GPU model if your cluster has NVIDIA GPUs:
 
 [source,bash]

--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -4,25 +4,77 @@ NOTE: User Workload Monitoring (UWM) was already configured in xref:02-platform-
 
 This phase adds *optional* observability enhancements on top of UWM:
 
+. *Tempo Operator* - provides the `TempoStack` CRD that the RHOAI operator's Monitoring controller requires for distributed tracing. Without this operator, the Monitoring CR cannot provision tracing infrastructure.
+
+. *Red Hat build of OpenTelemetry Operator* - provides the `OpenTelemetryCollector` CRD that the RHOAI operator's Monitoring controller requires. Without this operator, the Monitoring CR fails with: _"OpenTelemetryCollector operator must be installed for OpenTelemetry configuration"_. This blocks the full observability chain: MonitoringStack, ThanosQuerier, Perses, and PrometheusDatasource.
+
 . *Cluster Observability Operator (COO)* - required for the Observability Dashboard tab in the {rhoai} UI. COO provides the Perses CRDs (`Perses`, `PersesDatasource`, `PersesDashboard`) that the RHOAI operator uses to deploy the dashboard backend.
 
 . *Gateway Telemetry* - per-model, per-user, per-subscription usage metrics on the MaaS gateway. Adds fine-grained labels (`model`, `user`, `subscription`, `organization_id`, `cost_center`) to gateway metrics for usage attribution and billing.
 
-== Step 1: Install the Cluster Observability Operator
+== Step 1: Install the Tempo Operator
 
 [source,bash]
 ----
-oc apply -k manifests/07-observability/coo/
+oc apply -k manifests/07-observability/tempo/
 ----
 
 Wait for the operator CSV to reach `Succeeded`:
 
 [source,bash]
 ----
-oc get csv -n openshift-cluster-observability-operator -w
+oc wait csv -n openshift-tempo-operator \
+  -l operators.coreos.com/tempo-product.openshift-tempo-operator="" \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
 ----
 
-== Step 2: Apply Gateway Telemetry
+== Step 2: Install the Red Hat build of OpenTelemetry Operator
+
+[source,bash]
+----
+oc apply -k manifests/07-observability/opentelemetry/
+----
+
+Wait for the operator CSV to reach `Succeeded`:
+
+[source,bash]
+----
+oc wait csv -n openshift-opentelemetry-operator \
+  -l operators.coreos.com/opentelemetry-product.openshift-opentelemetry-operator="" \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+----
+
+== Step 3: Install the Cluster Observability Operator
+
+NOTE: COO is pinned to **v1.4.0** with Manual install plan approval. This avoids potential regressions in newer versions. The pin will be removed once upstream validation completes.
+
+[source,bash]
+----
+oc apply -k manifests/07-observability/coo/
+----
+
+Approve the install plan (required because of Manual approval):
+
+[source,bash]
+----
+sleep 10
+oc get installplan -n openshift-cluster-observability-operator --no-headers \
+  -o custom-columns='NAME:.metadata.name,APPROVED:.spec.approved' | \
+  grep false | awk '{print $1}' | \
+  xargs -I{} oc patch installplan {} -n openshift-cluster-observability-operator \
+    --type=merge -p '{"spec":{"approved":true}}'
+----
+
+Wait for the operator CSV to reach `Succeeded`:
+
+[source,bash]
+----
+oc wait csv -n openshift-cluster-observability-operator \
+  -l operators.coreos.com/cluster-observability-operator.openshift-cluster-observability="" \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+----
+
+== Step 4: Apply Gateway Telemetry
 
 Once COO is installed and the MaaS gateway is running:
 
@@ -33,18 +85,31 @@ oc apply -k manifests/07-observability/telemetry/
 
 == Verification
 
-Check the COO operator is installed:
+Check all three observability operators are installed:
 
 [source,bash]
 ----
+oc get csv -n openshift-tempo-operator | grep tempo
+# Expected: tempo-operator   Succeeded
+
+oc get csv -n openshift-opentelemetry-operator | grep opentelemetry
+# Expected: opentelemetry-operator   Succeeded
+
 oc get csv -n openshift-cluster-observability-operator | grep cluster-observability-operator
 # Expected: cluster-observability-operator   Succeeded
 ----
 
-Check the Perses CRDs are registered:
+Check the required CRDs are registered:
 
 [source,bash]
 ----
+# Tempo
+oc get crd tempostacks.tempo.grafana.com
+
+# OpenTelemetry
+oc get crd opentelemetrycollectors.opentelemetry.io
+
+# COO / Perses
 oc get crd perses.perses.dev
 ----
 
@@ -69,6 +134,16 @@ oc get telemetry.telemetry.istio.io latency-per-subscription -n openshift-ingres
 [source]
 ----
 manifests/07-observability/
+  tempo/
+    kustomization.yaml           # Tempo operator subscription
+    namespace.yaml               # openshift-tempo-operator namespace
+    operatorgroup.yaml           # Tempo OperatorGroup
+    subscription.yaml            # Tempo Subscription
+  opentelemetry/
+    kustomization.yaml           # OpenTelemetry operator subscription
+    namespace.yaml               # openshift-opentelemetry-operator namespace
+    operatorgroup.yaml           # OpenTelemetry OperatorGroup
+    subscription.yaml            # OpenTelemetry Subscription
   coo/
     kustomization.yaml           # COO operator subscription
     namespace.yaml               # COO namespace
@@ -82,6 +157,7 @@ manifests/07-observability/
 
 == References
 
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/managing_openshift_ai/managing-observability_managing-rhoai#enabling-the-observability-stack_managing-rhoai[RHOAI 3.4 - Enabling the observability stack]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/1-latest[Cluster Observability Operator documentation]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html-single/govern_llm_access_with_models-as-a-service/index#maas-observability_maas-deploy[RHOAI Observability dashboard]
 * link:https://docs.kuadrant.io/dev/kuadrant-operator/doc/reference/telemetrypolicy/[Kuadrant TelemetryPolicy]

--- a/manifests/07-observability/coo/subscription.yaml
+++ b/manifests/07-observability/coo/subscription.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: openshift-cluster-observability-operator
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  startingCSV: cluster-observability-operator.v1.4.0

--- a/manifests/07-observability/opentelemetry/kustomization.yaml
+++ b/manifests/07-observability/opentelemetry/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription.yaml

--- a/manifests/07-observability/opentelemetry/namespace.yaml
+++ b/manifests/07-observability/opentelemetry/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat build of OpenTelemetry"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-opentelemetry-operator

--- a/manifests/07-observability/opentelemetry/operatorgroup.yaml
+++ b/manifests/07-observability/opentelemetry/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-opentelemetry-operator
+  namespace: openshift-opentelemetry-operator

--- a/manifests/07-observability/opentelemetry/subscription.yaml
+++ b/manifests/07-observability/opentelemetry/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: opentelemetry-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/manifests/07-observability/tempo/kustomization.yaml
+++ b/manifests/07-observability/tempo/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription.yaml

--- a/manifests/07-observability/tempo/namespace.yaml
+++ b/manifests/07-observability/tempo/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Tempo Operator"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-tempo-operator

--- a/manifests/07-observability/tempo/operatorgroup.yaml
+++ b/manifests/07-observability/tempo/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-tempo-operator
+  namespace: openshift-tempo-operator

--- a/manifests/07-observability/tempo/subscription.yaml
+++ b/manifests/07-observability/tempo/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: tempo-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -10,7 +10,7 @@
 #   Phase 4: RHOAI config   - DataScienceCluster, DSCInitialization, Dashboard
 #   Phase 5: Deploy model  - auto-detect GPU, apply model Kustomize
 #   Phase 6: Verify  - run 6-phase E2E verification
-#   Phase 7: Observability (optional)  - COO + Gateway telemetry
+#   Phase 7: Observability (optional)  - Tempo + OpenTelemetry + COO + Gateway telemetry
 #   Phase 8: External models (optional) - deploy ExternalModel (e.g. OpenAI, Gemini)
 #
 # Each phase is idempotent  - re-running skips what's already done.
@@ -23,7 +23,7 @@
 #   --from-phase <N>     Start from phase N (default: 0)
 #   --skip-models        Skip Phase 5 (model deployment)
 #   --skip-verify        Skip Phase 6 (verification)
-#   --with-observability Also run Phase 7 (COO + telemetry)
+#   --with-observability Also run Phase 7 (Tempo + OpenTelemetry + COO + telemetry)
 #   --with-external-models Also run Phase 8 (ExternalModel deployment)
 #   --external-model-api-key <key>  API key for external provider (or EXTERNAL_MODEL_API_KEY env var)
 #   --dry-run            Preview without applying
@@ -85,7 +85,7 @@ Options:
   --from-phase <N>     Start from phase N (0-8, default: 0)
   --skip-models        Skip Phase 5 (model deployment)
   --skip-verify        Skip Phase 6 (verification)
-  --with-observability Also run Phase 7 (COO + Gateway telemetry)
+  --with-observability Also run Phase 7 (Tempo + OpenTelemetry + COO + Gateway telemetry)
   --with-external-models Also run Phase 8 (ExternalModel deployment + test)
   --external-model-provider <p>   Provider: openai (default), gemini, bedrock (or set EXTERNAL_MODEL_PROVIDER)
   --external-model-api-key <key>  API key for external provider (or set EXTERNAL_MODEL_API_KEY)
@@ -100,7 +100,7 @@ Phases:
   4  MaaS platform      PostgreSQL secrets/deployment, Authorino TLS
   5  Deploy model       Auto-detect GPU, apply model Kustomize manifests
   6  Verify             6-phase E2E verification (API, auth, rate limits)
-  7  Observability      COO + Gateway telemetry (only with --with-observability)
+  7  Observability      Tempo + OpenTelemetry + COO + Gateway telemetry (only with --with-observability)
   8  External models    ExternalModel + governance (only with --with-external-models)
 
 Auto-detection (--model auto):
@@ -710,6 +710,7 @@ if should_run 5 && [ "$SKIP_MODELS" = false ]; then
             log_info "Waiting for model pods (up to 10 minutes for GPU models)..."
             TIMEOUT=600
             ELAPSED=0
+            XET_PATCHED=false
             while [ $ELAPSED -lt $TIMEOUT ]; do
                 POD_COUNT=$(oc get pods -n llm --no-headers 2>/dev/null | wc -l | tr -d ' ')
                 if [ "$POD_COUNT" -gt 0 ]; then
@@ -718,6 +719,18 @@ if should_run 5 && [ "$SKIP_MODELS" = false ]; then
                     if [ "$NOT_READY" -eq 0 ]; then
                         log_info "All model pods Running"
                         break
+                    fi
+                    # HuggingFace Xet workaround: if pods stuck in Init for >120s, disable Xet
+                    if [ "$XET_PATCHED" = false ] && [ $ELAPSED -ge 120 ]; then
+                        INIT_STUCK=$(oc get pods -n llm --no-headers 2>/dev/null | grep "Init:" | wc -l | tr -d ' ')
+                        if [ "$INIT_STUCK" -gt 0 ]; then
+                            log_warn "Pod stuck in Init - applying HF_HUB_DISABLE_XET=1 workaround"
+                            for deploy in $(oc get deployment -n llm --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null); do
+                                oc patch deployment "$deploy" -n llm --type=json \
+                                    -p '[{"op":"add","path":"/spec/template/spec/initContainers/0/env/-","value":{"name":"HF_HUB_DISABLE_XET","value":"1"}}]' 2>/dev/null || true
+                            done
+                            XET_PATCHED=true
+                        fi
                     fi
                 fi
                 sleep 10
@@ -768,9 +781,68 @@ fi
 if should_run 7 && [ "$WITH_OBSERVABILITY" = true ]; then
     log_phase 7 "Observability"
 
+    # Tempo Operator
+    log_step "Installing Tempo Operator..."
+    run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/tempo/"
+    if [ "$DRY_RUN" = false ]; then
+        log_info "Waiting for Tempo CSV..."
+        TIMEOUT=300
+        ELAPSED=0
+        while [ $ELAPSED -lt $TIMEOUT ]; do
+            TEMPO_PHASE=$(oc get csv -n openshift-tempo-operator --no-headers 2>/dev/null \
+                | grep tempo-operator | awk '{print $NF}' || echo "")
+            [ "$TEMPO_PHASE" = "Succeeded" ] && break
+            sleep 10
+            ELAPSED=$((ELAPSED + 10))
+        done
+        if [ "${TEMPO_PHASE:-}" = "Succeeded" ]; then
+            log_info "Tempo CSV: Succeeded"
+        else
+            log_warn "Tempo CSV not Succeeded after ${TIMEOUT}s"
+        fi
+    fi
+
+    # Red Hat build of OpenTelemetry Operator
+    log_step "Installing Red Hat build of OpenTelemetry Operator..."
+    run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/opentelemetry/"
+    if [ "$DRY_RUN" = false ]; then
+        log_info "Waiting for OpenTelemetry CSV..."
+        TIMEOUT=300
+        ELAPSED=0
+        while [ $ELAPSED -lt $TIMEOUT ]; do
+            OTEL_PHASE=$(oc get csv -n openshift-opentelemetry-operator --no-headers 2>/dev/null \
+                | grep opentelemetry-operator | awk '{print $NF}' || echo "")
+            [ "$OTEL_PHASE" = "Succeeded" ] && break
+            sleep 10
+            ELAPSED=$((ELAPSED + 10))
+        done
+        if [ "${OTEL_PHASE:-}" = "Succeeded" ]; then
+            log_info "OpenTelemetry CSV: Succeeded"
+        else
+            log_warn "OpenTelemetry CSV not Succeeded after ${TIMEOUT}s"
+        fi
+    fi
+
     # COO
     log_step "Installing Cluster Observability Operator..."
     run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/coo/"
+
+    log_info "Approving COO install plan (pinned to v1.4.0, Manual approval)..."
+    if [ "$DRY_RUN" = false ]; then
+        for attempt in $(seq 1 30); do
+            PENDING=$(oc get installplan -n openshift-cluster-observability-operator --no-headers 2>/dev/null | grep -v "true" | awk '{print $1}')
+            if [ -n "$PENDING" ]; then
+                echo "$PENDING" | xargs -I{} oc patch installplan {} -n openshift-cluster-observability-operator \
+                    --type=merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+                log_info "  COO install plan(s) approved"
+                break
+            fi
+            sleep 2
+        done
+    else
+        log_info "[DRY RUN] Would approve COO install plan"
+    fi
+
     if [ "$DRY_RUN" = false ]; then
         log_info "Waiting for COO CSV..."
         TIMEOUT=300


### PR DESCRIPTION
## Summary

- **Pin COO to v1.4.0** with `startingCSV` + Manual install plan approval (matching RHCL v1.3.4 pattern) to avoid regressions in newer versions
- **Add Tempo and OpenTelemetry operator manifests** (namespace, operatorgroup, subscription, kustomization) - required by the RHOAI Monitoring controller for distributed tracing and telemetry collection
- **Document HuggingFace Xet download hang** in Phase 5 docs and automate the workaround in `setup-maas.sh` - HF migrated to Xet protocol which hangs the KServe storage-initializer; fix is `HF_HUB_DISABLE_XET=1`
- **Update 07-observability.adoc** with Tempo (Step 1), OpenTelemetry (Step 2), COO manual approval (Step 3), verification commands for all 3 operators, and updated directory structure

## Changes

| File | Change |
|------|--------|
| `manifests/07-observability/coo/subscription.yaml` | Add `startingCSV: cluster-observability-operator.v1.4.0` + `installPlanApproval: Manual` |
| `manifests/07-observability/tempo/` (4 files) | New: namespace, operatorgroup, subscription, kustomization |
| `manifests/07-observability/opentelemetry/` (4 files) | New: namespace, operatorgroup, subscription, kustomization |
| `content/modules/ROOT/pages/07-observability.adoc` | Add Tempo/OpenTelemetry steps, COO approval step, verification, directory structure |
| `content/modules/ROOT/pages/05-maas-models.adoc` | Add HuggingFace Xet download hang workaround NOTE |
| `scripts/setup-maas.sh` | Add auto Xet workaround in Phase 5, COO approval logic in Phase 7 |

## Test plan

- [x] Validated on cluster-7x9rq (OCP 4.20.24, SNO, platform=None, no GPU)
- [x] 15/15 verification checks passed
- [x] COO v1.4.0 installed successfully with Manual approval
- [x] Tempo and OpenTelemetry operators installed and CRDs registered
- [x] HF Xet workaround confirmed - pod completes init in ~30s after patch
- [x] Gateway stable at 2Gi memory, 0 OOMKill restarts
- [x] RHCL v1.3.4 pin still working correctly