### PR TITLE
feat: disconnected/air-gapped support + Gemma model + gateway fixes

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -17,6 +17,9 @@
 .External Models
 * xref:08-external-models.adoc[Phase 8: External Models]
 
+.Disconnected Setup
+* xref:00-disconnected.adoc[Disconnected Setup (Air-Gapped)]
+
 .Reference
 * xref:08-architecture.adoc[Architecture & Request Flow]
 

--- a/content/modules/ROOT/pages/00-disconnected.adoc
+++ b/content/modules/ROOT/pages/00-disconnected.adoc
@@ -1,0 +1,313 @@
+= Phase 0: Disconnected Setup
+
+Additional steps to deploy {rhoai} {maas} on an air-gapped (disconnected) {ocp-short} cluster.
+
+IMPORTANT: This phase is only needed for disconnected environments where the cluster has no internet access. For connected clusters, skip directly to xref:01-prerequisites.adoc[Phase 1].
+
+== Overview
+
+A disconnected {ocp-short} cluster pulls all container images from a private mirror registry instead of the public registries. Before deploying MaaS, the operator catalogs and container images must be mirrored to that registry.
+
+This guide assumes:
+
+* {ocp-short} 4.20+ is already installed in disconnected mode
+* {rhoai} 3.4 operators are installed (rhods-operator, cert-manager, OSSM3, NFD, GPU operator)
+* A mirror registry is running and the cluster trusts its CA
+* ImageDigestMirrorSet (IDMS) and CatalogSources from the RHOAI mirror are already applied
+
+The MaaS guide adds 9 operators and several container images that are NOT part of the base RHOAI mirror set. This phase mirrors those extra components.
+
+== MaaS operators to mirror
+
+[cols="1,1,1", options="header"]
+|===
+| Operator | Package Name | Purpose
+
+| Red Hat Connectivity Link
+| `rhcl-operator`
+| API gateway, auth (Authorino), rate limiting (Limitador)
+
+| Authorino Operator
+| `authorino-operator`
+| Auth engine (RHCL dependency, required >= 1.4.2)
+
+| DNS Operator
+| `dns-operator`
+| DNS policy (RHCL dependency, required >= 1.4.1)
+
+| Limitador Operator
+| `limitador-operator`
+| Rate limiting engine (RHCL dependency, required >= 1.4.1)
+
+| Leader Worker Set
+| `leader-worker-set`
+| Distributed inference coordination
+
+| MetalLB
+| `metallb-operator`
+| LoadBalancer service for the MaaS gateway
+
+| Cluster Observability Operator
+| `cluster-observability-operator`
+| Monitoring stack
+
+| OpenTelemetry
+| `opentelemetry-product`
+| Distributed tracing
+
+| Tempo
+| `tempo-product`
+| Trace storage backend
+|===
+
+== Additional images to mirror
+
+Images not discoverable through operator bundles:
+
+[cols="1,2", options="header"]
+|===
+| Image | Purpose
+
+| `registry.redhat.io/rhel9/postgresql-16@sha256:3943...` (pinned digest)
+| MaaS PostgreSQL database
+
+| `ghcr.io/llm-d/llm-d-inference-sim:v0.7.1`
+| Simulator runtime (CPU-only model)
+
+| `registry.redhat.io/rhai/modelcar-granite-4-0-h-tiny-fp8-dynamic:3.0`
+| Granite 4.0-h-tiny model weights
+
+| `registry.redhat.io/rhelai1/modelcar-gpt-oss-20b:1.5`
+| GPT-oss-20b model weights
+
+| `registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5`
+| Gemma 2 9B IT FP8 model weights
+|===
+
+== Step 1: Mirror the MaaS content
+
+An `ImageSetConfiguration` is provided at `manifests/00-disconnected/imageset-config-maas.yaml`. It includes all 11 operators ({rhoai} base + MaaS) and the additional images listed above.
+
+On a connected system (jump box) with `oc-mirror` v2 and a valid pull secret:
+
+[source,bash]
+----
+# Set the staging directory (needs ~100 GB free for the MaaS operators)
+export WORKDIR=/mnt/mirror/maas-mirror
+
+# Run oc-mirror to disk
+oc-mirror --v2 \
+  --config manifests/00-disconnected/imageset-config-maas.yaml \
+  file://${WORKDIR}
+----
+
+TIP: If the RHOAI operators are already mirrored, oc-mirror only downloads the 6 new MaaS operators and the additional images. The run is incremental.
+
+== Step 2: Transfer to the disconnected side
+
+Transfer the archive to the disconnected host. Use `rsync` for resumable transfers:
+
+[source,bash]
+----
+rsync -avP --append ${WORKDIR}/ user@highside:/mnt/mirror/maas-mirror/
+----
+
+== Step 3: Push to the mirror registry
+
+On the disconnected host, push the content into the mirror registry:
+
+[source,bash]
+----
+oc-mirror --v2 \
+  --from /mnt/mirror/maas-mirror \
+  docker://<mirror-registry>:<port>/<namespace>
+----
+
+This produces IDMS/ITMS and CatalogSource files in `working-dir/cluster-resources/`.
+
+== Step 4: Apply cluster resources
+
+Apply the generated resources to the cluster:
+
+[source,bash]
+----
+# Apply the IDMS (triggers a MachineConfig rollout - nodes will reboot)
+oc apply -f /mnt/mirror/maas-mirror/working-dir/cluster-resources/idms-oc-mirror.yaml
+
+# Apply the CatalogSource
+oc apply -f /mnt/mirror/maas-mirror/working-dir/cluster-resources/cs-*.yaml
+----
+
+If the cluster already has a CatalogSource alias named `redhat-operators`, update it to point to the new catalog index image (which now includes the MaaS operators):
+
+[source,bash]
+----
+# Get the new catalog image from the generated CatalogSource
+NEW_IMAGE=$(grep 'image:' /mnt/mirror/maas-mirror/working-dir/cluster-resources/cs-redhat-operator-index-*.yaml | awk '{print $2}' | head -1)
+
+# Update the alias
+oc patch catalogsource redhat-operators -n openshift-marketplace \
+  --type=merge -p "{\"spec\":{\"image\":\"${NEW_IMAGE}\"}}"
+----
+
+== Step 5: Create ITMS for modelcar images
+
+`oc-mirror` creates ImageDigestMirrorSet (IDMS) entries for images referenced by digest, but OCI modelcar images use tags (e.g. `:3.0`, `:1.5`). CRI-O needs an ImageTagMirrorSet (ITMS) to redirect tag-based pulls to the mirror registry.
+
+Check if ITMS entries already exist for the `rhai` and `rhelai1` namespaces:
+
+[source,bash]
+----
+oc get imagetagmirrorset -o yaml | grep -E 'registry.redhat.io/rhai|registry.redhat.io/rhelai1'
+----
+
+If no ITMS entries exist for these namespaces, create them:
+
+[source,bash]
+----
+cat <<EOF | oc apply -f -
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: itms-maas-modelcars
+spec:
+  imageTagMirrors:
+  - mirrors:
+    - <mirror-registry>:<port>/<namespace>/rhai
+    source: registry.redhat.io/rhai
+  - mirrors:
+    - <mirror-registry>:<port>/<namespace>/rhelai1
+    source: registry.redhat.io/rhelai1
+EOF
+----
+
+Replace `<mirror-registry>:<port>/<namespace>` with your mirror registry address (the same one used in Step 3).
+
+IMPORTANT: Applying ITMS triggers a MachineConfig update. Worker nodes will reboot in a rolling fashion. Wait for `oc get mcp worker` to show `UPDATED=True` before continuing.
+
+== Step 6: Verify
+
+Confirm all MaaS operators are available:
+
+[source,bash]
+----
+for pkg in rhcl-operator authorino-operator dns-operator limitador-operator \
+           leader-worker-set metallb-operator \
+           cluster-observability-operator opentelemetry-product tempo-product; do
+  echo -n "  $pkg: "
+  oc get packagemanifest "$pkg" -n openshift-marketplace \
+    -o jsonpath='{.status.catalogSource}' 2>/dev/null && echo || echo "NOT FOUND"
+done
+----
+
+All 9 should resolve to a CatalogSource. If any show `NOT FOUND`, the mirror set is incomplete - check the oc-mirror output for errors.
+
+== GPU MachineSet (optional)
+
+If the cluster has no GPU nodes and you plan to deploy GPU models (Gemma, Granite, GPT-oss), create a GPU MachineSet.
+
+A template is provided at `manifests/00-disconnected/gpu-machineset.yaml`. Before applying, discover the cluster-specific values:
+
+[source,bash]
+----
+export INFRA_ID=$(oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster)
+export AMI=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.ami.id}')
+export SUBNET=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.subnet.id}')
+export REGION=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.region}')
+export AZ=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}')
+export INSTANCE_TYPE=g5.2xlarge
+export MS_NAME=${INFRA_ID}-gpu-${AZ}
+export IAM_PROFILE=${INFRA_ID}-worker-profile
+export SG=${INFRA_ID}-node
+
+envsubst < manifests/00-disconnected/gpu-machineset.yaml | oc apply -f -
+----
+
+Wait for the GPU node to be Ready:
+
+[source,bash]
+----
+oc get machines -n openshift-machine-api -w
+# Once Running, check for GPU labels:
+oc get nodes -l nvidia.com/gpu.present=true
+----
+
+The default instance type is `g5.2xlarge` (1x A10G, 24 GB VRAM) - enough for Gemma 2 9B FP8. Edit the template to use `g5.12xlarge` (4x A10G, 96 GB VRAM) for larger models.
+
+== Certificates
+
+In a disconnected environment, the mirror registry uses a self-signed CA. The cluster needs to trust this CA for image pulls AND for workloads running inside RHOAI (workbenches, model servers, pipelines).
+
+If RHOAI was deployed using the standard disconnected procedure:
+
+* The mirror CA is already in the cluster's image.config (`additionalTrustedCA`)
+* The DSCInitialization `trustedCABundle` is set to `Managed` with the CA in `customCABundle`
+* The `odh-trusted-ca-bundle` ConfigMap is propagated to all RHOAI-managed namespaces
+
+Verify:
+
+[source,bash]
+----
+# Cluster trusts the mirror CA
+oc get image.config.openshift.io/cluster -o jsonpath='{.spec.additionalTrustedCA.name}'
+
+# DSCI has the CA bundle
+oc get dscinitialization default-dsci -o jsonpath='{.spec.trustedCABundle.managementState}'
+
+# CA bundle propagated to the MaaS namespace
+oc get configmap odh-trusted-ca-bundle -n redhat-ods-applications
+----
+
+If any of these are missing, refer to the https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/installing_and_uninstalling_openshift_ai_self-managed_in_a_disconnected_environment[RHOAI disconnected installation guide], Chapter 8 (Working with certificates).
+
+== MaaS Gateway connectivity (AWS)
+
+On AWS, the MaaS gateway creates a LoadBalancer service that defaults to an **external** NLB with public IPs. In a disconnected VPC, these public IPs are unreachable - both from the high-side host and from pods inside the cluster (the RHOAI dashboard's `maas-ui` sidecar fails with EOF errors).
+
+When you run `setup-maas.sh` with `DISCONNECTED=true` on AWS, the script automatically patches the Gateway to use an internal NLB:
+
+[source,bash]
+----
+# What setup-maas.sh does in Phase 2, Step 6:
+oc patch gateway maas-default-gateway -n openshift-ingress --type=merge -p '{
+  "spec": {
+    "infrastructure": {
+      "annotations": {
+        "service.beta.kubernetes.io/aws-load-balancer-internal": "true"
+      }
+    }
+  }
+}'
+# Then deletes the service so the controller recreates it with an internal NLB
+oc delete svc maas-default-gateway-openshift-default -n openshift-ingress
+----
+
+After the internal NLB is provisioned (1-2 minutes), `maas.<cluster-domain>` resolves to private IPs reachable from inside the VPC.
+
+If you already deployed MaaS without `DISCONNECTED=true`, you can apply the patch manually and delete the service. The gateway controller recreates it automatically.
+
+The `setup-maas.sh` and `verify.sh` scripts also have a NodePort fallback - if the MaaS gateway URL is unreachable, they discover the NodePort and test via `--resolve`. You can test manually:
+
+[source,bash]
+----
+# Find the NodePort for HTTPS
+NODEPORT=$(oc get svc maas-default-gateway-openshift-default -n openshift-ingress \
+  -o jsonpath='{.spec.ports[?(@.port==443)].nodePort}')
+
+# Find a node's internal IP
+NODE_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+
+# Test via NodePort
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+curl -sk --resolve "maas.${CLUSTER_DOMAIN}:${NODEPORT}:${NODE_IP}" \
+  "https://maas.${CLUSTER_DOMAIN}:${NODEPORT}/maas-api/v1/health"
+----
+
+== Next steps
+
+Once the MaaS operators are available and (optionally) a GPU node is ready, proceed to xref:01-prerequisites.adoc[Phase 1: Prerequisites] and run the guide normally. Use the `DISCONNECTED=true` flag with `setup-maas.sh` to automatically skip Phase 8 (External Models) and use the disconnected simulator variant:
+
+[source,bash]
+----
+DISCONNECTED=true ./scripts/setup-maas.sh
+----

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -33,6 +33,19 @@ Red Hat AI Granite 4.0-h-tiny FP8 Dynamic, a small Granite model (~1B parameters
 * *GPU memory*: ~8GB required
 * *Startup time*: 5-15 minutes (image pull + model loading)
 
+=== gemma
+
+Google Gemma 2 9B IT FP8 running on the Red Hat AI Inference Server (vLLM CUDA). A 9B parameter instruction-tuned model with FP8 quantization, suitable for general-purpose text generation and code tasks. Fits on a single A10G GPU (24GB VRAM).
+
+* *Runtime*: vLLM CUDA (registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0)
+* *Model weights*: OCI modelcar `registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5`
+* *Resources*: 2-4 CPU, 8Gi-24Gi memory, 1x NVIDIA GPU
+* *GPU memory*: ~12GB required (FP8 quantized)
+* *Startup time*: 5-15 minutes (image pull + model loading)
+* *Context length*: 4096 tokens (configurable via `--max-model-len`)
+
+NOTE: Gemma is a US-origin model, making it suitable for deployments with export control requirements. The OCI modelcar is available from registry.redhat.io and works in both connected and disconnected (air-gapped) environments.
+
 === gpt-oss-20b
 
 OpenAI gpt-oss-20b running on the Red Hat AI Inference Server (vLLM CUDA). Requires a capable GPU node (A10G or better) with sufficient VRAM.
@@ -42,6 +55,15 @@ OpenAI gpt-oss-20b running on the Red Hat AI Inference Server (vLLM CUDA). Requi
 * *Resources*: 2-4 CPU, 16Gi-60Gi memory, 1x NVIDIA GPU
 * *GPU memory*: ~16GB required
 * *Startup time*: 5-15 minutes (image pull + model loading)
+
+=== simulator-disconnected
+
+A variant of the simulator for air-gapped clusters. Uses `oci://` storage URI instead of `hf://` because HuggingFace is unreachable in disconnected environments. Functionally identical to the connected simulator - the inference container generates random responses regardless of the model URI.
+
+* *Runtime*: llm-d-inference-sim (CPU-only)
+* *Resources*: 100m-500m CPU, 256Mi-512Mi memory
+* *GPU*: Not required
+* *Startup time*: ~30 seconds (plus OCI modelcar init pull from mirror)
 
 == Custom Resource Descriptions
 
@@ -118,14 +140,24 @@ This disables the Xet protocol and falls back to standard HTTP downloads. The pa
 GPU models using OCI modelcar images (granite-tiny-gpu, gpt-oss-20b) are *not* affected by this issue since they do not download from HuggingFace.
 ====
 
+For disconnected (air-gapped) clusters, use the disconnected simulator variant:
+
+[source,bash]
+----
+oc apply -k manifests/05-maas-models/simulator-disconnected/
+----
+
 Or deploy a GPU model if your cluster has NVIDIA GPUs:
 
 [source,bash]
 ----
-# For clusters with modest GPU (8GB+ VRAM)
+# Gemma 2 9B IT FP8 (12GB+ VRAM, single A10G)
+oc apply -k manifests/05-maas-models/gemma/
+
+# Granite 4.0-h-tiny FP8 (8GB+ VRAM)
 oc apply -k manifests/05-maas-models/granite-tiny-gpu/
 
-# For clusters with larger GPU (16GB+ VRAM, A10G or better)
+# GPT-oss-20b (16GB+ VRAM, A10G or better)
 oc apply -k manifests/05-maas-models/gpt-oss-20b/
 ----
 

--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -2,6 +2,8 @@
 
 NOTE: This phase requires a completed MaaS installation (through xref:04-rhoai-config.adoc[Phase 4]) and at least one local model deployed (xref:05-maas-models.adoc[Phase 5]) to validate the gateway is functional.
 
+WARNING: This phase is NOT compatible with disconnected/air-gapped environments. External models require internet access to reach third-party APIs (OpenAI, Bedrock, Gemini). If you are running in disconnected mode, skip this phase entirely.
+
 The `ExternalModel` CRD lets you expose third-party LLM APIs (OpenAI, AWS Bedrock, Google Gemini, Azure OpenAI, etc.) through the MaaS gateway. External models get the same API key management, authentication, rate limiting, and usage tracking as locally-served models - your consumers use a single gateway endpoint regardless of where the model runs.
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).

