### PR TITLE
feat: disconnected/air-gapped support and CRIAB validation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,6 @@ www/
 node_modules/
 rhoai-maas-guide.code-workspace
 .serena/
+
+# macOS
+.DS_Store

--- a/content/modules/ROOT/pages/00-disconnected.adoc
+++ b/content/modules/ROOT/pages/00-disconnected.adoc
@@ -62,6 +62,8 @@ The MaaS guide adds 9 operators and several container images that are NOT part o
 
 == Additional images to mirror
 
+IMPORTANT: The vLLM CUDA runtime is published under `registry.redhat.io/rhaii/` (double 'i', no trailing 's'). Some upstream references incorrectly use `rhaiis/` - this will fail on disconnected clusters because the IDMS only covers `rhaii/`. The model manifests in this guide already use the correct `rhaii/` path with a pinned digest.
+
 Images not discoverable through operator bundles:
 
 [cols="1,2", options="header"]
@@ -70,6 +72,9 @@ Images not discoverable through operator bundles:
 
 | `registry.redhat.io/rhel9/postgresql-16@sha256:3943...` (pinned digest)
 | MaaS PostgreSQL database
+
+| `registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:5800...` (pinned digest)
+| vLLM CUDA runtime for GPU models
 
 | `ghcr.io/llm-d/llm-d-inference-sim:v0.7.1`
 | Simulator runtime (CPU-only model)
@@ -154,36 +159,28 @@ oc patch catalogsource redhat-operators -n openshift-marketplace \
 
 `oc-mirror` creates ImageDigestMirrorSet (IDMS) entries for images referenced by digest, but OCI modelcar images use tags (e.g. `:3.0`, `:1.5`). CRI-O needs an ImageTagMirrorSet (ITMS) to redirect tag-based pulls to the mirror registry.
 
-Check if ITMS entries already exist for the `rhai` and `rhelai1` namespaces:
+A ready-to-use ITMS manifest is provided at `manifests/00-disconnected/itms-maas-modelcars.yaml`. It covers `rhai/`, `rhelai1/`, and `ghcr.io/llm-d` namespaces.
+
+Check if ITMS entries already exist:
 
 [source,bash]
 ----
 oc get imagetagmirrorset -o yaml | grep -E 'registry.redhat.io/rhai|registry.redhat.io/rhelai1'
 ----
 
-If no ITMS entries exist for these namespaces, create them:
+If no ITMS entries exist, apply the manifest (replace the placeholder with your mirror address):
 
 [source,bash]
 ----
-cat <<EOF | oc apply -f -
-apiVersion: config.openshift.io/v1
-kind: ImageTagMirrorSet
-metadata:
-  name: itms-maas-modelcars
-spec:
-  imageTagMirrors:
-  - mirrors:
-    - <mirror-registry>:<port>/<namespace>/rhai
-    source: registry.redhat.io/rhai
-  - mirrors:
-    - <mirror-registry>:<port>/<namespace>/rhelai1
-    source: registry.redhat.io/rhelai1
-EOF
+sed 's|MIRROR_REGISTRY:PORT/NAMESPACE|<your-registry>:<port>/<ns>|g' \
+  manifests/00-disconnected/itms-maas-modelcars.yaml | oc apply -f -
 ----
 
-Replace `<mirror-registry>:<port>/<namespace>` with your mirror registry address (the same one used in Step 3).
+Replace `<your-registry>:<port>/<ns>` with your mirror registry address (the same one used in Step 3).
 
 IMPORTANT: Applying ITMS triggers a MachineConfig update. Worker nodes will reboot in a rolling fashion. Wait for `oc get mcp worker` to show `UPDATED=True` before continuing.
+
+TIP: Batch all ITMS/IDMS changes into a single `oc apply`. Do not add them incrementally - each apply triggers a separate MachineConfig rollout with node reboots.
 
 == Step 6: Verify
 
@@ -233,6 +230,90 @@ oc get nodes -l nvidia.com/gpu.present=true
 ----
 
 The default instance type is `g5.2xlarge` (1x A10G, 24 GB VRAM) - enough for Gemma 2 9B FP8. Edit the template to use `g5.12xlarge` (4x A10G, 96 GB VRAM) for larger models.
