### PR TITLE
fix: remove RHCL pin + add cleanup script

### DIFF
--- a/.claude/skills/verify-guide/SKILL.md
+++ b/.claude/skills/verify-guide/SKILL.md
@@ -32,7 +32,7 @@ If any of the three required arguments are missing, use `AskUserQuestion` to req
 | 0 | Cluster login, preflight detection (platform, OCP version, GPU, nodes) | instant |
 | 1 | Full MaaS installation via `./scripts/setup-maas.sh` | 15-30 min |
 | 2 | 15-point E2E via `./manifests/06-verification/verify.sh --no-cleanup` | 3-5 min |
-| 3 | 8 blind-spot regression checks (gateway OOM, MetalLB IP, RHCL pin, etc.) | 1-2 min |
+| 3 | 8 blind-spot regression checks (gateway OOM, MetalLB IP, RHCL version, etc.) | 1-2 min |
 | 4 | AsciiDoc guide commands produce documented output | 1-2 min |
 | 5 | Report generation + save findings to memory | instant |
 
@@ -263,7 +263,7 @@ Verify these labels exist:
 - FAIL for each missing label (report which ones)
 - If namespace llm does not exist, WARN (model may not have been deployed)
 
-#### Check 6: RHCL Pinned to v1.3.4
+#### Check 6: RHCL Version and Approval Mode
 
 ```bash
 RHCL_CSV=$(oc get csv -n openshift-operators --no-headers 2>/dev/null | grep rhcl || echo "")
@@ -271,8 +271,8 @@ RHCL_VERSION=$(echo "$RHCL_CSV" | awk '{print $1}' | grep -oE 'v[0-9]+\.[0-9]+\.
 RHCL_APPROVAL=$(oc get subscription -n openshift-operators -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.installPlanApproval}{"\n"}{end}' 2>/dev/null | grep rhcl || echo "")
 ```
 
-- PASS if RHCL version is v1.3.4 AND installPlanApproval is Manual
-- WARN if RHCL version is v1.4.x (known Wasm plugin issues with v1.4.0)
+- PASS if RHCL version is v1.4.2+ AND installPlanApproval is Automatic
+- WARN if installPlanApproval is Manual (old pin - should be Automatic now)
 - FAIL if RHCL is not installed or version cannot be determined
 
 #### Check 7: HF Xet Storage Behavior