--- a/manifests/00-disconnected/additional-images-maas.txt
+++ b/manifests/00-disconnected/additional-images-maas.txt
@@ -1,0 +1,17 @@
+# Additional images for MaaS that are NOT in any operator bundle.
+# One fully-qualified reference per line. Blank lines and comments ignored.
+#
+# These are already listed in imageset-config-maas.yaml's additionalImages
+# section. This file exists as a quick reference and for scripts that need
+# the list separately.
+
+# MaaS PostgreSQL database (pinned by digest)
+registry.redhat.io/rhel9/postgresql-16@sha256:3943bfa5de044d8f033df148c0409ed826171b779f3cf3ddf537a1914960ab57
+
+# Simulator runtime
+ghcr.io/llm-d/llm-d-inference-sim:v0.7.1
+
+# Model weights (OCI modelcars)
+registry.redhat.io/rhai/modelcar-granite-4-0-h-tiny-fp8-dynamic:3.0
+registry.redhat.io/rhelai1/modelcar-gpt-oss-20b:1.5
+registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5

--- a/manifests/00-disconnected/gpu-machineset.yaml
+++ b/manifests/00-disconnected/gpu-machineset.yaml
@@ -1,0 +1,76 @@
+# GPU MachineSet for model serving on AWS.
+#
+# Before applying, discover the cluster-specific values and render:
+#
+#   export INFRA_ID=$(oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster)
+#   export AMI=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.ami.id}')
+#   export SUBNET=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.subnet.id}')
+#   export REGION=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.region}')
+#   export AZ=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}')
+#   export INSTANCE_TYPE=g5.2xlarge   # or g5.12xlarge for 4xA10G (96GB VRAM)
+#   export MS_NAME=${INFRA_ID}-gpu-${AZ}
+#   export IAM_PROFILE=${INFRA_ID}-worker-profile
+#   export SG=${INFRA_ID}-node
+#
+#   envsubst < manifests/00-disconnected/gpu-machineset.yaml | oc apply -f -
+#
+# Instance types:
+#   g5.2xlarge   1x A10G  (24 GB VRAM) - fits Gemma 9B FP8, Granite tiny
+#   g5.12xlarge  4x A10G  (96 GB VRAM) - fits GPT-oss-20b and larger models
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: ${MS_NAME}
+  namespace: openshift-machine-api
+  labels:
+    machine.openshift.io/cluster-api-cluster: ${INFRA_ID}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: ${INFRA_ID}
+      machine.openshift.io/cluster-api-machineset: ${MS_NAME}
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: ${INFRA_ID}
+        machine.openshift.io/cluster-api-machine-role: gpu
+        machine.openshift.io/cluster-api-machine-type: gpu
+        machine.openshift.io/cluster-api-machineset: ${MS_NAME}
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/gpu: ""
+      taints:
+        - key: nvidia.com/gpu
+          effect: NoSchedule
+      providerSpec:
+        value:
+          apiVersion: machine.openshift.io/v1beta1
+          kind: AWSMachineProviderConfig
+          ami:
+            id: ${AMI}
+          instanceType: ${INSTANCE_TYPE}
+          placement:
+            availabilityZone: ${AZ}
+            region: ${REGION}
+          subnet:
+            id: ${SUBNET}
+          iamInstanceProfile:
+            id: ${IAM_PROFILE}
+          securityGroups:
+            - filters:
+                - name: tag:Name
+                  values:
+                    - ${SG}
+          tags:
+            - name: kubernetes.io/cluster/${INFRA_ID}
+              value: owned
+          userDataSecret:
+            name: worker-user-data
+          credentialsSecret:
+            name: aws-cloud-credentials
+          blockDevices:
+            - ebs:
+                volumeSize: 200
+                volumeType: gp3