+
+== GPU driver compilation on disconnected
+
+The NVIDIA GPU operator compiles the kernel module at runtime. In a disconnected environment, the driver container cannot reach external repos for the required kernel packages (`kernel-headers`, `kernel-devel`, and `kernel` with vmlinuz). The standard UBI repos do not ship kernel packages.
+
+The solution is to extract the kernel files from the Driver Toolkit (DTK) image - which is part of the OCP release and already mirrored - build local RPMs, and serve them via a local HTTP repo.
+
+=== Step 1: Find the DTK image
+
+[source,bash]
+----
+DTK_IMAGE=$(oc adm release info --image-for=driver-toolkit)
+echo "DTK: $DTK_IMAGE"
+----
+
+=== Step 2: Extract kernel packages from DTK
+
+On a host that can pull from the mirror registry:
+
+[source,bash]
+----
+KERNEL_VERSION=$(uname -r)  # or get from: oc debug node/<gpu-node> -- chroot /host uname -r
+
+# Create a container from the DTK and copy kernel files
+podman create --name dtk-extract $DTK_IMAGE
+podman cp dtk-extract:/usr/src/kernels/${KERNEL_VERSION} /tmp/kernel-src/
+podman cp dtk-extract:/usr/include /tmp/kernel-headers/
+podman cp dtk-extract:/lib/modules/${KERNEL_VERSION} /tmp/kernel-modules/
+podman rm dtk-extract
+----
+
+=== Step 3: Build RPMs and create a local repo
+
+[source,bash]
+----
+# Install rpmbuild and createrepo_c
+yum install -y rpm-build createrepo_c
+
+# Build kernel-devel, kernel-headers and kernel RPMs from the extracted files
+# (use rpmbuild with custom spec files that package the DTK files)
+# See the rhoai-maas-guide repo for example spec files
+
+# Create a yum repo from the RPMs
+mkdir -p /tmp/kernel-repo/rpms
+cp ~/rpmbuild/RPMS/x86_64/kernel*.rpm /tmp/kernel-repo/rpms/
+createrepo_c /tmp/kernel-repo/rpms/
+----
+
+=== Step 4: Serve the repo and configure the GPU operator
+
+[source,bash]
+----
+# Serve the repo over HTTP (from a host reachable by the GPU node)
+cd /tmp/kernel-repo/rpms && python3 -m http.server 8088 &
+
+# Create a ConfigMap with the repo config
+oc create configmap kernel-repo-config -n nvidia-gpu-operator \
+  --from-literal=local-kernel.repo="[local-kernel]
+name=Local Kernel Packages from DTK
+baseurl=http://<bastion-ip>:8088/
+enabled=1
+gpgcheck=0
+priority=1"
+
+# Patch the ClusterPolicy to use the repo
+oc patch clusterpolicy gpu-cluster-policy --type=merge \
+  -p '{"spec":{"driver":{"repoConfig":{"configMapName":"kernel-repo-config"}}}}'
+----
+
+Replace `<bastion-ip>` with the IP of the host serving the repo. The GPU driver pod must be able to reach this host on port 8088.
+
+NOTE: The NVIDIA CUDA repo (`developer.download.nvidia.com`) must also be reachable from the GPU node for CUDA headers. If using a proxy, add this domain to the allow list. If fully air-gapped, the CUDA development packages must also be included in the local repo.
+
+=== Step 5: Verify the driver
+
+[source,bash]
+----
+# Wait for the driver pod to complete compilation
+oc get pods -n nvidia-gpu-operator -l app=nvidia-driver-daemonset -w
+
+# Verify GPU is available
+oc get nodes -l nvidia.com/gpu.present=true \
+  -o jsonpath='{.items[*].status.allocatable.nvidia\.com/gpu}'
+----
 
 == Certificates
 

--- a/manifests/00-disconnected/additional-images-maas.txt
+++ b/manifests/00-disconnected/additional-images-maas.txt
@@ -8,6 +8,9 @@
 # MaaS PostgreSQL database (pinned by digest)
 registry.redhat.io/rhel9/postgresql-16@sha256:3943bfa5de044d8f033df148c0409ed826171b779f3cf3ddf537a1914960ab57
 
+# vLLM CUDA runtime (pinned by digest, matches RHOAI 3.4.2 relatedImages)
+registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:5800e12b2a465f15961fcf34b645d79ed4f91ec9161eab22b1205d12682183c8
+
 # Simulator runtime
 ghcr.io/llm-d/llm-d-inference-sim:v0.7.1
 

--- a/manifests/00-disconnected/imageset-config-maas.yaml
+++ b/manifests/00-disconnected/imageset-config-maas.yaml
@@ -96,10 +96,14 @@ mirror:
             - name: stable
 
   # Images not discoverable through operator bundles' relatedImages.
-  # Modelcar images, the PostgreSQL database and the simulator runtime.
+  # Modelcar images, the PostgreSQL database, vLLM runtime and simulator.
   additionalImages:
     # MaaS PostgreSQL database (pinned by digest)
     - name: registry.redhat.io/rhel9/postgresql-16@sha256:3943bfa5de044d8f033df148c0409ed826171b779f3cf3ddf537a1914960ab57
+    # vLLM CUDA runtime - included explicitly because separate oc-mirror runs
+    # for RHOAI vs MaaS place it in different mirror namespaces. The digest
+    # matches the RHOAI 3.4.2 operator's relatedImages entry.
+    - name: registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:5800e12b2a465f15961fcf34b645d79ed4f91ec9161eab22b1205d12682183c8
     # Simulator runtime (non-Red Hat, must be mirrored explicitly)
     - name: ghcr.io/llm-d/llm-d-inference-sim:v0.7.1
     # Model weights - OCI modelcar images

