### PR TITLE
Restrict gateway HTTPRoute binding to labeled namespaces

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -289,7 +289,34 @@ oc patch gateway maas-default-gateway -n openshift-ingress --type=merge -p '{
 This is tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68589[RHOAIENG-68589].
 ====
 
-*Step 5d:* Create Passthrough Route (Non-Cloud Platforms Only)
+*Step 5d:* Label namespaces for Gateway route binding
+
+The Gateway restricts HTTPRoute attachment to namespaces explicitly labeled with `maas.opendatahub.io/gateway-access=true`. This follows the principle of least privilege - only namespaces that are designated to expose services through the Gateway can create routes.
+
+[IMPORTANT]
+====
+Any namespace that needs to serve models through the MaaS Gateway must be labeled with `maas.opendatahub.io/gateway-access=true`. Without this label, HTTPRoutes created in that namespace will not be accepted by the Gateway and the model will not be reachable.
+
+If you create additional namespaces for model serving, remember to apply this label:
+
+[source,bash]
+----
+oc label namespace <your-namespace> \
+  maas.opendatahub.io/gateway-access=true --overwrite
+----
+====
+
+Label the `redhat-ods-applications` namespace where the MaaS API route is created:
+
+[source,bash]
+----
+oc label namespace redhat-ods-applications \
+  maas.opendatahub.io/gateway-access=true --overwrite
+----
+
+NOTE: Model namespaces (`llm`, `external-models`) are labeled in their respective deployment phases.
+
+*Step 5e:* Create Passthrough Route (Non-Cloud Platforms Only)
 
 If your platform type from Step 5a was `None`, `BareMetal`, or `OpenStack`, you must create a passthrough Route. This routes external traffic through the OpenShift ingress controller to the Gateway's LoadBalancer service.
 
@@ -390,7 +417,7 @@ $ oc get gateway maas-default-gateway -n openshift-ingress
 NAME                   CLASS               ADDRESS       PROGRAMMED   AGE
 maas-default-gateway   openshift-default   10.10.10.10   True         13m
 
-# (If you created a passthrough route in Step 5d)
+# (If you created a passthrough route in Step 5e)
 $ oc get route maas-default-gateway-https -n openshift-ingress -o jsonpath='{.status.ingress[0].conditions[?(@.type=="Admitted")].status}'
 True
 

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -81,7 +81,10 @@ Create the `llm` namespace if it doesn't exist and label it for RHOAI:
 ----
 oc create namespace llm
 oc label namespace llm opendatahub.io/generated-namespace=true --overwrite
+oc label namespace llm maas.opendatahub.io/gateway-access=true --overwrite
 ----
+
+IMPORTANT: The `maas.opendatahub.io/gateway-access` label is required for any namespace that serves models through the MaaS Gateway. Without it, the Gateway will not accept HTTPRoutes from this namespace and the model will not be reachable.
 
 Deploy the simulator (no GPU required):
 

--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -27,6 +27,8 @@ The external models live in their own namespace, separate from the MaaS platform
 oc apply -f manifests/08-external-models/openai/namespace.yaml
 ----
 
+NOTE: The namespace manifest includes the `maas.opendatahub.io/gateway-access=true` label, which is required for the Gateway to accept HTTPRoutes from this namespace. If you create the namespace manually instead of using the manifest, remember to apply this label: `oc label namespace external-models maas.opendatahub.io/gateway-access=true --overwrite`
+
 Create the provider credential Secret. This is done imperatively (never stored in manifests):
 
 [source,bash]

--- a/manifests/02-platform-config/gateway.yaml.tmpl
+++ b/manifests/02-platform-config/gateway.yaml.tmpl
@@ -20,14 +20,20 @@ spec:
      protocol: HTTP
      allowedRoutes:
        namespaces:
-         from: All
+         from: Selector
+         selector:
+           matchLabels:
+             maas.opendatahub.io/gateway-access: "true"
    - name: https
      hostname: maas.${CLUSTER_DOMAIN}
      port: 443
      protocol: HTTPS
      allowedRoutes:
        namespaces:
-         from: All
+         from: Selector
+         selector:
+           matchLabels:
+             maas.opendatahub.io/gateway-access: "true"
      tls:
        certificateRefs:
        - group: ""

--- a/manifests/03-maas-platform/openshift-gateway-setup/gateway.yaml.tmpl
+++ b/manifests/03-maas-platform/openshift-gateway-setup/gateway.yaml.tmpl
@@ -17,14 +17,20 @@ spec:
       protocol: HTTP
       allowedRoutes:
         namespaces:
-          from: All
+          from: Selector
+          selector:
+            matchLabels:
+              maas.opendatahub.io/gateway-access: "true"
     - name: https
       hostname: maas.${CLUSTER_DOMAIN}
       port: 443
       protocol: HTTPS
       allowedRoutes:
         namespaces:
-          from: All
+          from: Selector
+          selector:
+            matchLabels:
+              maas.opendatahub.io/gateway-access: "true"
       tls:
         certificateRefs:
           - group: ""