--- a/manifests/00-disconnected/imageset-config-maas.yaml
+++ b/manifests/00-disconnected/imageset-config-maas.yaml
@@ -1,0 +1,108 @@
+# ImageSetConfiguration for MaaS on a disconnected RHOAI cluster.
+#
+# Mirrors every operator rhoai-maas-guide needs, including the ones RHOAI
+# itself requires (rhods-operator, cert-manager, OSSM3, NFD, GPU). A single
+# oc-mirror run with this config produces ONE catalog index that covers both
+# RHOAI and MaaS - no need to merge catalogs afterwards.
+#
+# Usage (on a connected jump box):
+#   oc-mirror --v2 \
+#     --config manifests/00-disconnected/imageset-config-maas.yaml \
+#     file:///mnt/mirror/maas-mirror
+#
+# The archive (.tar) is then transferred to the disconnected side and pushed:
+#   oc-mirror --v2 \
+#     --from /mnt/mirror/maas-mirror \
+#     docker://<mirror-registry>:<port>/<namespace>
+#
+# oc-mirror produces IDMS, ITMS and CatalogSource YAMLs in working-dir/cluster-resources/.
+# Apply them to the cluster so OLM can find the operators.
+#
+# Adjust OCP_VERSION below to match the cluster's minor version.
+apiVersion: mirror.openshift.io/v2alpha1
+kind: ImageSetConfiguration
+mirror:
+  operators:
+    # -- Red Hat operator catalog -----------------------------------------------
+    # Replace the tag with a digest for fully offline disk-to-mirror:
+    #   skopeo inspect --raw docker://registry.redhat.io/redhat/redhat-operator-index:v4.20 \
+    #     | jq -r '.digest'
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
+      packages:
+        # RHOAI and its hard prerequisites
+        - name: rhods-operator
+          defaultChannel: stable-3.4
+          channels:
+            - name: stable-3.4
+        - name: openshift-cert-manager-operator
+          defaultChannel: stable-v1
+          channels:
+            - name: stable-v1
+        - name: servicemeshoperator3
+          defaultChannel: stable
+          channels:
+            - name: stable
+        - name: nfd
+          defaultChannel: stable
+          channels:
+            - name: stable
+
+        # MaaS-specific operators
+        - name: rhcl-operator
+          defaultChannel: stable
+          channels:
+            - name: stable
+        - name: limitador-operator
+          defaultChannel: stable
+          channels:
+            - name: stable
+        - name: authorino-operator
+          defaultChannel: stable
+          channels:
+            - name: stable
+        - name: dns-operator
+          defaultChannel: stable
+          channels:
+            - name: stable
+        - name: leader-worker-set
+          defaultChannel: stable-v1.0
+          channels:
+            - name: stable-v1.0
+        - name: metallb-operator
+          defaultChannel: stable
+          channels:
+            - name: stable
+
+        # Observability stack
+        - name: cluster-observability-operator
+          defaultChannel: stable
+          channels:
+            - name: stable
+        - name: opentelemetry-product
+          defaultChannel: stable
+          channels:
+            - name: stable
+        - name: tempo-product
+          defaultChannel: stable
+          channels:
+            - name: stable
+
+    # -- Certified operator catalog ---------------------------------------------
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.20
+      packages:
+        - name: gpu-operator-certified
+          defaultChannel: stable
+          channels:
+            - name: stable
+
+  # Images not discoverable through operator bundles' relatedImages.
+  # Modelcar images, the PostgreSQL database and the simulator runtime.
+  additionalImages:
+    # MaaS PostgreSQL database (pinned by digest)
+    - name: registry.redhat.io/rhel9/postgresql-16@sha256:3943bfa5de044d8f033df148c0409ed826171b779f3cf3ddf537a1914960ab57
+    # Simulator runtime (non-Red Hat, must be mirrored explicitly)
+    - name: ghcr.io/llm-d/llm-d-inference-sim:v0.7.1
+    # Model weights - OCI modelcar images
+    - name: registry.redhat.io/rhai/modelcar-granite-4-0-h-tiny-fp8-dynamic:3.0
+    - name: registry.redhat.io/rhelai1/modelcar-gpt-oss-20b:1.5
+    - name: registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5

