### PR TITLE
fix: avoid MetalLB IP collision with node IP on SNO

### DIFF
--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -205,17 +205,20 @@ oc apply -f manifests/01-prerequisites/metallb/metallb.yaml
 
 Create IPAddressPool + L2Advertisement.  
 
-[NOTE]
+[IMPORTANT]
 ====
-The following instruction is for SNO clusters and uses the node's internal IP. +
-For multi-node clusters, adjust the range in `METALLB_IP_RANGE` to an unused IP range on your network.
+Do *not* use the node's own IP for the MetalLB pool. When a LoadBalancer service shares the node IP on port 443, kube-proxy iptables rules intercept internal cluster traffic meant for the OpenShift router (which serves `*.apps` routes on the same IP:port via hostNetwork). This breaks OAuth callbacks, console access, and any in-cluster traffic to routes.
+
+The command below derives an IP one address above the first node's InternalIP. For multi-node clusters or complex networks, adjust `METALLB_IP_RANGE` to an unused IP on the same L2 subnet.
 ====
 
 [source,bash]
 ----
-export METALLB_IP_RANGE="$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')-$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+NODE_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+METALLB_IP=$(echo "$NODE_IP" | awk -F. '{printf "%s.%s.%s.%d", $1, $2, $3, $4+1}')
+export METALLB_IP_RANGE="${METALLB_IP}-${METALLB_IP}"
 
-echo $METALLB_IP_RANGE
+echo "Node IP: $NODE_IP  ->  MetalLB IP: $METALLB_IP_RANGE"
 
 envsubst < manifests/03-maas-platform/openshift-gateway-setup/metallb-config.yaml | oc apply -f -
 ----

--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -334,7 +334,7 @@ envsubst '${CLUSTER_DOMAIN}' < manifests/03-maas-platform/openshift-gateway-setu
 ====
 *Why is this needed?*
 
-On non-cloud platforms, the Gateway's LoadBalancer service receives an IP from MetalLB (e.g., 10.10.10.10), but that IP is only routable within the cluster network. External traffic cannot reach it directly.
+On non-cloud platforms, the Gateway's LoadBalancer service receives an IP from MetalLB (e.g., 10.10.10.11), but that IP is only routable within the cluster network. External traffic cannot reach it directly.
 
 The passthrough Route bridges external requests (via the OpenShift router at your cluster's public DNS) to the internal LoadBalancer IP, allowing the Gateway to be accessible from outside the cluster.
 ====
@@ -415,7 +415,7 @@ openshift-default   openshift.io/gateway-controller/v1   True       23m
 
 $ oc get gateway maas-default-gateway -n openshift-ingress
 NAME                   CLASS               ADDRESS       PROGRAMMED   AGE
-maas-default-gateway   openshift-default   10.10.10.10   True         13m
+maas-default-gateway   openshift-default   10.10.10.11   True         13m
 
 # (If you created a passthrough route in Step 5e)
 $ oc get route maas-default-gateway-https -n openshift-ingress -o jsonpath='{.status.ingress[0].conditions[?(@.type=="Admitted")].status}'

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -442,8 +442,9 @@ if should_run 2; then
                         if ! oc get ipaddresspool maas-pool -n metallb-system &>/dev/null; then
                             NODE_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null || echo "")
                             if [ -n "$NODE_IP" ]; then
-                                METALLB_IP_RANGE="192.168.1.240-192.168.1.240"
-                                log_info "Creating MetalLB IPAddressPool: ${METALLB_IP_RANGE}"
+                                METALLB_IP=$(echo "$NODE_IP" | awk -F. '{printf "%s.%s.%s.%d", $1, $2, $3, $4+1}')
+                                METALLB_IP_RANGE="${METALLB_IP}-${METALLB_IP}"
+                                log_info "Creating MetalLB IPAddressPool: ${METALLB_IP_RANGE} (node IP: ${NODE_IP})"
                                 export METALLB_IP_RANGE
                                 envsubst '${METALLB_IP_RANGE}' < "$MANIFESTS_DIR/03-maas-platform/openshift-gateway-setup/metallb-config.yaml" | oc apply -f -
                             else


### PR DESCRIPTION
## Summary

- **Docs + script told SNO users to use the node's own InternalIP for MetalLB**, which causes kube-proxy iptables to hijack port 443 traffic and route it to the MaaS Istio gateway instead of the OpenShift router
- This breaks OAuth callbacks (Keycloak token exchange gets connection reset), console access, and any in-cluster traffic to `*.apps` routes
- Now derives MetalLB IP as node IP + 1 (same L2 subnet, no conflict)
- Updates `01-prerequisites.adoc`, `02-platform-config.adoc` (example IPs), and `setup-maas.sh` (was hardcoded to `192.168.1.240`)

## Root cause

On SNO, the OpenShift router runs with `hostNetwork: true` and serves `*.apps` routes on `<nodeIP>:443`. When MetalLB advertises the same IP for the MaaS gateway's LoadBalancer service, kube-proxy creates iptables rules that intercept packets to `<nodeIP>:443` and redirect them to the Istio gateway pods. The OAuth pod trying to reach `sso.apps.<cluster>:443` gets its connection reset because Istio doesn't know how to handle the Keycloak route.

## Test plan

- [x] Changed MetalLB pool from `10.10.10.10` to `10.10.10.11` on live cluster-2q4k5
- [x] Gateway still Programmed=True with new IP
- [x] MaaS API responding (model listed, inference works)
- [x] Keycloak OIDC endpoint reachable from inside cluster (HTTP 200)
- [x] OAuth pod logs clean (no more connection reset errors)
- [x] Passthrough Route still works (targets service by name, not IP)