--- a/manifests/06-verification/verify.sh
+++ b/manifests/06-verification/verify.sh
@@ -318,6 +318,7 @@ log_step "Phase 2: Deploy simulator model and MaaS resources"
 # Create namespaces
 oc create namespace "$MODEL_NS" --dry-run=client -o yaml | oc apply -f - 2>/dev/null
 oc label namespace "$MODEL_NS" opendatahub.io/generated-namespace=true --overwrite 2>/dev/null || true
+oc label namespace "$MODEL_NS" maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
 oc create namespace "$MAAS_NS" --dry-run=client -o yaml | oc apply -f - 2>/dev/null
 oc label namespace "$MAAS_NS" opendatahub.io/generated-namespace=true --overwrite 2>/dev/null || true
 log_info "Ensured namespaces: $MODEL_NS, $MAAS_NS"

--- a/manifests/08-external-models/bedrock/namespace.yaml
+++ b/manifests/08-external-models/bedrock/namespace.yaml
@@ -4,3 +4,4 @@ metadata:
   name: external-models
   labels:
     opendatahub.io/generated-namespace: "true"
+    maas.opendatahub.io/gateway-access: "true"

--- a/manifests/08-external-models/gemini/namespace.yaml
+++ b/manifests/08-external-models/gemini/namespace.yaml
@@ -4,3 +4,4 @@ metadata:
   name: external-models
   labels:
     opendatahub.io/generated-namespace: "true"
+    maas.opendatahub.io/gateway-access: "true"

--- a/manifests/08-external-models/openai/namespace.yaml
+++ b/manifests/08-external-models/openai/namespace.yaml
@@ -4,3 +4,4 @@ metadata:
   name: external-models
   labels:
     opendatahub.io/generated-namespace: "true"
+    maas.opendatahub.io/gateway-access: "true"

--- a/scripts/deploy-model.sh
+++ b/scripts/deploy-model.sh
@@ -127,6 +127,18 @@ fi
 log_info "Selected model: $MODEL"
 
 # =============================================================================
+# Prepare llm namespace
+# =============================================================================
+log_step "Preparing llm namespace"
+
+if ! oc get namespace llm &>/dev/null; then
+    run_cmd oc create namespace llm
+fi
+oc label namespace llm opendatahub.io/generated-namespace=true --overwrite 2>/dev/null || true
+oc label namespace llm maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
+log_info "llm namespace ready with required labels"
+
+# =============================================================================
 # Deploy model
 # =============================================================================
 log_step "Deploying model: $MODEL"

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -490,6 +490,9 @@ if should_run 2; then
             security.opendatahub.io/authorino-tls-bootstrap="true" --overwrite
         log_info "Gateway authorino-tls-bootstrap annotation applied"
     fi
+
+    # Label redhat-ods-applications for Gateway route binding (best practice: least privilege)
+    oc label namespace redhat-ods-applications maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
 fi
 
 # =============================================================================
@@ -702,6 +705,7 @@ if should_run 5 && [ "$SKIP_MODELS" = false ]; then
             run_cmd oc create namespace llm
         fi
         oc label namespace llm opendatahub.io/generated-namespace=true --overwrite 2>/dev/null || true
+        oc label namespace llm maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
         run_cmd oc apply -k "$MODEL_DIR/"
         log_info "Model manifests applied"
 


### PR DESCRIPTION
The MaaS default gateway was using `allowedRoutes.namespaces.from: All`, which means any namespace in the cluster could create HTTPRoutes that attach to it. This isn't great from a least-privilege perspective - we should only allow namespaces that actually need to serve models through the gateway.

This switches both gateway templates to `from: Selector` with a label match on `maas.opendatahub.io/gateway-access=true`. Only namespaces carrying that label can attach HTTPRoutes to the gateway.

### What changed

**Gateway templates** (`manifests/02-platform-config/gateway.yaml.tmpl` and `manifests/03-maas-platform/openshift-gateway-setup/gateway.yaml.tmpl`):
- Both HTTP and HTTPS listeners now use `from: Selector` instead of `from: All`
- Selector matches on `maas.opendatahub.io/gateway-access: "true"`

**setup-maas.sh**:
- Phase 2: labels `redhat-ods-applications` after gateway annotation
- Phase 5: labels `llm` namespace alongside the existing `opendatahub.io/generated-namespace` label

**verify.sh**:
- Labels the model namespace during test setup so the verification flow works with the new selector

**External model namespace manifests** (openai, gemini, bedrock):
- Added `maas.opendatahub.io/gateway-access: "true"` to the namespace labels

**Guide docs**:
- New Step 5d in Phase 2 explaining the namespace labeling (with IMPORTANT admonition)
- Phase 5 now includes the gateway-access label command and a note about why it's needed
- Phase 8 has a NOTE reminding users about the label if they create the namespace manually
- Old Step 5d (passthrough route) renumbered to 5e

### Tested

Ran the full manual walkthrough (Phase 1 through 6) on a fresh RHPDS SNO cluster (OCP 4.20.24, platform None). All 15 verification checks passed. Also confirmed the selector works correctly:
- HTTPRoute in an unlabeled namespace: rejected (`NotAllowedByListeners`)
- Same namespace after labeling: accepted
- After removing the label: rejected again