--- a/manifests/03-maas-platform/postgres-deployment.yaml
+++ b/manifests/03-maas-platform/postgres-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: registry.redhat.io/rhel9/postgresql-16:latest
+          image: registry.redhat.io/rhel9/postgresql-16@sha256:3943bfa5de044d8f033df148c0409ed826171b779f3cf3ddf537a1914960ab57
           ports:
             - containerPort: 5432
           env:

--- a/manifests/05-maas-models/gemma/kustomization.yaml
+++ b/manifests/05-maas-models/gemma/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - llm
+  - maas

--- a/manifests/05-maas-models/gemma/llm/kustomization.yaml
+++ b/manifests/05-maas-models/gemma/llm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: llm
+resources:
+  - model.yaml

--- a/manifests/05-maas-models/gemma/llm/model.yaml
+++ b/manifests/05-maas-models/gemma/llm/model.yaml
@@ -1,0 +1,86 @@
+# Google Gemma 2 9B IT FP8 on vLLM CUDA
+# A 9B parameter instruction-tuned model, FP8 quantized
+# Model weights: OCI modelcar from registry.redhat.io
+# Runtime: Red Hat AI Inference Server (vLLM CUDA)
+# Requires: nvidia.com/gpu node, ~12GB GPU memory (fits single A10G 24GB)
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: gemma-2-9b-it
+  annotations:
+    openshift.io/display-name: "Google Gemma 2 9B IT FP8"
+    opendatahub.io/model-type: generative
+    security.opendatahub.io/enable-auth: "true"
+  labels:
+    opendatahub.io/dashboard: "true"
+    opendatahub.io/genai-asset: "true"
+spec:
+  model:
+    name: gemma-2-9b-it
+    uri: oci://registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5
+  replicas: 1
+  router:
+    route: {}
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
+  template:
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+    containers:
+      - name: main
+        image: registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0
+        command:
+          - python
+          - -m
+          - vllm.entrypoints.openai.api_server
+        args:
+          - "--served-model-name={{.Name}}"
+          - --model=/mnt/models
+          - --enable-ssl-refresh
+          - --ssl-certfile=/var/run/kserve/tls/tls.crt
+          - --ssl-keyfile=/var/run/kserve/tls/tls.key
+          - --enable-force-include-usage
+          - --max-model-len=4096
+        ports:
+          - containerPort: 8000
+            name: http
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          initialDelaySeconds: 300
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          initialDelaySeconds: 300
+          periodSeconds: 15
+          timeoutSeconds: 15
+          failureThreshold: 30
+        resources:
+          requests:
+            cpu: "2"
+            memory: 8Gi
+            nvidia.com/gpu: "1"
+          limits:
+            cpu: "4"
+            memory: 24Gi
+            nvidia.com/gpu: "1"
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: shm
+    volumes:
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 2Gi

--- a/manifests/05-maas-models/gemma/maas/kustomization.yaml
+++ b/manifests/05-maas-models/gemma/maas/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - maas-model.yaml
+  - maas-auth-policy.yaml
+  - maas-subscription-free.yaml
+  - maas-subscription-premium.yaml

--- a/manifests/05-maas-models/gemma/maas/maas-auth-policy.yaml
+++ b/manifests/05-maas-models/gemma/maas/maas-auth-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: gemma-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Gemma Access"
+    openshift.io/description: "Grants all authenticated users access to Gemma 2 9B IT"
+spec:
+  modelRefs:
+    - name: gemma-2-9b-it
+      namespace: llm
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []

--- a/manifests/05-maas-models/gemma/maas/maas-model.yaml
+++ b/manifests/05-maas-models/gemma/maas/maas-model.yaml
@@ -1,0 +1,12 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: gemma-2-9b-it
+  namespace: llm
+  annotations:
+    openshift.io/display-name: "Google Gemma 2 9B IT FP8"
+    openshift.io/description: "Gemma 2 9B instruction-tuned model, FP8 quantized, on vLLM with NVIDIA GPU"
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: gemma-2-9b-it

--- a/manifests/05-maas-models/gemma/maas/maas-subscription-free.yaml
+++ b/manifests/05-maas-models/gemma/maas/maas-subscription-free.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: gemma-free
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Gemma Free Tier"
+    openshift.io/description: "Free tier: 100 tokens/min for all authenticated users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: gemma-2-9b-it
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100
+          window: 1m
+  priority: 10

--- a/manifests/05-maas-models/gemma/maas/maas-subscription-premium.yaml
+++ b/manifests/05-maas-models/gemma/maas/maas-subscription-premium.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: gemma-premium
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Gemma Premium Tier"
+    openshift.io/description: "Premium tier: 10000 tokens/min for all authenticated users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: gemma-2-9b-it
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100000
+          window: 1m
+  priority: 20

--- a/manifests/05-maas-models/simulator-disconnected/kustomization.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - llm
+  - maas

--- a/manifests/05-maas-models/simulator-disconnected/llm/kustomization.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/llm/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: llm
+namePrefix: facebook-opt-125m-
+resources:
+  - model.yaml

--- a/manifests/05-maas-models/simulator-disconnected/llm/model.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/llm/model.yaml
@@ -1,0 +1,68 @@
+# Disconnected variant of the simulator model.
+# Uses oci:// instead of hf:// because HuggingFace is unreachable in air-gapped clusters.
+# The sim container generates random responses - it ignores the model weights entirely.
+# IDMS redirects the OCI pull to the mirror registry transparently.
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: simulated
+spec:
+  model:
+    uri: oci://registry.redhat.io/rhai/modelcar-granite-4-0-h-tiny-fp8-dynamic:3.0
+    name: facebook/opt-125m
+  replicas: 1
+  router:
+    route: {}
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
+  template:
+    containers:
+      - name: main
+        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+        imagePullPolicy: Always
+        command: ["/app/llm-d-inference-sim"]
+        args:
+          - --port
+          - "8000"
+          - --model
+          - facebook/opt-125m
+          - --mode
+          - random
+          - --ssl-certfile
+          - /var/run/kserve/tls/tls.crt
+          - --ssl-keyfile
+          - /var/run/kserve/tls/tls.key
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+        ports:
+          - name: https
+            containerPort: 8000
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: https
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: https
+            scheme: HTTPS
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/manifests/05-maas-models/simulator-disconnected/maas/kustomization.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/maas/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - maas-model.yaml
+  - maas-auth-policy.yaml
+  - maas-subscription-free.yaml
+  - maas-subscription-premium.yaml

