### PR TITLE
Populate DSCI monitoring config after Phase 7 operators are ready

### DIFF
--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -74,7 +74,45 @@ oc wait csv -n openshift-cluster-observability-operator \
   --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
 ----
 
-== Step 4: Apply Gateway Telemetry
+== Step 4: Enable DSCI Monitoring
+
+Now that all three observability operators are installed, configure the DSCI monitoring section to trigger the operator's observability cascade (MonitoringStack, ThanosQuerier, Perses, tracing):
+
+[source,bash]
+----
+oc patch dsci default-dsci --type=merge -p '{
+  "spec": {
+    "monitoring": {
+      "namespace": "redhat-ods-monitoring",
+      "metrics": {
+        "replicas": 1,
+        "storage": {
+          "size": "5Gi",
+          "retention": "90d"
+        }
+      },
+      "traces": {
+        "sampleRatio": "0.1",
+        "storage": {
+          "backend": "pv",
+          "retention": "2160h"
+        }
+      }
+    }
+  }
+}'
+----
+
+IMPORTANT: This step is required for the Observability Dashboard tab in the RHOAI UI to show metrics. Without it, the DSCI monitoring section remains empty (`metrics: {}`) and the dashboard has no data source.
+
+Wait for the DSCI to reconcile:
+
+[source,bash]
+----
+oc wait --for=jsonpath='{.status.phase}'=Ready dsci/default-dsci --timeout=300s
+----
+
+== Step 5: Apply Gateway Telemetry
 
 Once COO is installed and the MaaS gateway is running:
 

--- a/manifests/04-rhoai-config/dscinitialization.yaml
+++ b/manifests/04-rhoai-config/dscinitialization.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   applicationsNamespace: redhat-ods-applications
   # Monitoring is Managed so the RHOAI operator owns its monitoring CRs.
-  # The metrics.storage block is intentionally omitted here. Populating it
-  # triggers the operator's full observability cascade (MonitoringStack,
-  # ThanosQuerier, Perses, Tempo, OpenTelemetryCollector DaemonSet,
-  # NodeMetricsEndpoint). That cascade is applied separately in Phase 7
-  # (manifests/07-observability/) after a settle-gate confirms the cluster can handle it.
+  # The metrics/traces config is intentionally omitted here because populating
+  # it triggers the operator's observability cascade (MonitoringStack,
+  # ThanosQuerier, Perses, tracing) which requires Tempo, OpenTelemetry, and
+  # COO operators to be installed first. Phase 7 installs those operators and
+  # then patches this DSCI to add the metrics/traces config.
   monitoring:
     managementState: Managed
   trustedCABundle:

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -865,6 +865,36 @@ if should_run 7 && [ "$WITH_OBSERVABILITY" = true ]; then
         fi
     fi
 
+    # DSCI monitoring config
+    log_step "Enabling DSCI monitoring (metrics + traces)..."
+    run_cmd oc patch dsci default-dsci --type=merge -p '{
+      "spec": {
+        "monitoring": {
+          "namespace": "redhat-ods-monitoring",
+          "metrics": {
+            "replicas": 1,
+            "storage": {
+              "size": "5Gi",
+              "retention": "90d"
+            }
+          },
+          "traces": {
+            "sampleRatio": "0.1",
+            "storage": {
+              "backend": "pv",
+              "retention": "2160h"
+            }
+          }
+        }
+      }
+    }'
+    if [ "$DRY_RUN" = false ]; then
+        log_info "Waiting for DSCI to reconcile..."
+        oc wait --for=jsonpath='{.status.phase}'=Ready dsci/default-dsci --timeout=300s 2>/dev/null || \
+            log_warn "DSCI did not reach Ready within 300s (monitoring cascade may still be provisioning)"
+    fi
+    log_info "DSCI monitoring configured"
+
     # Telemetry
     log_step "Applying Gateway telemetry..."
     run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/telemetry/"


### PR DESCRIPTION
## What

Phase 7 installs the three observability operators (Tempo, OpenTelemetry, COO) but never tells the DSCI to actually use them. The monitoring section stays as `metrics: {}`, so the Observability Dashboard tab in the RHOAI UI has no data source and shows nothing useful.

This adds a step after the operators are confirmed ready that patches the DSCI with:
- **Metrics**: 1 replica, 5Gi storage, 90-day retention
- **Traces**: 10% sampling ratio, PV-backed storage, 90-day retention

Once patched, the RHOAI operator provisions the full monitoring cascade (MonitoringStack, Perses, OpenTelemetryCollector, PersesDashboards) and the dashboard works.

Values match what we've been using successfully in other deployments (ref: joshgav/openshift-services).

## Changes

- `07-observability.adoc` - new Step 4 (Enable DSCI Monitoring) between COO install and gateway telemetry
- `setup-maas.sh` - same DSCI patch added to Phase 7, with a wait for DSCI reconciliation
- `dscinitialization.yaml` - updated comment to accurately describe that Phase 7 patches the DSCI (the old comment claimed it but nothing actually did it)

## Tested on

- cluster-tzg4m (RHPDS AWS SNO, OCP 4.20)
- Installed Tempo, OpenTelemetry, COO operators
- Applied the DSCI patch
- Confirmed MonitoringStack, Perses, OpenTelemetryCollector, and 4 PersesDashboards were created
- Opened RHOAI dashboard, all three tabs (Cluster, Models, Usage) render with data
- Inference requests (200s + 429 rate-limited) confirmed working after patch

Fixes #35