### PR TITLE
fix: add istiod/proxyv2 images for disconnected OCP >= 4.20.32

### DIFF
--- a/content/modules/ROOT/pages/00-disconnected.adoc
+++ b/content/modules/ROOT/pages/00-disconnected.adoc
@@ -11,7 +11,7 @@ A disconnected {ocp-short} cluster pulls all container images from a private mir
 This guide assumes:
 
 * {ocp-short} 4.20+ is already installed in disconnected mode
-* {rhoai} 3.4 operators are installed (rhods-operator, cert-manager, OSSM3, NFD, GPU operator)
+* {rhoai} 3.4 operators are installed (rhods-operator, cert-manager, NFD, GPU operator)
 * A mirror registry is running and the cluster trusts its CA
 * ImageDigestMirrorSet (IDMS) and CatalogSources from the RHOAI mirror are already applied
 
@@ -92,6 +92,12 @@ Images not discoverable through operator bundles:
 
 | `registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5`
 | Gemma 2 9B IT FP8 model weights
+
+| `registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:...` (pinned digest)
+| Istiod control plane ({ocp-short} >= 4.20.32 only, see <<istiod-images>>)
+
+| `registry.redhat.io/openshift-service-mesh/proxyv2-rhel9@sha256:...` (pinned digest)
+| Envoy proxy / gateway data plane ({ocp-short} >= 4.20.32 only, see <<istiod-images>>)
 |===
 
 IMPORTANT: The WASM shim image lives on `registry.access.redhat.com` (not `registry.redhat.io`). This is a different registry. The WASM shim digest changes with each RHCL operator version - see <<wasm-shim>> for how to discover it.
@@ -115,6 +121,28 @@ oc get csv -n openshift-operators \
 
 # Replace the placeholder in imageset-config-maas.yaml with the digest
 ----
+
+[[istiod-images]]
+On {ocp-short} 4.20.32 and later, the openshift-ingress operator embeds the Istio sail library instead of installing a standalone OSSM operator. The istiod and proxyv2 images it pulls are NOT in the OCP release payload and NOT in any operator catalog. They must be mirrored explicitly.
+
+NOTE: On {ocp-short} < 4.20.32, the `servicemeshoperator3` catalog entry covers these images and you can skip this block.
+
+To discover the digests, you need a connected reference cluster running the same {ocp-short} version with a Gateway already created (creating a Gateway triggers istiod provisioning):
+
+[source,bash]
+----
+# istiod (control plane)
+oc get deployment -n openshift-ingress -l app=istiod \
+  -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
+
+# proxyv2 (data plane / gateway proxy)
+oc get deployment -n openshift-ingress -l istio.io/gateway-name \
+  -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
+----
+
+Replace `<ISTIOD_DIGEST>` and `<PROXYV2_DIGEST>` in `imageset-config-maas.yaml` with the digests from the commands above.
+
+TIP: If you do not have a connected reference cluster with a Gateway, check the {ocp-short} release notes for your z-stream. The istiod and proxyv2 images are listed under the Service Mesh / Gateway API components.
 
 On a connected system (jump box) with `oc-mirror` v2 and a valid pull secret:
 
@@ -529,6 +557,22 @@ applying deny RBAC filter
 
 * The cluster proxy trusted CA bundle: `oc get proxy/cluster -o jsonpath='{.spec.trustedCA.name}'`
 * The `additionalTrustedCA` in `image.config.openshift.io/cluster`
+
+=== Istiod / gateway pod ImagePullBackOff ({ocp-short} >= 4.20.32)
+
+**Symptom:** After creating the MaaS gateway, the istiod deployment or gateway proxy pod in `openshift-ingress` shows `ImagePullBackOff` or `ErrImagePull` with errors referencing `registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9` or `proxyv2-rhel9`.
+
+**Cause:** On {ocp-short} >= 4.20.32, the openshift-ingress operator embeds the Istio sail library and pulls istiod/proxyv2 images directly from `registry.redhat.io`. These images are not in the OCP release payload and not in any operator catalog. Without explicit mirroring, the disconnected cluster cannot pull them.
+
+**Fix:** Mirror the istiod and proxyv2 images as described in <<istiod-images>>. Discover the correct digests from a connected reference cluster, add them to `imageset-config-maas.yaml`, re-run oc-mirror, and apply the updated IDMS.
+
+After the IDMS is applied and nodes reboot, delete the failed pods so they retry with the new mirror configuration:
+
+[source,bash]
+----
+oc delete pods -n openshift-ingress -l app=istiod
+oc delete pods -n openshift-ingress -l istio.io/gateway-name=maas-default-gateway
+----
 
 === Certificates
 

--- a/manifests/00-disconnected/additional-images-maas.txt
+++ b/manifests/00-disconnected/additional-images-maas.txt
@@ -16,6 +16,14 @@ registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:5800e12b2a465f15961fcf34b645d79e
 # Find the digest: oc get csv -n openshift-operators -o yaml | grep -A1 RELATED_IMAGE_WASMSHIM
 registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:<WASM_SHIM_DIGEST>
 