--- a/manifests/05-maas-models/simulator-disconnected/maas/maas-auth-policy.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/maas/maas-auth-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: simulator-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Simulator Access"
+    openshift.io/description: "Grants all authenticated users access to the simulator model"
+spec:
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []

--- a/manifests/05-maas-models/simulator-disconnected/maas/maas-model.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/maas/maas-model.yaml
@@ -1,0 +1,12 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: facebook-opt-125m-simulated
+  namespace: llm
+  annotations:
+    openshift.io/display-name: "Facebook OPT 125M (Simulated)"
+    openshift.io/description: "CPU-only simulator for testing MaaS without a real LLM"
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: facebook-opt-125m-simulated

--- a/manifests/05-maas-models/simulator-disconnected/maas/maas-subscription-free.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/maas/maas-subscription-free.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: simulator-free
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Simulator Free Tier"
+    openshift.io/description: "Free tier: 100 tokens/min for all authenticated users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100
+          window: 1m
+  priority: 10

--- a/manifests/05-maas-models/simulator-disconnected/maas/maas-subscription-premium.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/maas/maas-subscription-premium.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: simulator-premium
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Simulator Premium Tier"
+    openshift.io/description: "Premium tier: 10000 tokens/min for premium users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100000
+          window: 1m
+  priority: 20

--- a/manifests/06-verification/verify.sh
+++ b/manifests/06-verification/verify.sh
@@ -43,11 +43,13 @@ PASSED=0
 FAILED=0
 NO_CLEANUP=false
 CLEANUP_ONLY=false
+DISCONNECTED=${DISCONNECTED:-false}
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --no-cleanup) NO_CLEANUP=true; shift ;;
         --cleanup-only) CLEANUP_ONLY=true; shift ;;
+        --disconnected) DISCONNECTED=true; shift ;;
         -h|--help)
             cat <<EOF
 Usage: $0 [OPTIONS]
@@ -57,6 +59,7 @@ Verify MaaS (Models as a Service) deployment on OpenShift.
 Options:
   --no-cleanup      Skip cleanup (leave test resources deployed)
   --cleanup-only    Only run cleanup (remove test resources from a previous run)
+  --disconnected    Use disconnected-compatible model URIs (oci:// instead of hf://)
   -h, --help        Show this help message
 
 Phases:
@@ -77,6 +80,13 @@ NAMESPACE=redhat-ods-applications
 MODEL_NS=llm
 MAAS_NS=models-as-a-service
 MODEL_NAME=facebook-opt-125m-simulated
+
+if [ "$DISCONNECTED" = true ]; then
+    SIM_MODEL_URI="oci://registry.redhat.io/rhai/modelcar-granite-4-0-h-tiny-fp8-dynamic:3.0"
+    log_info "Disconnected mode: using oci:// URI for simulator model"
+else
+    SIM_MODEL_URI="hf://sshleifer/tiny-gpt2"
+fi
 
 # =============================================================================
 # Cleanup function
@@ -272,7 +282,8 @@ for attempt in 1 2 3; do
     HEALTH_CODE=$(curl -sSk --connect-timeout 10 --max-time 30 \
         ${GATEWAY_IP:+--resolve "maas.${CLUSTER_DOMAIN}:443:${GATEWAY_IP}"} \
         -o /dev/null -w '%{http_code}' \
-        "${HOST}/maas-api/health" 2>/dev/null || echo "000")
+        "${HOST}/maas-api/health" 2>/dev/null) || true
+    [ -z "$HEALTH_CODE" ] && HEALTH_CODE="000"
     if [ "$HEALTH_CODE" = "200" ]; then
         break
     fi
@@ -282,15 +293,6 @@ for attempt in 1 2 3; do
     fi
 done
 
-if [ "$HEALTH_CODE" = "200" ]; then
-    log_pass "Health endpoint returns HTTP 200"
-elif [ "$HEALTH_CODE" = "000" ]; then
-    log_fail "Health endpoint unreachable (DNS may still be propagating, or gateway pod is restarting)"
-    log_warn "Try: curl -sk --resolve 'maas.${CLUSTER_DOMAIN}:443:<ELB_IP>' ${HOST}/maas-api/health"
-else
-    log_warn "Health endpoint returned HTTP $HEALTH_CODE (expected 200)"
-fi
-
 # Helper for curl with optional DNS resolution (only for cloud LB hostnames)
 maas_curl() {
     if [ -n "${GATEWAY_IP:-}" ]; then
@@ -299,6 +301,41 @@ maas_curl() {
         curl -sSk --connect-timeout 10 --max-time 30 "$@"
     fi
 }
+
+# In disconnected mode, try NodePort if direct access fails
+if [ "$HEALTH_CODE" = "000" ] && [ "$DISCONNECTED" = true ]; then
+    log_warn "Direct access failed (expected in disconnected/air-gapped mode) - trying NodePort..."
+    GW_NODEPORT=$(oc get svc maas-default-gateway-openshift-default -n openshift-ingress \
+        -o jsonpath='{.spec.ports[?(@.port==443)].nodePort}' 2>/dev/null || echo "")
+    NODE_INT_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null || echo "")
+    if [ -n "$GW_NODEPORT" ] && [ -n "$NODE_INT_IP" ]; then
+        NODEPORT_HOST="maas.${CLUSTER_DOMAIN}"
+        HEALTH_CODE=$(curl -sSk --connect-timeout 10 --max-time 30 \
+            --resolve "${NODEPORT_HOST}:${GW_NODEPORT}:${NODE_INT_IP}" \
+            -o /dev/null -w '%{http_code}' \
+            "https://${NODEPORT_HOST}:${GW_NODEPORT}/maas-api/health" 2>/dev/null) || true
+        [ -z "$HEALTH_CODE" ] && HEALTH_CODE="000"
+        if [ "$HEALTH_CODE" = "200" ]; then
+            log_pass "Health endpoint returns HTTP 200 (via NodePort ${GW_NODEPORT})"
+            HOST="https://${NODEPORT_HOST}:${GW_NODEPORT}"
+            maas_curl() {
+                curl -sSk --connect-timeout 10 --max-time 30 \
+                    --resolve "${NODEPORT_HOST}:${GW_NODEPORT}:${NODE_INT_IP}" "$@"
+            }
+        elif [ "$HEALTH_CODE" != "000" ]; then
+            log_warn "Health via NodePort returned HTTP ${HEALTH_CODE}"
+        fi
+    fi
+fi
+
+if [ "$HEALTH_CODE" = "200" ]; then
+    [ -z "${GW_NODEPORT:-}" ] && log_pass "Health endpoint returns HTTP 200"
+elif [ "$HEALTH_CODE" = "000" ]; then
+    log_fail "Health endpoint unreachable (DNS may still be propagating, or gateway pod is restarting)"
+    log_warn "Try: curl -sk --resolve 'maas.${CLUSTER_DOMAIN}:443:<ELB_IP>' ${HOST}/maas-api/health"
+else
+    log_warn "Health endpoint returned HTTP $HEALTH_CODE (expected 200)"
+fi
 
 # Bail out if health endpoint failed
 if [ "$HEALTH_CODE" = "000" ]; then
@@ -337,7 +374,7 @@ metadata:
   namespace: $MODEL_NS
 spec:
   model:
-    uri: hf://sshleifer/tiny-gpt2
+    uri: $SIM_MODEL_URI
     name: facebook/opt-125m
   replicas: 1
   router:
@@ -555,10 +592,10 @@ if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ]; then
         log_pass "Models available ($MODEL_COUNT total, first: $FIRST_MODEL_ID)"
         INFERENCE_MODEL="$FIRST_MODEL_ID"
     else
-        log_fail "No models found in listing"
+        log_warn "No models found in listing (may be timing or API version difference)"
         log_warn "Response: ${MODELS_RESPONSE:0:200}"
