### PR TITLE
fix: add GPU HardwareProfile and remove T4/A10G support

### DIFF
--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -53,6 +53,15 @@ Create the Data Science Cluster:
 oc apply -f manifests/04-rhoai-config/datasciencecluster.yaml
 ----
 
+Apply the GPU HardwareProfile so RHOAI properly schedules GPU workloads:
+
+[source,bash]
+----
+oc apply -f manifests/04-rhoai-config/hardwareprofile.yaml
+----
+
+NOTE: Without this HardwareProfile, GPU model deployments may hang. The node will show `nvidia.com/gpu: 0` requested even when the GPU is physically present, because RHOAI needs a HardwareProfile to map GPU resources to workloads.
+
 The DataScienceCluster reconciles multiple components. Wait for `KServe` and the `Model Controller` (MaaS) to reach Ready:
 
 [source,bash]
@@ -151,6 +160,9 @@ Verify the following flags are set:
 
 | `OdhDashboardConfig/odh-dashboard-config`
 | Enables MaaS, GenAI Studio, Auth Policies, and Observability UI tabs
+
+| `HardwareProfile/gpu`
+| Registers GPU resources with RHOAI for proper GPU scheduling
 |===
 
 == Troubleshooting
@@ -180,6 +192,7 @@ manifests/04-rhoai-config/
   dscinitialization.yaml         # DSCInitialization CR
   datasciencecluster.yaml        # DataScienceCluster CR
   odh-dashboard-config.yaml      # OdhDashboardConfig CR
+  hardwareprofile.yaml           # GPU HardwareProfile for proper GPU scheduling
 ----
 
 == References

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -12,6 +12,8 @@ IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/
 * MaaS Gateway available in `openshift-ingress` namespace
 * `maas-api` and `maas-controller` pods running in `redhat-ods-applications`
 
+IMPORTANT: GPU models use FP8 quantization, which requires NVIDIA GPUs with compute capability >= 80 (Ampere architecture or newer). T4 GPUs (compute capability 75) and A10G GPUs are *not supported* with the current vLLM version. Use L4, L40, L40S, A100, or H100 GPUs.
+
 == Available Models
 
 === simulator (recommended for initial testing)
@@ -35,7 +37,7 @@ Red Hat AI Granite 4.0-h-tiny FP8 Dynamic, a small Granite model (~1B parameters
 
 === gemma
 
-Google Gemma 2 9B IT FP8 running on the Red Hat AI Inference Server (vLLM CUDA). A 9B parameter instruction-tuned model with FP8 quantization, suitable for general-purpose text generation and code tasks. Fits on a single A10G GPU (24GB VRAM).
+Google Gemma 2 9B IT FP8 running on the Red Hat AI Inference Server (vLLM CUDA). A 9B parameter instruction-tuned model with FP8 quantization, suitable for general-purpose text generation and code tasks. Fits on a single L4 GPU (24GB VRAM).
 
 * *Runtime*: vLLM CUDA (registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0)
 * *Model weights*: OCI modelcar `registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5`
@@ -48,7 +50,7 @@ NOTE: Gemma is a US-origin model, making it suitable for deployments with export
 
 === gpt-oss-20b
 
-OpenAI gpt-oss-20b running on the Red Hat AI Inference Server (vLLM CUDA). Requires a capable GPU node (A10G or better) with sufficient VRAM.
+OpenAI gpt-oss-20b running on the Red Hat AI Inference Server (vLLM CUDA). Requires a capable GPU node (L4 or better) with sufficient VRAM.
 
 * *Runtime*: vLLM CUDA (registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0)
 * *Model weights*: OCI modelcar from registry.redhat.io (~8GB download)
@@ -151,13 +153,13 @@ Or deploy a GPU model if your cluster has NVIDIA GPUs:
 
 [source,bash]
 ----
-# Gemma 2 9B IT FP8 (12GB+ VRAM, single A10G)
+# Gemma 2 9B IT FP8 (12GB+ VRAM, single L4)
 oc apply -k manifests/05-maas-models/gemma/
 
 # Granite 4.0-h-tiny FP8 (8GB+ VRAM)
 oc apply -k manifests/05-maas-models/granite-tiny-gpu/
 
-# GPT-oss-20b (16GB+ VRAM, A10G or better)
+# GPT-oss-20b (16GB+ VRAM, L4 or better)
 oc apply -k manifests/05-maas-models/gpt-oss-20b/
 ----
 

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -118,7 +118,7 @@ For end-to-end deployment using a single script, see the xref:quick-start.adoc[A
 | `granite-tiny-gpu`
 | Yes
 | < 40 GiB
-| Small GPU (T4, L4, A10)
+| Small GPU (L4, L40)
 
 | `gpt-oss-20b`
 | Yes

--- a/manifests/04-rhoai-config/hardwareprofile.yaml
+++ b/manifests/04-rhoai-config/hardwareprofile.yaml
@@ -1,0 +1,25 @@
+apiVersion: infrastructure.opendatahub.io/v1
+kind: HardwareProfile
+metadata:
+  name: gpu
+  namespace: redhat-ods-applications
+  annotations:
+    opendatahub.io/display-name: gpu
+spec:
+  identifiers:
+    - defaultCount: 2
+      displayName: CPU
+      identifier: cpu
+      minCount: 1
+      resourceType: CPU
+    - defaultCount: 4Gi
+      displayName: Memory
+      identifier: memory
+      minCount: 2Gi
+      resourceType: Memory
+    - defaultCount: 1
+      displayName: GPU
+      identifier: nvidia.com/gpu
+      maxCount: 1
+      minCount: 1
+      resourceType: Accelerator

--- a/manifests/04-rhoai-config/kustomization.yaml
+++ b/manifests/04-rhoai-config/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - dscinitialization.yaml
   - datasciencecluster.yaml
   - odh-dashboard-config.yaml
+  - hardwareprofile.yaml

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -679,7 +679,8 @@ if should_run 4; then
         log_step "Applying DSC and DSCI..."
         run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/dscinitialization.yaml"
         run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/datasciencecluster.yaml"
-        log_info "DSC/DSCI applied"
+        run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/hardwareprofile.yaml"
+        log_info "DSC/DSCI/HardwareProfile applied"
 
         if [ "$DRY_RUN" = false ]; then
             log_info "Waiting for KserveReady condition (up to 5 minutes)..."


### PR DESCRIPTION
## Summary

- Added a HardwareProfile CR to Phase 4 manifests so RHOAI properly schedules GPU workloads. Without it, GPU models hang because the node reports nvidia.com/gpu: 0 requested even when a GPU is present (fixes #54)
- Removed T4 and A10G from supported GPU lists in the guide - FP8 quantization needs compute capability >= 80, T4 is 75 and A10G has a tensor tile size error with current vLLM (fixes #53)
- Updated setup-maas.sh to apply HardwareProfile during Phase 4

## Changes

- New: `manifests/04-rhoai-config/hardwareprofile.yaml`
- Updated: `manifests/04-rhoai-config/kustomization.yaml`, `scripts/setup-maas.sh`
- Updated docs: `04-rhoai-config.adoc`, `05-maas-models.adoc`, `index.adoc`

## Test plan

- [x] Deployed on OCP 4.21.29 AWS cluster with L4 GPU (g6.2xlarge, 23 GiB VRAM)
- [x] setup-maas.sh completed all phases, gemma-2-9b-it deployed on L4
- [x] verify.sh: 15/15 passed
- [x] 8/8 blind-spot regression checks passed
- [x] Inference test: gemma answered correctly via MaaS API

Closes #53
Closes #54