--- a/manifests/00-disconnected/itms-maas-modelcars.yaml
+++ b/manifests/00-disconnected/itms-maas-modelcars.yaml
@@ -1,0 +1,31 @@
+# ImageTagMirrorSet for MaaS modelcar and runtime images.
+#
+# oc-mirror creates IDMS entries for digest-referenced images but NOT ITMS
+# for tag-referenced images. OCI modelcar URIs use tags (e.g. :1.5, :3.0)
+# so CRI-O needs an ITMS to redirect tag-based pulls to the mirror registry.
+#
+# Before applying, replace MIRROR_REGISTRY with your mirror registry address
+# and NAMESPACE with the oc-mirror target namespace (e.g. "maas"):
+#
+#   sed 's|MIRROR_REGISTRY:PORT/NAMESPACE|<your-registry>:<port>/<ns>|g' \
+#     manifests/00-disconnected/itms-maas-modelcars.yaml | oc apply -f -
+#
+# WARNING: Applying ITMS triggers a MachineConfig rollout - nodes will reboot.
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: itms-maas-modelcars
+spec:
+  imageTagMirrors:
+    # Modelcar images (rhai = single 'i')
+    - mirrors:
+        - MIRROR_REGISTRY:PORT/NAMESPACE/rhai
+      source: registry.redhat.io/rhai
+    # Modelcar images (rhelai1)
+    - mirrors:
+        - MIRROR_REGISTRY:PORT/NAMESPACE/rhelai1
+      source: registry.redhat.io/rhelai1
+    # Simulator runtime from GitHub Container Registry
+    - mirrors:
+        - MIRROR_REGISTRY:PORT/NAMESPACE/llm-d
+      source: ghcr.io/llm-d

--- a/manifests/05-maas-models/gemma/llm/model.yaml
+++ b/manifests/05-maas-models/gemma/llm/model.yaml
@@ -32,7 +32,7 @@ spec:
         operator: Exists
     containers:
       - name: main
-        image: registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0
+        image: registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:5800e12b2a465f15961fcf34b645d79ed4f91ec9161eab22b1205d12682183c8
         command:
           - python
           - -m

--- a/manifests/05-maas-models/gpt-oss-20b/llm/model.yaml
+++ b/manifests/05-maas-models/gpt-oss-20b/llm/model.yaml
@@ -31,7 +31,7 @@ spec:
         operator: Exists
     containers:
       - name: main
-        image: registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0
+        image: registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:5800e12b2a465f15961fcf34b645d79ed4f91ec9161eab22b1205d12682183c8
         command:
           - python
           - -m

--- a/manifests/05-maas-models/granite-tiny-gpu/llm/model.yaml
+++ b/manifests/05-maas-models/granite-tiny-gpu/llm/model.yaml
@@ -32,7 +32,7 @@ spec:
         operator: Exists
     containers:
       - name: main
-        image: registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0
+        image: registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:5800e12b2a465f15961fcf34b645d79ed4f91ec9161eab22b1205d12682183c8
         command:
           - python
           - -m

--- a/manifests/05-maas-models/simulator-disconnected/llm/model.yaml
+++ b/manifests/05-maas-models/simulator-disconnected/llm/model.yaml
@@ -21,7 +21,7 @@ spec:
     containers:
       - name: main
         image: "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["/app/llm-d-inference-sim"]
         args:
           - --port

--- a/manifests/06-verification/verify.sh
+++ b/manifests/06-verification/verify.sh
@@ -387,7 +387,7 @@ spec:
     containers:
       - name: main
         image: "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["/app/llm-d-inference-sim"]
         args:
           - --port


### PR DESCRIPTION
## Summary

- Add full disconnected/air-gapped support for MaaS deployment (Phase 0 docs, ImageSetConfiguration, ITMS manifest, GPU MachineSet template)
- Add Gemma 2 9B IT FP8 model and disconnected simulator variant
- Fix vLLM image path (`rhaiis/` -> `rhaii/`) and pin by digest across all GPU model manifests - this was silently broken on disconnected because CRI-O has no fallback
- Add vLLM to ImageSetConfiguration so MaaS mirror is self-contained when mirrored separately from RHOAI
- Add `DISCONNECTED=true` mode to setup-maas.sh and verify.sh
- Document GPU driver DTK extraction procedure for air-gapped nodes

Validated end-to-end on CRIAB cluster (OCP 4.20.30, RHOAI 3.4.2) with Gemma 2 9B IT FP8 running inference on GPU via MaaS API, fully air-gapped.

## Test plan

- [x] Gemma inference working on GPU via MaaS API on disconnected cluster
- [x] Simulator (disconnected variant) working on CPU
- [x] vLLM image path fix verified - pods pull correctly with rhaii/ + digest
- [x] ITMS manifest validated for tag-based modelcar redirects
- [x] GPU driver compilation via DTK extraction validated
- [x] setup-maas.sh DISCONNECTED=true skips external models, uses disconnected simulator
- [x] verify.sh passes on disconnected cluster
- [ ] Connected cluster regression (vLLM path change is backwards compatible)