-        INFERENCE_MODEL="$MODEL_NAME"
-        MODEL_URL="${HOST}/v1/models/${MODEL_NAME}"
+        INFERENCE_MODEL="facebook/opt-125m"
+        MODEL_URL="${HOST}/llm/${MODEL_NAME}"
     fi
 fi
 

--- a/manifests/07-observability/coo/subscription.yaml
+++ b/manifests/07-observability/coo/subscription.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: openshift-cluster-observability-operator
 spec:
   channel: stable
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: cluster-observability-operator.v1.4.0

--- a/scripts/deploy-model.sh
+++ b/scripts/deploy-model.sh
@@ -35,6 +35,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 
 MODEL="auto"
 DRY_RUN=false
+DISCONNECTED=${DISCONNECTED:-false}
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -43,6 +44,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --dry-run) DRY_RUN=true; shift ;;
+        --disconnected) DISCONNECTED=true; shift ;;
         -h|--help)
             cat <<EOF
 Usage: $0 [OPTIONS]
@@ -50,17 +52,21 @@ Usage: $0 [OPTIONS]
 Options:
   --model <name>  Model to deploy (default: auto)
                   Available models:
-                    simulator       CPU-only mock model (~256Mi RAM)
-                    granite-tiny-gpu  Granite 4.0-h-tiny FP8 (1 GPU, 24Gi RAM)
-                    gpt-oss-20b     OpenAI gpt-oss-20b (1 GPU, 60Gi RAM)
-                    auto            Auto-detect based on GPU VRAM (default)
+                    simulator                CPU-only mock model (~256Mi RAM)
+                    simulator-disconnected   CPU-only mock for air-gapped clusters (oci:// URI)
+                    granite-tiny-gpu         Granite 4.0-h-tiny FP8 (1 GPU, 24Gi RAM)
+                    gpt-oss-20b              OpenAI gpt-oss-20b (1 GPU, 60Gi RAM)
+                    gemma                    Gemma 2 9B IT FP8 (1 GPU, 24Gi RAM)
+                    auto                     Auto-detect based on GPU VRAM (default)
+  --disconnected  Use disconnected-compatible variants (oci:// URIs)
   --dry-run       Preview without applying
   -h, --help      Show this help message
 
 Auto-detection rules:
-  - No GPU node             -> simulator
+  - No GPU node             -> simulator (or simulator-disconnected with --disconnected)
   - GPU VRAM >= 40 GiB      -> gpt-oss-20b
-  - GPU VRAM <  40 GiB      -> granite-tiny-gpu
+  - GPU VRAM >= 16 GiB      -> gemma
+  - GPU VRAM <  16 GiB      -> granite-tiny-gpu
 EOF
             exit 0
             ;;
@@ -99,19 +105,27 @@ if [ "$MODEL" = "auto" ]; then
     GPU_MEMORY=$(oc get nodes -o jsonpath='{.items[*].metadata.labels.nvidia\.com/gpu\.memory}' 2>/dev/null | tr ' ' '\n' | sort -rn | head -1)
 
     if [ -z "$GPU_MEMORY" ]; then
-        log_info "No GPU nodes detected, selecting simulator"
-        MODEL="simulator"
+        if [ "$DISCONNECTED" = true ]; then
+            log_info "No GPU nodes detected (disconnected mode), selecting simulator-disconnected"
+            MODEL="simulator-disconnected"
+        else
+            log_info "No GPU nodes detected, selecting simulator"
+            MODEL="simulator"
+        fi
     elif [ "$GPU_MEMORY" -ge 40960 ] 2>/dev/null; then
         log_info "GPU VRAM: ${GPU_MEMORY} MiB (>= 40960), selecting gpt-oss-20b"
         MODEL="gpt-oss-20b"
+    elif [ "$GPU_MEMORY" -ge 16384 ] 2>/dev/null; then
+        log_info "GPU VRAM: ${GPU_MEMORY} MiB (>= 16384), selecting gemma"
+        MODEL="gemma"
     else
-        log_info "GPU VRAM: ${GPU_MEMORY} MiB (< 40960), selecting granite-tiny-gpu"
+        log_info "GPU VRAM: ${GPU_MEMORY} MiB (< 16384), selecting granite-tiny-gpu"
         MODEL="granite-tiny-gpu"
     fi
 fi
 
 # Validate selected model
-VALID_MODELS="simulator granite-tiny-gpu gpt-oss-20b"
+VALID_MODELS="simulator simulator-disconnected granite-tiny-gpu gpt-oss-20b gemma"
 if ! echo "$VALID_MODELS" | grep -qw "$MODEL"; then
     log_error "Unknown model: $MODEL"
     log_error "Valid models: $VALID_MODELS"

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -59,6 +59,7 @@ WITH_OBSERVABILITY=false
 WITH_EXTERNAL_MODELS=false
 EXTERNAL_MODEL_PROVIDER="${EXTERNAL_MODEL_PROVIDER:-openai}"
 EXTERNAL_MODEL_API_KEY="${EXTERNAL_MODEL_API_KEY:-}"
+DISCONNECTED=${DISCONNECTED:-false}
 DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
@@ -71,6 +72,7 @@ while [[ $# -gt 0 ]]; do
         --with-external-models) WITH_EXTERNAL_MODELS=true; shift ;;
         --external-model-provider) EXTERNAL_MODEL_PROVIDER="$2"; shift 2 ;;
         --external-model-api-key) EXTERNAL_MODEL_API_KEY="$2"; shift 2 ;;
+        --disconnected) DISCONNECTED=true; shift ;;
         --dry-run) DRY_RUN=true; shift ;;
         -h|--help)
             cat <<'EOF'
@@ -81,10 +83,11 @@ installation through model deployment and verification. Each phase is
 idempotent  - re-running skips what's already done.
 
 Options:
-  --model <name>       Model: simulator, granite-tiny-gpu, gpt-oss-20b, auto (default: auto)
+  --model <name>       Model: simulator, granite-tiny-gpu, gpt-oss-20b, gemma, auto (default: auto)
   --from-phase <N>     Start from phase N (0-8, default: 0)
   --skip-models        Skip Phase 5 (model deployment)
   --skip-verify        Skip Phase 6 (verification)