@@ -538,7 +538,7 @@ This list was built from 7 walkthroughs. The blind-spot checks target these spec
 | Help text phase numbering mismatch | v7 | OPEN |
 | MetalLB IP collision with node IP | v6 | FIXED (PR #40) |
 | Kuadrant Wasm plugin startup race | v3 | UPSTREAM |
-| RHCL v1.4.0 Wasm/UI bugs | v5 | MITIGATED (pin to v1.3.4) |
+| RHCL v1.4.0 Wasm/UI bugs | v5 | FIXED (v1.4.2, pin removed) |
 
 ## Troubleshooting
 

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,4 @@ www/
 .cache/antora/
 node_modules/
 rhoai-maas-guide.code-workspace
+.serena/

--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -20,5 +20,8 @@
 .Reference
 * xref:08-architecture.adoc[Architecture & Request Flow]
 
+.Cleanup
+* xref:09-cleanup.adoc[Cleanup & Teardown]
+
 .Tools
 * xref:claude-code.adoc[AI-Assisted Installation]

--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -16,7 +16,7 @@ IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/
 | `redhat-ods-operator`
 | Core RHOAI platform, model serving, dashboards, pipelines
 
-| Red Hat Connectivity Link (`rhcl-operator`) ^1^
+| Red Hat Connectivity Link (`rhcl-operator`)
 | `openshift-operators`
 | API gateway policies, authentication (Authorino) and rate limiting (Limitador) for MaaS endpoints
 
@@ -28,8 +28,6 @@ IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/
 | `openshift-lws-operator`
 | Coordinates multi-replica workloads for distributed inference and training
 |===
-
-^1^ RHCL is pinned to v1.3.4. Version 1.4.0 has known issues with WASM plugin loading that cause gateway errors and break the RHOAI model UI. The subscription uses `Manual` install plan approval to prevent auto-upgrade. This pin will be removed once the upstream fix ships.
 
 === Optional GPU Operators
 
@@ -81,25 +79,6 @@ oc apply -k manifests/01-prerequisites/operators/
 ----
 
 This installs all four required operator subscriptions. OLM will resolve and install each operator automatically.
-
-=== Step 1b: Approve RHCL Install Plan
-
-The RHCL operator uses `Manual` install plan approval to pin version 1.3.4. After applying the subscriptions, approve the pending install plan so OLM can install it:
-
-[source,bash]
-----
-# Wait for the install plan to appear (takes ~10s)
-sleep 10
-
-# Approve all pending install plans in openshift-operators
-oc get installplan -n openshift-operators --no-headers \
-  -o custom-columns='NAME:.metadata.name,APPROVED:.spec.approved' | \
-  grep false | awk '{print $1}' | \
-  xargs -I{} oc patch installplan {} -n openshift-operators \
-    --type=merge -p '{"spec":{"approved":true}}'
-----
-
-NOTE: Only the RHCL operator has a pending install plan (other operators use `Automatic` approval). This step is required because RHCL is pinned to v1.3.4 to avoid known WASM plugin issues in v1.4.0.
 
 === Step 2 (Optional): Install GPU Operators
 
@@ -299,11 +278,9 @@ openshift-lws-operator   leader-worker-set                                      
 openshift-operators      authorino-operator-stable-redhat-operators-openshift-marketplace                       authorino-operator.v1.3.1                          AtLatestKnown
 openshift-operators      dns-operator-stable-redhat-operators-openshift-marketplace                             dns-operator.v1.3.1                                AtLatestKnown
 openshift-operators      limitador-operator-stable-redhat-operators-openshift-marketplace                       limitador-operator.v1.3.1                          AtLatestKnown
-openshift-operators      rhcl-operator                                                                          rhcl-operator.v1.4.0                               UpgradePending
+openshift-operators      rhcl-operator                                                                          rhcl-operator.v1.4.2                               AtLatestKnown
 redhat-ods-operator      rhods-operator                                                                         rhods-operator.3.4.0                               AtLatestKnown
 ----
-
-TIP: The RHCL subscription shows `UpgradePending` with `currentCSV: v1.4.0` because OLM sees the upgrade but it is blocked by Manual approval. The *installed* version is v1.3.4. Verify with: `oc get csv -n openshift-operators rhcl-operator.v1.3.4 -o jsonpath='{.status.phase}'` (should return `Succeeded`).
 
 == Appendix
 

--- a/content/modules/ROOT/pages/09-cleanup.adoc
+++ b/content/modules/ROOT/pages/09-cleanup.adoc
@@ -1,0 +1,197 @@
+= Cleanup & Teardown
+
+Remove {maas} and its dependencies from your OpenShift cluster.
+
+== Automated Cleanup
+
+The cleanup script reverses `setup-maas.sh` in reverse order, checking whether each resource exists before deleting.
+
+[source,bash]
+----
+./scripts/cleanup-maas.sh
+----
+
+The script prompts for confirmation before deleting anything. Pass `--yes` to skip the prompt.
+
+=== Options
+
+[cols="1,3", options="header"]
+|===
+| Flag | Description
+
+| `--dry-run`
+| Preview what would be deleted without actually deleting
+
+| `--keep-operators`
+| Skip operator removal (Phase 7) - useful when you only want to tear down models and config
+
+| `--from-phase <N>`
+| Start from a specific cleanup phase (1-7)
+
+| `--yes`
+| Skip the confirmation prompt
+|===
+
+=== Cleanup Phases
+
+The script runs these phases in order:
+
+[cols="1,2,3", options="header"]
+|===
+| Phase | Name | What it removes
+
+| 1
+| External Models
+| ExternalModel CRs, provider API key secrets, `external-models` namespace
+
+| 2
+| Observability
+| Telemetry policies, COO / OpenTelemetry / Tempo operators and namespaces
+
+| 3
+| Models
+| MaaSSubscription, MaaSAuthPolicy, MaaSModelRef, LLMInferenceService, `llm` namespace
+
+| 4
+| RHOAI Configuration
+| OdhDashboardConfig, DataScienceCluster, DSCInitialization
+
+| 5
+| MaaS Platform
+| PostgreSQL deployment / PVC / service, `postgres-creds` and `maas-db-config` secrets
+
+| 6
+| Platform Configuration
+| Gateway, GatewayClass, Route, Kuadrant CR, user workload monitoring config, MetalLB (if installed)
+
+| 7
+| Operators
+| RHCL, cert-manager, LWS, RHOAI subscriptions / CSVs, operator namespaces, RHOAI-managed namespaces
+|===
+
+=== Examples
+
+Preview what would be deleted:
+
+[source,bash]
+----
+./scripts/cleanup-maas.sh --dry-run
+----
+
+Remove models and config but keep operators installed:
+
+[source,bash]
+----
+./scripts/cleanup-maas.sh --keep-operators
+----
+
+Remove only the operators (everything else already cleaned up):
+
+[source,bash]
+----
+./scripts/cleanup-maas.sh --from-phase 7
+----
+
+== Manual Cleanup
+
+If you prefer to remove resources selectively, follow these steps in order.
+
+=== Remove Models
+
+[source,bash]
+----
+# Delete MaaS governance CRs
+oc delete maassubscription --all -n models-as-a-service --ignore-not-found
+oc delete maasauthpolicy --all -n models-as-a-service --ignore-not-found
+oc delete maasmodelref --all -n llm --ignore-not-found
+
+# Delete model serving
+oc delete llminferenceservice --all -n llm --ignore-not-found
+
+# Delete model namespace
+oc delete namespace llm --ignore-not-found
+----
+
+=== Remove RHOAI Configuration
+
+[source,bash]
+----
+oc delete odhdashboardconfig odh-dashboard-config -n redhat-ods-applications --ignore-not-found
+oc delete datasciencecluster default-dsc --ignore-not-found
+oc delete dscinitialization default-dsci --ignore-not-found
+----
+
+=== Remove MaaS Platform (PostgreSQL)
+
+[source,bash]
+----
+oc delete deployment postgres -n redhat-ods-applications --ignore-not-found
+oc delete service postgres -n redhat-ods-applications --ignore-not-found
+oc delete pvc postgres-data -n redhat-ods-applications --ignore-not-found
+oc delete secret postgres-creds maas-db-config -n redhat-ods-applications --ignore-not-found
+----
+
+=== Remove Gateway and Kuadrant
+
+[source,bash]
+----
+# Gateway resources
+oc delete route maas-default-gateway-https -n openshift-ingress --ignore-not-found
+oc delete gateway maas-default-gateway -n openshift-ingress --ignore-not-found
+oc delete configmap maas-gateway-options -n openshift-ingress --ignore-not-found
+oc delete gatewayclass openshift-default --ignore-not-found
+
+# Kuadrant
+oc delete kuadrant kuadrant -n kuadrant-system --ignore-not-found
+oc delete namespace kuadrant-system --ignore-not-found
+----
+
+=== Remove Operators
+
+Delete subscriptions first, then CSVs, then namespaces:
+
+[source,bash]
+----
+# RHCL (shared openshift-operators namespace - only delete the subscription and CSVs)
+oc delete subscription rhcl-operator -n openshift-operators --ignore-not-found
+oc delete csv -n openshift-operators -l operators.coreos.com/rhcl-operator.openshift-operators= --ignore-not-found
+
+# cert-manager
+oc delete subscription openshift-cert-manager-operator -n cert-manager-operator --ignore-not-found
+oc delete csv --all -n cert-manager-operator --ignore-not-found
+oc delete namespace cert-manager-operator --ignore-not-found
+
+# Leader Worker Set
+oc delete subscription leader-worker-set -n openshift-lws-operator --ignore-not-found
+oc delete csv --all -n openshift-lws-operator --ignore-not-found
+oc delete namespace openshift-lws-operator --ignore-not-found
+
+# RHOAI (last - manages many resources)
+oc delete subscription rhods-operator -n redhat-ods-operator --ignore-not-found
+oc delete csv --all -n redhat-ods-operator --ignore-not-found
+oc delete namespace redhat-ods-operator --ignore-not-found
+----
+
+Wait 60 seconds for the RHOAI operator to clean up managed resources, then remove its namespaces:
+
+[source,bash]
+----
+oc delete namespace redhat-ods-applications --ignore-not-found
+oc delete namespace redhat-ods-monitoring --ignore-not-found
+oc delete namespace rhods-notebooks --ignore-not-found
+oc delete namespace rhoai-model-registries --ignore-not-found
+oc delete namespace models-as-a-service --ignore-not-found
+----
+
+== What Is Not Removed
+
+The cleanup script does not remove:
+
+- Pre-existing namespaces (`openshift-operators`, `openshift-monitoring`, `openshift-ingress`)
+- GPU operators (NFD, NVIDIA GPU Operator) - these are installed separately
+- CRDs left behind by operators (OLM does not remove CRDs on operator deletion)
+- Persistent data in external storage (e.g., if you used an external PostgreSQL)
+
+== Next step
+
+To reinstall, run `./scripts/setup-maas.sh` - see xref:quick-start.adoc[Automated Setup].

--- a/manifests/01-prerequisites/operators/connectivity-link/subscription.yaml
+++ b/manifests/01-prerequisites/operators/connectivity-link/subscription.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: stable
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: rhcl-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: rhcl-operator.v1.3.4

--- a/scripts/cleanup-maas.sh
+++ b/scripts/cleanup-maas.sh
@@ -1,0 +1,460 @@
+#!/usr/bin/env bash
+#
+# cleanup-maas.sh - Tear down MaaS (Models as a Service) from RHOAI
+#
+# Reverses setup-maas.sh in reverse order:
+#   Phase 1: External models  - ExternalModel CRs, secrets, namespace
+#   Phase 2: Observability    - telemetry, COO, OpenTelemetry, Tempo operators
+#   Phase 3: Models           - LLMInferenceService, MaaS CRs, llm namespace
+#   Phase 4: RHOAI config     - DataScienceCluster, DSCInitialization, Dashboard
+#   Phase 5: MaaS platform    - PostgreSQL, secrets
+#   Phase 6: Platform config  - Gateway, Kuadrant, UWM, MetalLB
+#   Phase 7: Operators        - subscriptions, CSVs, operator namespaces
+#
+# Each phase checks if resources exist before deleting (idempotent).
+#
+# Usage:
+#   ./scripts/cleanup-maas.sh [OPTIONS]
+#
+# Options:
+#   --from-phase <N>     Start from phase N (1-7, default: 1)
+#   --keep-operators     Skip Phase 7 (keep operators installed)
+#   --dry-run            Preview without deleting
+#   --yes                Skip confirmation prompt
+#   -h, --help           Show this help message
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUIDE_DIR="$SCRIPT_DIR/.."
+MANIFESTS_DIR="$GUIDE_DIR/manifests"
+NAMESPACE=redhat-ods-applications
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_step()  { echo -e "${BLUE}[STEP]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_phase() { echo -e "\n${BOLD}${RED}════════════════════════════════════════════${NC}"; echo -e "${BOLD}${RED}  Cleanup Phase $1: $2${NC}"; echo -e "${BOLD}${RED}════════════════════════════════════════════${NC}"; }
+
+FROM_PHASE=1
+KEEP_OPERATORS=false
+DRY_RUN=false
+AUTO_YES=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --from-phase) FROM_PHASE="$2"; shift 2 ;;
+        --keep-operators) KEEP_OPERATORS=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --yes) AUTO_YES=true; shift ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: cleanup-maas.sh [OPTIONS]
+
+Tear down MaaS from RHOAI. Reverses setup-maas.sh in reverse order.
+Each phase checks if resources exist before deleting (idempotent).
+
+Options:
+  --from-phase <N>     Start from phase N (1-7, default: 1)
+  --keep-operators     Skip Phase 7 (keep operators installed)
+  --dry-run            Preview without deleting
+  --yes                Skip confirmation prompt
+  -h, --help           Show this help message
+
+Phases:
+  1  External models    ExternalModel CRs, provider secrets, external-models namespace
+  2  Observability      Telemetry, COO, OpenTelemetry, Tempo operators
+  3  Models             LLMInferenceService, MaaS CRs, llm namespace
+  4  RHOAI config       DataScienceCluster, DSCInitialization, Dashboard config
+  5  MaaS platform      PostgreSQL deployment, PVC, secrets
+  6  Platform config    Gateway, GatewayClass, Kuadrant, UWM, MetalLB
+  7  Operators          Subscriptions, CSVs, operator namespaces
+EOF
+            exit 0
+            ;;
+        *) log_error "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+run_cmd() {
+    if [ "$DRY_RUN" = true ]; then
+        log_info "[DRY RUN] $*"
+    else
+        "$@"
+    fi
+}
+
+should_run() { [ "$FROM_PHASE" -le "$1" ]; }
+
+delete_if_exists() {
+    local resource="$1"
+    local name="$2"
+    local namespace="${3:-}"
+
+    local ns_flag=""
+    [ -n "$namespace" ] && ns_flag="-n $namespace"
+
+    if oc get "$resource" "$name" $ns_flag &>/dev/null; then
+        log_info "  Deleting $resource/$name${namespace:+ in $namespace}..."
+        run_cmd oc delete "$resource" "$name" $ns_flag --ignore-not-found --timeout=120s
+    else
+        log_info "  $resource/$name${namespace:+ in $namespace} not found, skipping"
+    fi
+}
+
+delete_namespace() {
+    local ns="$1"
+    if oc get namespace "$ns" &>/dev/null; then
+        log_info "  Deleting namespace $ns..."
+        run_cmd oc delete namespace "$ns" --ignore-not-found --timeout=300s
+    else
+        log_info "  Namespace $ns not found, skipping"
+    fi
+}
+
+delete_all_in_ns() {
+    local resource="$1"
+    local namespace="$2"
+
+    local count
+    count=$(oc get "$resource" -n "$namespace" --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+    if [ "$count" -gt 0 ]; then
+        log_info "  Deleting all $resource in $namespace ($count found)..."
+        run_cmd oc delete "$resource" --all -n "$namespace" --ignore-not-found --timeout=120s
+    fi
+}
+
+# =============================================================================
+# Preflight
+# =============================================================================
+if ! oc whoami &>/dev/null; then
+    log_error "Not logged into OpenShift cluster. Run: oc login <cluster>"
+    exit 1
+fi
+log_info "Cluster: $(oc whoami --show-server)"
+log_info "User:    $(oc whoami)"
+
+if [ "$DRY_RUN" = true ]; then
+    log_warn "DRY RUN mode - no resources will be deleted"
+    echo ""
+fi
+
+if [ "$AUTO_YES" = false ] && [ "$DRY_RUN" = false ]; then
+    echo ""
+    echo -e "${RED}${BOLD}WARNING: This will delete MaaS resources from the cluster.${NC}"
+    echo -e "Cluster: ${BOLD}$(oc whoami --show-server)${NC}"
+    echo -e "Phases to run: ${FROM_PHASE}-$([ "$KEEP_OPERATORS" = true ] && echo "6" || echo "7")"
+    echo ""
+    read -rp "Are you sure? (y/N) " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        log_info "Aborted."
+        exit 0
+    fi
+fi
+
+# =============================================================================
+# Phase 1: External Models
+# =============================================================================
+if should_run 1; then
+    log_phase 1 "External Models"
+
+    for provider in openai gemini bedrock; do
+        if oc get namespace external-models &>/dev/null; then
+            delete_all_in_ns "externalmodel" "external-models"
+        fi
+    done
+
+    # MaaS governance CRs for external models
+    for cr in maasauthpolicy maassubscription; do
+        for name in $(oc get "$cr" -n models-as-a-service --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep -E 'openai|gemini|bedrock' || true); do
+            log_info "  Deleting $cr/$name in models-as-a-service..."
+            run_cmd oc delete "$cr" "$name" -n models-as-a-service --ignore-not-found
+        done
+    done
+
+    for name in $(oc get maasmodelref -n external-models --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null || true); do
+        log_info "  Deleting maasmodelref/$name in external-models..."
+        run_cmd oc delete maasmodelref "$name" -n external-models --ignore-not-found
+    done
+
+    # Provider secrets
+    for secret in openai-api-key gemini-api-key bedrock-api-key; do
+        if oc get secret "$secret" -n external-models &>/dev/null; then
+            log_info "  Deleting secret/$secret in external-models..."
+            run_cmd oc delete secret "$secret" -n external-models --ignore-not-found
+        fi
+    done
+
+    delete_namespace "external-models"
+    log_info "External models cleanup complete"
+fi
+
+# =============================================================================
+# Phase 2: Observability
+# =============================================================================
+if should_run 2; then
+    log_phase 2 "Observability"
+
+    # Telemetry CRs
+    if oc get namespace openshift-ingress &>/dev/null; then
+        for cr in telemetrypolicy telemetry; do
+            delete_all_in_ns "$cr" "openshift-ingress" 2>/dev/null || true
+        done
+    fi
+
+    # COO operator
+    if oc get csv -n openshift-cluster-observability-operator --no-headers 2>/dev/null | grep -q "cluster-observability-operator"; then
+        log_info "  Removing COO operator..."
+        delete_if_exists subscription cluster-observability-operator openshift-cluster-observability-operator
+        for csv in $(oc get csv -n openshift-cluster-observability-operator --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep cluster-observability-operator || true); do
+            run_cmd oc delete csv "$csv" -n openshift-cluster-observability-operator --ignore-not-found
+        done
+        delete_namespace "openshift-cluster-observability-operator"
+    else
+        log_info "  COO operator not found, skipping"
+    fi
+
+    # OpenTelemetry operator
+    if oc get csv -n openshift-opentelemetry-operator --no-headers 2>/dev/null | grep -q "opentelemetry"; then
+        log_info "  Removing OpenTelemetry operator..."
+        delete_if_exists subscription opentelemetry-product openshift-opentelemetry-operator
+        for csv in $(oc get csv -n openshift-opentelemetry-operator --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep opentelemetry || true); do
+            run_cmd oc delete csv "$csv" -n openshift-opentelemetry-operator --ignore-not-found
+        done
+        delete_namespace "openshift-opentelemetry-operator"
+    else
+        log_info "  OpenTelemetry operator not found, skipping"
+    fi
+
+    # Tempo operator
+    if oc get csv -n openshift-tempo-operator --no-headers 2>/dev/null | grep -q "tempo"; then
+        log_info "  Removing Tempo operator..."
+        delete_if_exists subscription tempo-product openshift-tempo-operator
+        for csv in $(oc get csv -n openshift-tempo-operator --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep tempo || true); do
+            run_cmd oc delete csv "$csv" -n openshift-tempo-operator --ignore-not-found
+        done
+        delete_namespace "openshift-tempo-operator"
+    else
+        log_info "  Tempo operator not found, skipping"
+    fi
+
+    log_info "Observability cleanup complete"
+fi
+
+# =============================================================================
+# Phase 3: Models
+# =============================================================================
+if should_run 3; then
+    log_phase 3 "Models"
+
+    # MaaS governance CRs (auth policies and subscriptions in models-as-a-service)
+    if oc get namespace models-as-a-service &>/dev/null; then
+        for cr in maassubscription maasauthpolicy; do
+            delete_all_in_ns "$cr" "models-as-a-service"
+        done
+    fi
+
+    # MaaSModelRef in model namespace
+    if oc get namespace llm &>/dev/null; then
+        delete_all_in_ns "maasmodelref" "llm"
+        delete_all_in_ns "llminferenceservice" "llm"
+        delete_namespace "llm"
+    else
+        log_info "  Namespace llm not found, skipping"
+    fi
+
+    log_info "Models cleanup complete"
+fi
+
+# =============================================================================
+# Phase 4: RHOAI Configuration
+# =============================================================================
+if should_run 4; then
+    log_phase 4 "RHOAI Configuration"
+
+    delete_if_exists odhdashboardconfig odh-dashboard-config "$NAMESPACE"
+    delete_if_exists datasciencecluster default-dsc ""
+    delete_if_exists dscinitialization default-dsci ""
+
+    log_info "RHOAI configuration cleanup complete"
+fi
+
+# =============================================================================
+# Phase 5: MaaS Platform
+# =============================================================================
+if should_run 5; then
+    log_phase 5 "MaaS Platform"
+
+    delete_if_exists deployment postgres "$NAMESPACE"
+    delete_if_exists service postgres "$NAMESPACE"
+    delete_if_exists pvc postgres-data "$NAMESPACE"
+    delete_if_exists secret postgres-creds "$NAMESPACE"
+    delete_if_exists secret maas-db-config "$NAMESPACE"
+
+    log_info "MaaS platform cleanup complete"
+fi
+
+# =============================================================================
+# Phase 6: Platform Configuration
+# =============================================================================
+if should_run 6; then
+    log_phase 6 "Platform Configuration"
+
+    # Gateway and Route
+    delete_if_exists route maas-default-gateway-https openshift-ingress
+    delete_if_exists gateway maas-default-gateway openshift-ingress
+    delete_if_exists configmap maas-gateway-options openshift-ingress
+    delete_if_exists gatewayclass openshift-default ""
+
+    # Kuadrant
+    if oc get namespace kuadrant-system &>/dev/null; then
+        delete_if_exists kuadrant kuadrant kuadrant-system
+        # Wait for the Kuadrant CR finalizers to clean up
+        if [ "$DRY_RUN" = false ]; then
+            log_info "  Waiting for Kuadrant cleanup (30s)..."
+            sleep 10
+        fi
+        delete_if_exists service authorino-authorino-authorization kuadrant-system
+        delete_namespace "kuadrant-system"
+    else
+        log_info "  Namespace kuadrant-system not found, skipping"
+    fi
+
+    # UWM - remove enableUserWorkload from cluster-monitoring-config
+    if oc get configmap cluster-monitoring-config -n openshift-monitoring &>/dev/null; then
+        log_info "  Removing enableUserWorkload from cluster-monitoring-config..."
+        if [ "$DRY_RUN" = false ]; then
+            oc patch configmap cluster-monitoring-config -n openshift-monitoring \
+                --type=merge -p '{"data":{"config.yaml":""}}' 2>/dev/null || true
+        else
+            log_info "[DRY RUN] Would patch cluster-monitoring-config"
+        fi
+    fi
+
+    # Remove gateway-access label from redhat-ods-applications
+    if [ "$DRY_RUN" = false ]; then
+        oc label namespace "$NAMESPACE" maas.opendatahub.io/gateway-access- 2>/dev/null || true
+    else
+        log_info "[DRY RUN] Would remove gateway-access label from $NAMESPACE"
+    fi
+
+    # MetalLB (if installed by setup-maas.sh)
+    if oc get namespace metallb-system &>/dev/null; then
+        log_info "  Removing MetalLB resources..."
+        delete_if_exists l2advertisement maas-advertisement metallb-system
+        delete_if_exists ipaddresspool maas-pool metallb-system
+        delete_if_exists metallb metallb metallb-system
+        delete_if_exists subscription metallb-operator metallb-system
+        for csv in $(oc get csv -n metallb-system --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep metallb || true); do
+            run_cmd oc delete csv "$csv" -n metallb-system --ignore-not-found
+        done
+        delete_namespace "metallb-system"
+    else
+        log_info "  MetalLB not found, skipping"
+    fi
+
+    log_info "Platform configuration cleanup complete"
+fi
+
+# =============================================================================
+# Phase 7: Operators
+# =============================================================================
+if should_run 7 && [ "$KEEP_OPERATORS" = false ]; then
+    log_phase 7 "Operators"
+
+    # Delete CRs before operators so finalizers can run
+    # Tenant CR has a finalizer that only the RHOAI operator can remove - delete it first
+    if oc get namespace models-as-a-service &>/dev/null; then
+        for tenant in $(oc get tenants.maas.opendatahub.io -n models-as-a-service --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null || true); do
+            log_info "  Deleting tenant/$tenant in models-as-a-service..."
+            run_cmd oc delete tenant "$tenant" -n models-as-a-service --ignore-not-found --timeout=30s 2>/dev/null || \
+                run_cmd oc patch tenant "$tenant" -n models-as-a-service --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+        done
+    fi
+
+    # RHCL / Kuadrant operator (subscription is in openshift-operators, shared namespace)
+    log_info "  Removing RHCL operator..."
+    delete_if_exists subscription rhcl-operator openshift-operators
+    for csv in $(oc get csv -n openshift-operators --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep -E 'rhcl-operator|authorino-operator|limitador-operator|dns-operator' || true); do
+        log_info "  Deleting CSV $csv..."
+        run_cmd oc delete csv "$csv" -n openshift-operators --ignore-not-found
+    done
+
+    # cert-manager
+    log_info "  Removing cert-manager operator..."
+    delete_if_exists subscription openshift-cert-manager-operator cert-manager-operator
+    for csv in $(oc get csv -n cert-manager-operator --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep cert-manager || true); do
+        run_cmd oc delete csv "$csv" -n cert-manager-operator --ignore-not-found
+    done
+    delete_namespace "cert-manager-operator"
+
+    # Leader Worker Set
+    log_info "  Removing Leader Worker Set operator..."
+    delete_if_exists subscription leader-worker-set openshift-lws-operator
+    for csv in $(oc get csv -n openshift-lws-operator --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep leader-worker-set || true); do
+        run_cmd oc delete csv "$csv" -n openshift-lws-operator --ignore-not-found
+    done
+    delete_namespace "openshift-lws-operator"
+
+    # RHOAI (last - it manages many resources)
+    log_info "  Removing RHOAI operator..."
+    delete_if_exists subscription rhods-operator redhat-ods-operator
+    for csv in $(oc get csv -n redhat-ods-operator --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null | grep rhods || true); do
+        run_cmd oc delete csv "$csv" -n redhat-ods-operator --ignore-not-found
+    done
+
+    # Wait for RHOAI operator to clean up managed resources
+    if [ "$DRY_RUN" = false ]; then
+        log_info "  Waiting for RHOAI operator cleanup (60s)..."
+        sleep 30
+    fi
+
+    delete_namespace "redhat-ods-operator"
+
+    # Clean up RHOAI-managed namespaces
+    delete_namespace "redhat-ods-applications"
+    delete_namespace "redhat-ods-monitoring"
+    delete_namespace "rhods-notebooks"
+    delete_namespace "rhoai-model-registries"
+    # models-as-a-service may have Tenant CRs with finalizers stuck if operator is gone
+    if oc get namespace models-as-a-service &>/dev/null 2>&1; then
+        for tenant in $(oc get tenants.maas.opendatahub.io -n models-as-a-service --no-headers -o custom-columns='NAME:.metadata.name' 2>/dev/null || true); do
+            log_info "  Removing finalizer from stuck tenant/$tenant..."
+            run_cmd oc patch tenant "$tenant" -n models-as-a-service --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+        done
+    fi
+    delete_namespace "models-as-a-service"
+
+    log_info "Operator cleanup complete"
+elif should_run 7 && [ "$KEEP_OPERATORS" = true ]; then
+    log_info "Skipping Phase 7 (--keep-operators)"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo -e "${BOLD}${GREEN}════════════════════════════════════════════${NC}"
+echo -e "${BOLD}${GREEN}  Cleanup complete${NC}"
+echo -e "${BOLD}${GREEN}════════════════════════════════════════════${NC}"
+
+if [ "$DRY_RUN" = true ]; then
+    log_warn "DRY RUN - no resources were actually deleted"
+    log_info "Re-run without --dry-run to perform the cleanup"
+fi
+
+if [ "$KEEP_OPERATORS" = true ]; then
+    log_info "Operators were kept (--keep-operators). To remove them, re-run with --from-phase 7"
+fi
+
+echo ""
+log_info "To reinstall MaaS, run: ./scripts/setup-maas.sh"

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -257,6 +257,7 @@ if should_run 1; then
         if [ "$DRY_RUN" = false ]; then
             for ns_label in \
                 "redhat-ods-operator operators.coreos.com/rhods-operator.redhat-ods-operator" \
+                "openshift-operators operators.coreos.com/rhcl-operator.openshift-operators" \
                 "cert-manager-operator operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator" \
                 "openshift-lws-operator operators.coreos.com/leader-worker-set.openshift-lws-operator"
             do
@@ -265,44 +266,10 @@ if should_run 1; then
                 log_info "  Waiting for CSV in $ns..."
                 oc wait csv -n "$ns" -l "$label=" \
                     --for=jsonpath='{.status.phase}'=Succeeded --timeout=900s 2>/dev/null || \
-                    { log_error "  CSV in $ns did not reach Succeeded within 900s — aborting (re-run with --from-phase 1 after manual check)"; exit 1; }
+                    { log_error "  CSV in $ns did not reach Succeeded within 900s - aborting (re-run with --from-phase 1 after manual check)"; exit 1; }
             done
-
-            log_info "  Waiting for RHCL CSV in openshift-operators (Manual approval)..."
-            RHCL_APPROVED=false
-            RHCL_TIMEOUT=900
-            RHCL_ELAPSED=0
-            while [ $RHCL_ELAPSED -lt $RHCL_TIMEOUT ]; do
-                if [ "$RHCL_APPROVED" = false ]; then
-                    PLAN_NAME=$(oc get subscription rhcl-operator -n openshift-operators \
-                        -o jsonpath='{.status.installPlanRef.name}' 2>/dev/null || true)
-                    if [ -n "$PLAN_NAME" ]; then
-                        APPROVED=$(oc get installplan "$PLAN_NAME" -n openshift-operators \
-                            -o jsonpath='{.spec.approved}' 2>/dev/null || echo "true")
-                        if [ "$APPROVED" != "true" ]; then
-                            oc patch installplan "$PLAN_NAME" -n openshift-operators \
-                                --type=merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
-                            log_info "  Install plan $PLAN_NAME approved"
-                        fi
-                        RHCL_APPROVED=true
-                    fi
-                fi
-                RHCL_PHASE=$(oc get csv -n openshift-operators -l 'operators.coreos.com/rhcl-operator.openshift-operators=' \
-                    --no-headers -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
-                if [ "$RHCL_PHASE" = "Succeeded" ]; then
-                    log_info "  RHCL CSV: Succeeded"
-                    break
-                fi
-                sleep 5
-                RHCL_ELAPSED=$((RHCL_ELAPSED + 5))
-                [ $((RHCL_ELAPSED % 60)) -eq 0 ] && log_info "    Still waiting for RHCL... (${RHCL_ELAPSED}s)"
-            done
-            if [ "$RHCL_PHASE" != "Succeeded" ]; then
-                log_error "  CSV in openshift-operators did not reach Succeeded within ${RHCL_TIMEOUT}s — aborting (re-run with --from-phase 1 after manual check)"
-                exit 1
-            fi
         else
-            log_info "[DRY RUN] Would approve RHCL install plan"
+            log_info "[DRY RUN] Would wait for operator CSVs"
         fi
         log_info "All operator CSVs ready"
     fi


### PR DESCRIPTION
## Summary

- Remove RHCL v1.3.4 pin since v1.4.2 fixes the WASM bugs (#51)
- Add cleanup-maas.sh script and guide page for teardown (#55)

### RHCL pin removal
RHCL 1.4.2 shipped the fix for the WASM plugin loading issues from 1.4.0. Subscription now uses Automatic approval like everything else, removed Step 1b from the guide and the manual approval loop from setup-maas.sh.

### Cleanup script
New `scripts/cleanup-maas.sh` that tears down everything setup-maas.sh creates in reverse order (7 phases). Supports `--dry-run`, `--keep-operators`, `--from-phase N`, `--yes`. Handles the Tenant CR finalizer that blocks namespace deletion after operators are gone.

Guide page at 09-cleanup.adoc with both automated and manual cleanup steps.

## Test plan

- [x] Fresh install on SNO (OCP 4.21) with RHCL Automatic approval - 15/15
- [x] Full cleanup run - all namespaces, operators, CRs removed
- [x] Reinstall after cleanup - 15/15 again
- [x] Tenant finalizer handling verified (namespace was stuck, script now patches it)

Closes #51
Closes #55