### PR TITLE
fix: before rhoai 3.4.4 the telemetrypolicy should omitted cost_center

### DIFF
--- a/manifests/07-observability/telemetry/gateway-telemetry-policy.yaml
+++ b/manifests/07-observability/telemetry/gateway-telemetry-policy.yaml
@@ -13,8 +13,9 @@ spec:
         user: auth.identity.userid
         # Subscription metadata for usage attribution and billing
         subscription: auth.identity.selected_subscription
-        organization_id: auth.identity.subscription_info.organizationId
-        cost_center: auth.identity.subscription_info.costCenter
+        # Before RHOAI 3.4.4 https://redhat.atlassian.net/browse/RHOAIENG-79318 the cost_center and organization_id should be omitted
+        # organization_id: auth.identity.subscription_info.organizationId
+        # cost_center: auth.identity.subscription_info.costCenter
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway


### PR DESCRIPTION
## Summary
https://redhat.atlassian.net/browse/RHOAIENG-79318

the issue will cause observed in AI dashboard cannot show token consumption.