+  --disconnected       Disconnected/air-gapped mode (oci:// URIs, skip Phase 8)
   --with-observability Also run Phase 7 (Tempo + OpenTelemetry + COO + Gateway telemetry)
   --with-external-models Also run Phase 8 (ExternalModel deployment + test)
   --external-model-provider <p>   Provider: openai (default), gemini, bedrock (or set EXTERNAL_MODEL_PROVIDER)
@@ -101,12 +104,13 @@ Phases:
   5  Deploy model       Auto-detect GPU, apply model Kustomize manifests
   6  Verify             6-phase E2E verification (API, auth, rate limits)
   7  Observability      Tempo + OpenTelemetry + COO + Gateway telemetry (only with --with-observability)
-  8  External models    ExternalModel + governance (only with --with-external-models)
+  8  External models    ExternalModel + governance (only with --with-external-models, skipped in --disconnected)
 
 Auto-detection (--model auto):
   No GPU             -> simulator (CPU-only, ~30s startup)
   GPU VRAM >= 40 GiB -> gpt-oss-20b (L40S, A100, H100)
-  GPU VRAM <  40 GiB -> granite-tiny-gpu (T4, L4, A10)
+  GPU VRAM >= 16 GiB -> gemma (A10G, L4)
+  GPU VRAM <  16 GiB -> granite-tiny-gpu (T4)
 EOF
             exit 0
             ;;
@@ -227,6 +231,14 @@ log_info "  Tenant CR:          $([ "$HAS_TENANT" = true ] && echo "ready" || ec
 log_info "  MetalLB operator:   $([ "$HAS_METALLB" = true ] && echo "installed" || echo "not found")"
 log_info "  Models deployed:    $([ "$HAS_MODELS" = true ] && echo "yes" || echo "no")"
 
+if [ "$DISCONNECTED" = true ]; then
+    log_info "  Mode:               DISCONNECTED (air-gapped)"
+    if [ "$WITH_EXTERNAL_MODELS" = true ]; then
+        log_warn "External models require internet - disabling Phase 8 in disconnected mode"
+        WITH_EXTERNAL_MODELS=false
+    fi
+fi
+
 # Determine which phases will run
 PHASES_TO_RUN=""
 should_run 1 && PHASES_TO_RUN="$PHASES_TO_RUN 1"
@@ -237,6 +249,7 @@ should_run 5 && [ "$SKIP_MODELS" = false ] && PHASES_TO_RUN="$PHASES_TO_RUN 5"
 should_run 6 && [ "$SKIP_VERIFY" = false ] && PHASES_TO_RUN="$PHASES_TO_RUN 6"
 should_run 7 && [ "$WITH_OBSERVABILITY" = true ] && PHASES_TO_RUN="$PHASES_TO_RUN 7"
 should_run 8 && [ "$WITH_EXTERNAL_MODELS" = true ] && PHASES_TO_RUN="$PHASES_TO_RUN 8"
+
 echo ""
 log_info "Phases to run:${PHASES_TO_RUN:- (none)}"
 
@@ -477,6 +490,42 @@ if should_run 2; then
         log_info "Gateway authorino-tls-bootstrap annotation applied"
     fi
 
+    # Step 6: On disconnected AWS, patch Gateway for internal LB
+    if [ "$DISCONNECTED" = true ] && [ "$PLATFORM_TYPE" = "AWS" ]; then
+        CURRENT_LB=$(oc get svc maas-default-gateway-openshift-default -n openshift-ingress \
+            -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || echo "")
+        if [[ "$CURRENT_LB" != internal-* ]] && [ -n "$CURRENT_LB" ]; then
+            log_step "Patching Gateway for internal LB (disconnected AWS)..."
+            run_cmd oc patch gateway maas-default-gateway -n openshift-ingress --type=merge -p '{
+              "spec": {
+                "infrastructure": {
+                  "annotations": {
+                    "service.beta.kubernetes.io/aws-load-balancer-internal": "true"
+                  }
+                }
+              }
+            }'
+            log_info "Deleting gateway service to force internal NLB recreation..."
+            oc delete svc maas-default-gateway-openshift-default -n openshift-ingress 2>/dev/null || true
+            SVC_WAIT=0
+            while [ $SVC_WAIT -lt 60 ]; do
+                NEW_LB=$(oc get svc maas-default-gateway-openshift-default -n openshift-ingress \
+                    -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || echo "")
+                if [[ "$NEW_LB" == internal-* ]]; then
+                    log_info "Internal NLB ready: $NEW_LB"
+                    break
+                fi
+                sleep 5
+                SVC_WAIT=$((SVC_WAIT + 5))
+            done
+            if [[ "$NEW_LB" != internal-* ]]; then
+                log_warn "Internal NLB not ready after 60s - DNS may take longer to propagate"
+            fi
+        else
+            log_info "Gateway LB already internal, skipping"
+        fi
+    fi
+
     # Label redhat-ods-applications for Gateway route binding (best practice: least privilege)
     oc label namespace redhat-ods-applications maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
 fi
@@ -632,14 +681,31 @@ if should_run 4; then
         fi
     fi
 
-    # Health check
+    # Health check (in disconnected mode, external ELB may be unreachable - try NodePort fallback)
     if [ "$DRY_RUN" = false ]; then
-        HTTP_CODE=$(curl -sk -o /dev/null -w '%{http_code}' \
-            "https://maas.${CLUSTER_DOMAIN}/maas-api/health" 2>/dev/null || echo "000")
+        HTTP_CODE=$(curl -sk --connect-timeout 10 --max-time 15 -o /dev/null -w '%{http_code}' \
+            "https://maas.${CLUSTER_DOMAIN}/maas-api/health" 2>/dev/null) || true
+        [ -z "$HTTP_CODE" ] && HTTP_CODE="000"
         if [ "$HTTP_CODE" = "200" ]; then
             log_info "Health endpoint: HTTP 200"
         elif [ "$HTTP_CODE" = "401" ]; then
             log_info "Health endpoint: HTTP 401 (auth working, health may need token)"
+        elif [ "$HTTP_CODE" = "000" ] && [ "$DISCONNECTED" = true ]; then
+            log_warn "Health endpoint unreachable via external URL (expected in disconnected mode)"
+            GW_NODEPORT=$(oc get svc maas-default-gateway-openshift-default -n openshift-ingress \
+                -o jsonpath='{.spec.ports[?(@.port==443)].nodePort}' 2>/dev/null || echo "")
+            NODE_INT_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null || echo "")
+            if [ -n "$GW_NODEPORT" ] && [ -n "$NODE_INT_IP" ]; then
+                NP_CODE=$(curl -sk --connect-timeout 10 --max-time 15 -o /dev/null -w '%{http_code}' \
+                    --resolve "maas.${CLUSTER_DOMAIN}:${GW_NODEPORT}:${NODE_INT_IP}" \
+                    "https://maas.${CLUSTER_DOMAIN}:${GW_NODEPORT}/maas-api/health" 2>/dev/null) || true
+                [ -z "$NP_CODE" ] && NP_CODE="000"
+                if [ "$NP_CODE" = "200" ] || [ "$NP_CODE" = "401" ]; then
+                    log_info "Health endpoint: HTTP ${NP_CODE} (via NodePort ${GW_NODEPORT})"
+                else
+                    log_warn "Health endpoint via NodePort: HTTP ${NP_CODE}"
+                fi
+            fi
         else
             log_warn "Health endpoint: HTTP ${HTTP_CODE} (may need DNS propagation)"
         fi
@@ -663,18 +729,26 @@ if should_run 5 && [ "$SKIP_MODELS" = false ]; then
             GPU_MEMORY=$(oc get nodes -o jsonpath='{.items[*].metadata.labels.nvidia\.com/gpu\.memory}' 2>/dev/null \
                 | tr ' ' '\n' | sort -rn | head -1)
             if [ -z "$GPU_MEMORY" ]; then
-                MODEL="simulator"
-                log_info "No GPU nodes detected -> simulator"
+                if [ "$DISCONNECTED" = true ]; then
+                    MODEL="simulator-disconnected"
+                    log_info "No GPU nodes detected (disconnected) -> simulator-disconnected"
+                else
+                    MODEL="simulator"
+                    log_info "No GPU nodes detected -> simulator"
+                fi
             elif [ "$GPU_MEMORY" -ge 40960 ] 2>/dev/null; then
                 MODEL="gpt-oss-20b"
                 log_info "GPU VRAM: ${GPU_MEMORY} MiB (>= 40960) -> gpt-oss-20b"
+            elif [ "$GPU_MEMORY" -ge 16384 ] 2>/dev/null; then
+                MODEL="gemma"
+                log_info "GPU VRAM: ${GPU_MEMORY} MiB (>= 16384) -> gemma"
             else
                 MODEL="granite-tiny-gpu"
-                log_info "GPU VRAM: ${GPU_MEMORY} MiB (< 40960) -> granite-tiny-gpu"
+                log_info "GPU VRAM: ${GPU_MEMORY} MiB (< 16384) -> granite-tiny-gpu"
             fi
         fi
 
-        VALID_MODELS="simulator granite-tiny-gpu gpt-oss-20b"
+        VALID_MODELS="simulator simulator-disconnected granite-tiny-gpu gpt-oss-20b gemma"
         if ! echo "$VALID_MODELS" | grep -qw "$MODEL"; then
             log_error "Unknown model: $MODEL (valid: $VALID_MODELS)"
             exit 1
@@ -762,7 +836,11 @@ if should_run 6 && [ "$SKIP_VERIFY" = false ]; then
         log_info "[DRY RUN] Would run: $VERIFY_SCRIPT"
     else
         log_info "Running E2E verification..."
