### PR TITLE
docs: fix Phase 0 nav ordering and add to overview

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -1,6 +1,9 @@
 * xref:index.adoc[Overview]
 * xref:quick-start.adoc[Automated Setup]
 
+.Disconnected Setup
+* xref:00-disconnected.adoc[Phase 0: Disconnected Setup]
+
 .Installation Guide
 * xref:01-prerequisites.adoc[Phase 1: Prerequisites]
 * xref:02-platform-config.adoc[Phase 2: Platform Configuration]
@@ -16,9 +19,6 @@
 
 .External Models
 * xref:08-external-models.adoc[Phase 8: External Models]
-
-.Disconnected Setup
-* xref:00-disconnected.adoc[Disconnected Setup (Air-Gapped)]
 
 .Reference
 * xref:08-architecture.adoc[Architecture & Request Flow]

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -29,6 +29,17 @@ You also need:
 
 Each phase has step-by-step instructions, status gates, and troubleshooting.
 
+=== Disconnected Setup
+
+[cols="1,3,1", options="header"]
+|===
+| Phase | Description | Time
+
+| xref:00-disconnected.adoc[0. Disconnected Setup] _(air-gapped only)_
+| Mirror MaaS operators and images, ITMS for modelcars, WASM shim patch, GPU driver setup
+| 30-60 min
+|===
+
 === Installation Guide
 
 [cols="1,3,1", options="header"]


### PR DESCRIPTION
## Summary

- Moved Phase 0 (Disconnected Setup) to the top of the sidebar nav, before Phase 1 - it was at the bottom after Phase 8 which made no sense
- Added Phase 0 to the overview page phases table so people can see it exists
- Renamed nav entry from "Disconnected Setup (Air-Gapped)" to "Phase 0: Disconnected Setup" to match the other phases

## Test plan

- [ ] Sidebar nav shows Phase 0 before Phase 1
- [ ] Prev/Next navigation flows correctly (Overview -> Phase 0 -> Phase 1)
- [ ] Overview page shows the Phase 0 table