### PR TITLE
docs: remove references to resolved Jira bugs

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -289,8 +289,6 @@ oc patch gateway maas-default-gateway -n openshift-ingress --type=merge -p '{
   }
 }'
 ----
-
-This is tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68589[RHOAIENG-68589].
 ====
 
 *Step 5d:* Label namespaces for Gateway route binding

--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -126,8 +126,6 @@ curl -sk "${MAAS_GW}/external-models/gpt-4o-mini/v1/chat/completions" \
 
 A successful response contains a `choices` array with the model's reply.
 
-WARNING: There is a known platform bug where the BBR ext-proc filter is never inserted into the Envoy filter chain due to an EnvoyFilter match mismatch. If inference returns 404, see the <<known-issues>> section below. This is tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68594[RHOAIENG-68594].
-
 == Automated Setup
 
 The setup script handles all of the above in a single command:
@@ -281,20 +279,6 @@ curl -sk "${MAAS_GW}/external-models/aws-gpt-oss-20b/v1/chat/completions" \
 [[known-issues]]
 == Known Issues
 
-=== ext-proc filter not inserted (RHOAIENG-68594)
-
-The `payload-processing` EnvoyFilter matches on a WasmPlugin-style filter name (`extensions.istio.io/wasmplugin/...`), but Kuadrant creates the Wasm filter with the generic name `envoy.filters.http.wasm`. The match fails, so the BBR ext-proc is never added to the Envoy filter chain. Without ext-proc, there is no path rewriting and no credential injection - inference returns 404 or 401 from the upstream provider.
-
-This affects all external model providers. A temporary workaround (reverted by the MaaS controller within seconds):
-
-[source,bash]
-----
-oc patch envoyfilter payload-processing -n openshift-ingress --type='json' \
-  -p='[{"op": "replace", "path": "/spec/configPatches/0/match/listener/filterChain/filter/subFilter/name", "value": "envoy.filters.http.wasm"}]'
-----
-
-Tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68594[RHOAIENG-68594].
-
 === Gemini path incompatibility (RHOAIENG-68592)
 
 The BBR `openai` provider hardcodes the upstream path to `/v1/chat/completions`, but Gemini requires `/v1beta/openai/chat/completions`. See the <<google-gemini,Google Gemini>> section above for details. Tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68592[RHOAIENG-68592].
@@ -354,7 +338,6 @@ The `provider` field in the ExternalModel spec maps to a BBR payload translator.
 
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index#maas-external-model_maas-deploy[RHOAI ExternalModel documentation]
 * link:https://github.com/opendatahub-io/ai-gateway-payload-processing[BBR (ai-gateway-payload-processing) repository]
-* link:https://redhat.atlassian.net/browse/RHOAIENG-68594[RHOAIENG-68594 - ext-proc EnvoyFilter match mismatch (all providers)]
 * link:https://redhat.atlassian.net/browse/RHOAIENG-68592[RHOAIENG-68592 - Gemini BBR path incompatibility]
 
 == Next step


### PR DESCRIPTION
## Summary

- Removed RHOAIENG-68594 (ext-proc filter not inserted) - **Resolved** in Jira. Removed the WARNING, the known-issue subsection with workaround, and the reference link from `08-external-models.adoc`
- Removed RHOAIENG-68589 (gateway OOMKill) - **Closed** in Jira. Removed the tracking link from `02-platform-config.adoc`. The NOTE block explaining the 2Gi ConfigMap fix stays since it helps users on older guide versions
- RHOAIENG-82814 and RHOAIENG-68592 are still open, no changes

## Test plan

- [ ] `grep -r 'RHOAIENG-68594\|RHOAIENG-68589' content/` returns nothing
- [ ] `grep -r 'RHOAIENG-82814\|RHOAIENG-68592' content/` still finds references
- [ ] Antora site builds without broken xrefs