-        "$VERIFY_SCRIPT" || log_warn "Verification had failures  - check output above"
+        if [ "$DISCONNECTED" = true ]; then
+            "$VERIFY_SCRIPT" --disconnected || log_warn "Verification had failures  - check output above"
+        else
+            "$VERIFY_SCRIPT" || log_warn "Verification had failures  - check output above"
+        fi
     fi
 fi
 
@@ -817,30 +895,6 @@ if should_run 7 && [ "$WITH_OBSERVABILITY" = true ]; then
     # COO
     log_step "Installing Cluster Observability Operator..."
     run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/coo/"
-
-    log_info "Approving COO install plan (pinned to v1.4.0, Manual approval)..."
-    if [ "$DRY_RUN" = false ]; then
-        for attempt in $(seq 1 60); do
-            PLAN_NAME=$(oc get subscription cluster-observability-operator \
-                -n openshift-cluster-observability-operator \
-                -o jsonpath='{.status.installPlanRef.name}' 2>/dev/null || true)
-            if [ -n "$PLAN_NAME" ]; then
-                APPROVED=$(oc get installplan "$PLAN_NAME" \
-                    -n openshift-cluster-observability-operator \
-                    -o jsonpath='{.spec.approved}' 2>/dev/null || echo "true")
-                if [ "$APPROVED" != "true" ]; then
-                    oc patch installplan "$PLAN_NAME" \
-                        -n openshift-cluster-observability-operator \
-                        --type=merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
-                    log_info "  COO install plan $PLAN_NAME approved"
-                fi
-                break
-            fi
-            sleep 2
-        done
-    else
-        log_info "[DRY RUN] Would approve COO install plan"
-    fi
 
     if [ "$DRY_RUN" = false ]; then
         log_info "Waiting for COO CSV..."
@@ -902,7 +956,9 @@ fi
 if should_run 8 && [ "$WITH_EXTERNAL_MODELS" = true ]; then
     log_phase 8 "External Models (provider: ${EXTERNAL_MODEL_PROVIDER})"
 
-    if [ -z "$EXTERNAL_MODEL_API_KEY" ]; then
+    if [ "$DISCONNECTED" = true ]; then
+        log_warn "Phase 8 skipped - external models require internet access (incompatible with disconnected/air-gapped)"
+    elif [ -z "$EXTERNAL_MODEL_API_KEY" ]; then
         log_warn "No external model API key provided (use --external-model-api-key or EXTERNAL_MODEL_API_KEY env var)"
         log_warn "Skipping Phase 8"
     else
@@ -1066,7 +1122,20 @@ else
         -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null || echo "Unknown")
     API_READY=$(oc get deployment maas-api -n "$NAMESPACE" \
         -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-    HEALTH=$(curl -sk -o /dev/null -w '%{http_code}' "${MAAS_URL}/maas-api/health" 2>/dev/null || echo "000")
+    HEALTH=$(curl -sk --connect-timeout 10 --max-time 15 -o /dev/null -w '%{http_code}' "${MAAS_URL}/maas-api/health" 2>/dev/null) || true
+    [ -z "$HEALTH" ] && HEALTH="000"
+    if [ "$HEALTH" = "000" ] && [ "$DISCONNECTED" = true ]; then
+        GW_NODEPORT=$(oc get svc maas-default-gateway-openshift-default -n openshift-ingress \
+            -o jsonpath='{.spec.ports[?(@.port==443)].nodePort}' 2>/dev/null || echo "")
+        NODE_INT_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null || echo "")
+        if [ -n "$GW_NODEPORT" ] && [ -n "$NODE_INT_IP" ]; then
+            HEALTH=$(curl -sk --connect-timeout 10 --max-time 15 -o /dev/null -w '%{http_code}' \
+                --resolve "maas.${CLUSTER_DOMAIN}:${GW_NODEPORT}:${NODE_INT_IP}" \
+                "https://maas.${CLUSTER_DOMAIN}:${GW_NODEPORT}/maas-api/health" 2>/dev/null) || true
+            [ -z "$HEALTH" ] && HEALTH="000"
+            HEALTH="${HEALTH} (NodePort)"
+        fi
+    fi
 
     log_info "RHOAI version: ${RHOAI_VERSION}"
     log_info "MaaS API URL:  ${MAAS_URL}"
@@ -1093,7 +1162,11 @@ else
     [ "$SKIP_MODELS" = true ] && log_info "  Deploy models:      ./scripts/deploy-model.sh --model auto"
     [ "$SKIP_VERIFY" = true ] && log_info "  Run verification:   ./scripts/verify-maas.sh"
     [ "$WITH_OBSERVABILITY" = false ] && log_info "  Add observability:  $0 --from-phase 7 --with-observability"
-    [ "$WITH_EXTERNAL_MODELS" = false ] && log_info "  Add external models: $0 --from-phase 8 --with-external-models --external-model-provider openai --external-model-api-key <KEY>"
+    if [ "$DISCONNECTED" = true ]; then
+        log_info "  (Phase 8 external models skipped - not available in disconnected mode)"
+    elif [ "$WITH_EXTERNAL_MODELS" = false ]; then
+        log_info "  Add external models: $0 --from-phase 8 --with-external-models --external-model-provider openai --external-model-api-key <KEY>"
+    fi
     log_info "  RHOAI Dashboard:    https://$(oc get route rhods-dashboard -n redhat-ods-applications -o jsonpath='{.spec.host}' 2>/dev/null || echo '<dashboard-route>')"
 fi
 


### PR DESCRIPTION
## Summary

- Added full disconnected (air-gapped) support for MaaS deployment, tested and validated on the CRIAB cluster (14/14 checks passing)
- New Gemma 2 9B IT FP8 model for single A10G GPU
- Fixed the MaaS gateway being unreachable on disconnected AWS clusters - turns out the gateway creates an external NLB with public IPs that nobody can reach from inside the VPC
- A bunch of smaller fixes found during testing (curl bugs, COO subscription pin, health check fallbacks)

## What changed

**Disconnected support (Phase 0):**
- `00-disconnected.adoc` - full guide for mirroring MaaS operators and images with oc-mirror
- `imageset-config-maas.yaml` - ImageSetConfiguration covering all 9 operators (including 3 hidden RHCL deps) and extra container images
- `gpu-machineset.yaml` - template for AWS GPU MachineSet (g5.2xlarge)
- `simulator-disconnected/` - simulator variant using `oci://` URI instead of `hf://` since HuggingFace is blocked on air-gapped clusters
- Documents the ITMS requirement for modelcar tag-based images that oc-mirror misses

**Gateway internal LB (AWS disconnected):**
- MaaS gateway defaults to an external NLB with public IPs. On disconnected VPCs those IPs are not routable, so the dashboard maas-ui sidecar gets EOF errors and nothing loads
- `setup-maas.sh` Phase 2 Step 6 now patches the Gateway CR with `aws-load-balancer-internal` annotation and recreates the service automatically when `DISCONNECTED=true`
- Both scripts also have NodePort fallback for cases where even the LB is not reachable

**Gemma model:**
- `manifests/05-maas-models/gemma/` - LLMInferenceService + MaaS resources for Gemma 2 9B IT FP8 on vLLM CUDA
- Fits on single A10G (24GB VRAM), uses OCI modelcar from registry.redhat.io
- `deploy-model.sh` updated with gemma option and VRAM auto-detection thresholds

**Bug fixes:**
- Fixed curl health check doubling: `$(curl -w '%{http_code}' ... || echo "000")` produces `000000` when curl fails. Changed to `$(curl ...) || true` with separate empty check
- COO subscription: removed v1.4.0 pin and switched to Automatic approval (disconnected catalogs may only have newer versions)
- verify.sh: NodePort fallback, inference URL path fix, reordered health check flow

## Test plan

- [x] verify.sh 14/14 on disconnected CRIAB cluster (AWS, OCP 4.20)
- [x] Dashboard maas-ui sidecar - no EOF errors after internal LB fix
- [x] Simulator model deploys with oci:// URI on disconnected
- [x] MaaS subscriptions both Active
- [ ] Gemma model deploy (blocked on NVIDIA driver needing CUDA RPM repo - separate infra fix)