+# Istio images for OCP >= 4.20.32 (embedded sail library in openshift-ingress)
+# NOT needed on OCP < 4.20.32 where servicemeshoperator3 covers these.
+# Digests change per OCP z-stream. Discover from a connected cluster:
+#   oc get deployment -n openshift-ingress -l app=istiod -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
+#   oc get deployment -n openshift-ingress -l istio.io/gateway-name -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
+registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:<ISTIOD_DIGEST>
+registry.redhat.io/openshift-service-mesh/proxyv2-rhel9@sha256:<PROXYV2_DIGEST>
+
 # Simulator runtime
 ghcr.io/llm-d/llm-d-inference-sim:v0.7.1
 

--- a/manifests/00-disconnected/imageset-config-maas.yaml
+++ b/manifests/00-disconnected/imageset-config-maas.yaml
@@ -38,6 +38,10 @@ mirror:
           defaultChannel: stable-v1
           channels:
             - name: stable-v1
+        # OSSM3 -- only needed on OCP < 4.20.32.
+        # On OCP >= 4.20.32, the openshift-ingress operator embeds the Istio
+        # sail library directly and no OSSM OLM operator is installed.
+        # The istiod/proxyv2 images for >= 4.20.32 are in additionalImages.
         - name: servicemeshoperator3
           defaultChannel: stable
           channels:
@@ -123,3 +127,25 @@ mirror:
     - name: registry.redhat.io/rhai/modelcar-granite-4-0-h-tiny-fp8-dynamic:3.0
     - name: registry.redhat.io/rhelai1/modelcar-gpt-oss-20b:1.5
     - name: registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5
+    # -- Istio images for OCP >= 4.20.32 (embedded sail library) ----------------
+    # On OCP >= 4.20.32, the openshift-ingress operator embeds the Istio sail
+    # library and pulls istiod + proxyv2 from registry.redhat.io. These images
+    # are NOT in the OCP release payload and NOT in any operator catalog. They
+    # must be mirrored explicitly for disconnected clusters.
+    #
+    # The digests change per OCP z-stream. Discover them from a connected
+    # reference cluster after creating a Gateway (which triggers istiod):
+    #
+    #   # istiod (control plane)
+    #   oc get deployment -n openshift-ingress -l app=istiod \
+    #     -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
+    #
+    #   # proxyv2 (data plane / gateway proxy)
+    #   oc get deployment -n openshift-ingress -l istio.io/gateway-name \
+    #     -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
+    #
+    # Replace the <ISTIOD_DIGEST> and <PROXYV2_DIGEST> placeholders below.
+    # On OCP < 4.20.32, servicemeshoperator3 covers these - leave the
+    # placeholders as-is or remove these lines.
+    - name: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:<ISTIOD_DIGEST>
+    - name: registry.redhat.io/openshift-service-mesh/proxyv2-rhel9@sha256:<PROXYV2_DIGEST>

--- a/manifests/00-disconnected/itms-maas-modelcars.yaml
+++ b/manifests/00-disconnected/itms-maas-modelcars.yaml
@@ -33,3 +33,7 @@ spec:
     - mirrors:
         - MIRROR_REGISTRY:PORT/NAMESPACE/llm-d
       source: ghcr.io/llm-d
+    # Istio images for OCP >= 4.20.32 (openshift-ingress embedded sail library)
+    - mirrors:
+        - MIRROR_REGISTRY:PORT/NAMESPACE/openshift-service-mesh
+      source: registry.redhat.io/openshift-service-mesh

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -438,7 +438,7 @@ if should_run 2; then
     else
         log_step "Creating GatewayClass..."
         run_cmd oc apply -f "$MANIFESTS_DIR/02-platform-config/gatewayclass.yaml"
-        wait_for "GatewayClass accepted (openshift-ingress installs OSSM)" 300 \
+        wait_for "GatewayClass accepted (openshift-ingress provisions Istio)" 300 \
             oc wait gatewayclass openshift-default \
             --for=jsonpath='{.status.conditions[?(@.type=="Accepted")].status}'=True
     fi


### PR DESCRIPTION
## Summary

- On OCP 4.20.32+, the ingress operator embeds Istio (sail library) instead of using a standalone OSSM operator. The istiod/proxyv2 images are not in any operator catalog or OCP release payload, so disconnected clusters get ImagePullBackOff when the MaaS gateway creates the istiod deployment.
- Added placeholder digests with discovery commands to `imageset-config-maas.yaml` and `additional-images-maas.txt` (same pattern we use for the WASM shim).
- Added version-boundary comment to `servicemeshoperator3` explaining it only covers OCP < 4.20.32.
- Added ITMS entry for `registry.redhat.io/openshift-service-mesh` as defensive coverage.
- Updated `00-disconnected.adoc` with a discovery block (`[[istiod-images]]`) and a troubleshooting section for ImagePullBackOff.
- Removed "OSSM3" from the prerequisites list since it is not manually installed on 4.20+.

## Context

Reported by jpetnik on OCP 4.20.33 + RHOAI 3.4.3. After mirroring one image (istio-pilot), another was needed (proxyv2) - the full list was not documented anywhere.

Fixes #74

## Test plan

- [ ] Verify the discovery commands (`oc get deployment -n openshift-ingress -l app=istiod ...`) return the correct image on a connected 4.20.32+ cluster
- [ ] Verify `imageset-config-maas.yaml` is valid YAML after the additions
- [ ] Verify the AsciiDoc renders the `[[istiod-images]]` anchor and cross-references correctly
- [ ] On a disconnected 4.20.32+ cluster, confirm that mirroring the discovered images and applying IDMS resolves the ImagePullBackOff