### PR TITLE
feat: RHOAI 3.4/3.5 dual-version support

### DIFF
--- a/content/modules/ROOT/pages/00-disconnected.adoc
+++ b/content/modules/ROOT/pages/00-disconnected.adoc
@@ -11,7 +11,7 @@ A disconnected {ocp-short} cluster pulls all container images from a private mir
 This guide assumes:
 
 * {ocp-short} 4.20+ is already installed in disconnected mode
-* {rhoai} 3.4 operators are installed (rhods-operator, cert-manager, NFD, GPU operator)
+* {rhoai} 3.4 / 3.5 operators are installed (rhods-operator, cert-manager, NFD, GPU operator)
 * A mirror registry is running and the cluster trusts its CA
 * ImageDigestMirrorSet (IDMS) and CatalogSources from the RHOAI mirror are already applied
 
@@ -337,7 +337,7 @@ export AMI=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].
 export SUBNET=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.subnet.id}')
 export REGION=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.region}')
 export AZ=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}')
-export INSTANCE_TYPE=g5.2xlarge
+export INSTANCE_TYPE=g6.2xlarge
 export MS_NAME=${INFRA_ID}-gpu-${AZ}
 export IAM_PROFILE=${INFRA_ID}-worker-profile
 export SG=${INFRA_ID}-node
@@ -354,7 +354,9 @@ oc get machines -n openshift-machine-api -w
 oc get nodes -l nvidia.com/gpu.present=true
 ----
 
-The default instance type is `g5.2xlarge` (1x A10G, 24 GB VRAM) - enough for Gemma 2 9B FP8. Edit the template to use `g5.12xlarge` (4x A10G, 96 GB VRAM) for larger models.
+The default instance type is `g6.2xlarge` (1x L4, 24 GB VRAM) - enough for Gemma 2 9B FP8. Edit the template to use `g6e.2xlarge` (1x L40S, 48 GB VRAM) for larger models like gpt-oss-20b.
+
+IMPORTANT: Do not use `g5` instances (A10G GPUs) - vLLM FP8 requires compute capability >= 80 (Ampere or newer). A10G GPUs are not supported. Use `g6` (L4) or `g6e` (L40S) instances instead.
 
 === GPU driver compilation on disconnected
 

--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -1,6 +1,6 @@
 = Phase 1: Prerequisites
 
-Install the operator subscriptions required by {rhoai} 3.4 {maas}.
+Install the operator subscriptions required by {rhoai} 3.4 / 3.5 {maas}.
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
@@ -279,7 +279,7 @@ openshift-operators      authorino-operator-stable-redhat-operators-openshift-ma
 openshift-operators      dns-operator-stable-redhat-operators-openshift-marketplace                             dns-operator.v1.3.1                                AtLatestKnown
 openshift-operators      limitador-operator-stable-redhat-operators-openshift-marketplace                       limitador-operator.v1.3.1                          AtLatestKnown
 openshift-operators      rhcl-operator                                                                          rhcl-operator.v1.4.2                               AtLatestKnown
-redhat-ods-operator      rhods-operator                                                                         rhods-operator.3.4.0                               AtLatestKnown
+redhat-ods-operator      rhods-operator                                                                         rhods-operator.3.5.0                               AtLatestKnown
 ----
 
 == Appendix
@@ -313,8 +313,10 @@ manifests/01-prerequisites/
 
 == References
 
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.5 MaaS Official Docs]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.4 MaaS Official Docs]
 * link:https://opendatahub-io.github.io/models-as-a-service/latest/[Upstream MaaS Documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/installing_and_uninstalling_openshift_ai_self-managed/index[RHOAI 3.5 Installation Guide]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/installing_and_uninstalling_openshift_ai_self-managed/index[RHOAI 3.4 Installation Guide]
 
 == Next step

--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -4,7 +4,7 @@ Install the operator subscriptions required by {rhoai} 3.4 {maas}.
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Operator Overview
 

--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -6,7 +6,7 @@ Apply each step in order and wait for the status gates before proceeding to the 
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Prerequisites
 
@@ -310,13 +310,32 @@ oc label namespace <your-namespace> \
 ----
 ====
 
-Label the `redhat-ods-applications` namespace where the MaaS API route is created:
+Label the namespace where the MaaS API route is created:
 
+[tabs]
+====
+RHOAI 3.5+::
++
+--
+[source,bash]
+----
+oc label namespace redhat-ai-gateway-infra \
+  maas.opendatahub.io/gateway-access=true --overwrite
+----
+
+In RHOAI 3.5+, the MaaS API route is created in `redhat-ai-gateway-infra`.
+--
+
+RHOAI 3.4::
++
+--
 [source,bash]
 ----
 oc label namespace redhat-ods-applications \
   maas.opendatahub.io/gateway-access=true --overwrite
 ----
+--
+====
 
 NOTE: Model namespaces (`llm`, `external-models`) are labeled in their respective deployment phases.
 

--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -58,7 +58,7 @@ oc wait --for=condition=Ready kuadrant/kuadrant -n kuadrant-system --timeout=180
 
 == Step 2: Configure TLS for Models-as-a-Service
 
-Now that Kuadrant is deployed, we need to update the Authorino CR to enable TLS. (Detailed documentation for this step is available in the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service_maas#configure-tls-for-maas_maas-deploy[RHOAI 3.4 docs section 1.4]. )
+Now that Kuadrant is deployed, we need to update the Authorino CR to enable TLS. (Detailed documentation for this step is available in the RHOAI docs: link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service_maas#configure-tls-for-maas_maas-deploy[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service_maas#configure-tls-for-maas_maas-deploy[3.4].)
 Follow the four steps below to enable TLS between the Gateway and Authorino.
 
 *Step 2a:* The service annotation (already applied above) triggered the service-ca operator to generate the `authorino-server-cert` TLS Secret:

--- a/content/modules/ROOT/pages/03-maas-platform.adoc
+++ b/content/modules/ROOT/pages/03-maas-platform.adoc
@@ -167,6 +167,7 @@ manifests/03-maas-platform/
 == References
 
 * link:https://github.com/opendatahub-io/models-as-a-service/blob/main/docs/content/install/maas-setup.md[MaaS Setup (upstream)]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.5 MaaS Official Docs]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.4 MaaS Official Docs]
 
 == Next step

--- a/content/modules/ROOT/pages/03-maas-platform.adoc
+++ b/content/modules/ROOT/pages/03-maas-platform.adoc
@@ -4,7 +4,7 @@ Deploy the PostgreSQL database required by the MaaS API for key lifecycle manage
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Prerequisites
 
@@ -44,6 +44,8 @@ oc create secret generic maas-db-config \
   -n redhat-ods-applications \
   --from-literal=DB_CONNECTION_URL="postgresql://maas:${POSTGRES_PASSWORD}@postgres:5432/maas?sslmode=disable"
 ----
+
+NOTE: On RHOAI 3.5+, the `maas-api` deployment runs in `redhat-ai-gateway-infra`. The `maas-db-config` secret must also exist in that namespace. The `setup-maas.sh` script handles this mirroring automatically. If installing manually, create the same secret in `redhat-ai-gateway-infra` after the one above.
 
 === Step 2: Deploy PostgreSQL
 

--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -18,12 +18,12 @@ Verify the operator is ready before proceeding:
 oc get csv -n redhat-ods-operator | grep rhods-operator
 ----
 
-Expected output:
+Expected output (version varies):
 
 [source]
 ----
 NAME                     DISPLAY                 VERSION   REPLACES               PHASE
-rhods-operator.3.4.0     Red Hat OpenShift AI    3.4.0     rhods-operator.3.3.2   Succeeded
+rhods-operator.3.5.0     Red Hat OpenShift AI    3.5.0     rhods-operator.3.4.3   Succeeded
 ----
 
 == Apply
@@ -104,20 +104,26 @@ NOTE: On subsequent runs (CRDs already exist), `oc apply -k manifests/04-rhoai-c
 
 === Check MaaS CRDs are installed
 
-The operator installs MaaS CRDs when `modelsAsService` is set to Managed:
+The operator installs MaaS CRDs when Models-as-a-Service is set to Managed:
 
 [source,bash]
 ----
 oc get crd | grep maas.opendatahub.io
 ----
 
-Expected CRDs:
+Expected CRDs (RHOAI 3.4):
 
 * externalmodels.maas.opendatahub.io
 * maasauthpolicies.maas.opendatahub.io
 * maasmodelrefs.maas.opendatahub.io
 * maassubscriptions.maas.opendatahub.io
 * tenants.maas.opendatahub.io
+
+RHOAI 3.5+ adds three additional CRDs:
+
+* aitenants.maas.opendatahub.io
+* configs.maas.opendatahub.io
+* maastenantconfigs.maas.opendatahub.io
 
 
 === Check maas-api deployment
@@ -149,8 +155,24 @@ oc rollout status deployment/maas-api -n redhat-ods-applications --timeout=120s
 
 TIP: The `maas-api` deployment may take 30-60 seconds to appear after the DSC is applied. If it is not found, wait and retry.
 
-=== Check Tenant CR
+=== Check Tenant / Config CR
 
+[tabs]
+====
+RHOAI 3.5+::
++
+--
+In RHOAI 3.5+, the maas-controller auto-creates a `Config` CR (replacing the Tenant CR from 3.4):
+
+[source,bash]
+----
+oc get configs.maas.opendatahub.io -n models-as-a-service
+----
+--
+
+RHOAI 3.4::
++
+--
 The maas-controller auto-creates a `default-tenant` CR in the `models-as-a-service` namespace:
 
 [source,bash]
@@ -158,7 +180,9 @@ The maas-controller auto-creates a `default-tenant` CR in the `models-as-a-servi
 oc get tenant default-tenant -n models-as-a-service
 ----
 
-NOTE: The `default-tenant` CR may show either `Ready=True` (reason `Reconciled`) or `Ready=False` (reason `DeploymentsNotReady`) at this stage. Both are normal — if it shows `Ready=False`, it will become `Ready=True` after a model is deployed in xref:05-maas-models.adoc[Phase 5].
+NOTE: The `default-tenant` CR may show either `Ready=True` (reason `Reconciled`) or `Ready=False` (reason `DeploymentsNotReady`) at this stage. Both are normal - if it shows `Ready=False`, it will become `Ready=True` after a model is deployed in xref:05-maas-models.adoc[Phase 5].
+--
+====
 
 === MaaS health endpoint
 
@@ -181,8 +205,9 @@ Verify the following flags are set:
 
 * `modelAsService: true` - enables the Models as a Service tab
 * `genAiStudio: true` - enables the GenAI Studio tab (requires llamastackoperator Managed)
-* `maasAuthPolicies: true` - enables MaaS auth policy management in the UI
 * `observabilityDashboard: true` - enables the Observability tab (requires COO + monitoring configured)
+
+NOTE: The `maasAuthPolicies` flag was removed from the OdhDashboardConfig CRD in RHOAI 3.5. Do not include it in the manifest - the admission webhook will reject it.
 
 == What this creates
 
@@ -197,7 +222,7 @@ Verify the following flags are set:
 | Enables all RHOAI components including KServe with modelsAsService Managed
 
 | `OdhDashboardConfig/odh-dashboard-config`
-| Enables MaaS, GenAI Studio, Auth Policies, and Observability UI tabs
+| Enables MaaS, GenAI Studio, and Observability UI tabs
 
 | `HardwareProfile/gpu`
 | Registers GPU resources with RHOAI for proper GPU scheduling
@@ -228,14 +253,17 @@ oc get pods -n redhat-ods-applications
 manifests/04-rhoai-config/
   kustomization.yaml             # Aggregates all RHOAI config resources
   dscinitialization.yaml         # DSCInitialization CR
-  datasciencecluster.yaml        # DataScienceCluster CR
+  datasciencecluster.yaml        # DataScienceCluster CR (RHOAI 3.5+, aigateway path)
+  datasciencecluster-34.yaml     # DataScienceCluster CR (RHOAI 3.4, kserve path)
   odh-dashboard-config.yaml      # OdhDashboardConfig CR
   hardwareprofile.yaml           # GPU HardwareProfile for proper GPU scheduling
 ----
 
 == References
 
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.5 MaaS Official Docs]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.4 MaaS Official Docs]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/installing_and_uninstalling_openshift_ai_self-managed/index[RHOAI 3.5 Installation Guide]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/installing_and_uninstalling_openshift_ai_self-managed/index[RHOAI 3.4 Installation Guide]
 * link:https://opendatahub-io.github.io/models-as-a-service/latest/[Upstream MaaS Documentation]
 

--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -4,7 +4,7 @@ Configure the RHOAI operator instances to enable Models-as-a-Service. Because th
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Prerequisites
 
@@ -48,10 +48,30 @@ oc wait --for=jsonpath='{.status.phase}'=Ready \
 
 Create the Data Science Cluster:
 
+[tabs]
+====
+RHOAI 3.5+::
++
+--
 [source,bash]
 ----
 oc apply -f manifests/04-rhoai-config/datasciencecluster.yaml
 ----
+
+Enables MaaS via `aigateway.modelsAsAService: Managed`, the modularized path for RHOAI 3.5+.
+--
+
+RHOAI 3.4::
++
+--
+[source,bash]
+----
+oc apply -f manifests/04-rhoai-config/datasciencecluster-34.yaml
+----
+
+WARNING: The `kserve.modelsAsService` DSC path is deprecated in RHOAI 3.5 and replaced by `aigateway.modelsAsAService`. Plan your migration to the 3.5+ manifest.
+--
+====
 
 Apply the GPU HardwareProfile so RHOAI properly schedules GPU workloads:
 
@@ -104,10 +124,28 @@ Expected CRDs:
 
 Since PostgreSQL and the `maas-db-config` secret were created in Phase 3, the `maas-api` deployment should start healthy:
 
+[tabs]
+====
+RHOAI 3.5+::
++
+--
+[source,bash]
+----
+oc rollout status deployment/maas-api -n redhat-ai-gateway-infra --timeout=120s
+----
+
+In RHOAI 3.5+, `maas-api` runs in the `redhat-ai-gateway-infra` namespace.
+--
+
+RHOAI 3.4::
++
+--
 [source,bash]
 ----
 oc rollout status deployment/maas-api -n redhat-ods-applications --timeout=120s
 ----
+--
+====
 
 TIP: The `maas-api` deployment may take 30-60 seconds to appear after the DSC is applied. If it is not found, wait and retry.
 

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -10,7 +10,7 @@ IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} docum
 
 * xref:01-prerequisites.adoc[Phases 1]-xref:04-rhoai-config.adoc[4] completed (RHOAI installed, MaaS platform running)
 * MaaS Gateway available in `openshift-ingress` namespace
-* `maas-api` and `maas-controller` pods running in `redhat-ods-applications`
+* `maas-api` and `maas-controller` pods running (in `redhat-ai-gateway-infra` on RHOAI 3.5+, or `redhat-ods-applications` on 3.4)
 
 IMPORTANT: GPU models use FP8 quantization, which requires NVIDIA GPUs with compute capability >= 80 (Ampere architecture or newer). T4 GPUs (compute capability 75) and A10G GPUs are *not supported* with the current vLLM version. Use L4, L40, L40S, A100, or H100 GPUs.
 

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -4,7 +4,7 @@ This phase deploys LLM models and registers them with the MaaS platform. Each mo
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Prerequisites
 

--- a/content/modules/ROOT/pages/06-verification.adoc
+++ b/content/modules/ROOT/pages/06-verification.adoc
@@ -4,7 +4,7 @@ End-to-end verification of a MaaS ({maas}) deployment on {ocp-short}.
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == What it tests
 

--- a/content/modules/ROOT/pages/06-verification.adoc
+++ b/content/modules/ROOT/pages/06-verification.adoc
@@ -63,6 +63,37 @@ If you prefer to verify each phase manually:
 
 === Phase 1: Infrastructure health
 
+[tabs]
+====
+RHOAI 3.5+::
++
+--
+[source,bash]
+----
+# Gateway
+oc get gateway maas-default-gateway -n openshift-ingress \
+  -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}'
+
+# Core deployments (maas-api is in redhat-ai-gateway-infra on 3.5+)
+oc get deployment postgres maas-controller -n redhat-ods-applications
+oc get deployment maas-api -n redhat-ai-gateway-infra
+
+# Authorino
+oc get deployment authorino -n kuadrant-system
+
+# DSC condition (ModelsAsAServiceReady on 3.5+)
+oc get datasciencecluster default-dsc \
+  -o jsonpath='{.status.conditions[?(@.type=="ModelsAsAServiceReady")].status}'
+
+# Health endpoint
+DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+curl -sk "https://maas.${DOMAIN}/maas-api/health"
+----
+--
+
+RHOAI 3.4::
++
+--
 [source,bash]
 ----
 # Gateway
@@ -83,6 +114,8 @@ oc get datasciencecluster default-dsc \
 DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 curl -sk "https://maas.${DOMAIN}/maas-api/health"
 ----
+--
+====
 
 === Phase 2: Deploy simulator model
 

--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -14,7 +14,7 @@ This phase adds *optional* observability enhancements on top of UWM:
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Step 1: Install the Tempo Operator
 

--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -185,9 +185,11 @@ manifests/07-observability/
 
 == References
 
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/managing_openshift_ai/managing-observability_managing-rhoai#enabling-the-observability-stack_managing-rhoai[RHOAI 3.5 - Enabling the observability stack]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/managing_openshift_ai/managing-observability_managing-rhoai#enabling-the-observability-stack_managing-rhoai[RHOAI 3.4 - Enabling the observability stack]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/1-latest[Cluster Observability Operator documentation]
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index#maas-observability_maas-deploy[RHOAI Observability dashboard]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index#maas-observability_maas-deploy[RHOAI 3.5 Observability dashboard]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index#maas-observability_maas-deploy[RHOAI 3.4 Observability dashboard]
 * link:https://docs.kuadrant.io/dev/kuadrant-operator/doc/reference/telemetrypolicy/[Kuadrant TelemetryPolicy]
 
 == Next step

--- a/content/modules/ROOT/pages/08-architecture.adoc
+++ b/content/modules/ROOT/pages/08-architecture.adoc
@@ -4,7 +4,7 @@ This page explains how {rhoai} {maas} works under the hood — what each compone
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Component Overview
 

--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -8,7 +8,7 @@ The `ExternalModel` CRD lets you expose third-party LLM APIs (OpenAI, AWS Bedroc
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == How It Works
 

--- a/content/modules/ROOT/pages/09-cleanup.adoc
+++ b/content/modules/ROOT/pages/09-cleanup.adoc
@@ -129,6 +129,9 @@ oc delete deployment postgres -n redhat-ods-applications --ignore-not-found
 oc delete service postgres -n redhat-ods-applications --ignore-not-found
 oc delete pvc postgres-data -n redhat-ods-applications --ignore-not-found
 oc delete secret postgres-creds maas-db-config -n redhat-ods-applications --ignore-not-found
+
+# RHOAI 3.5+ mirrored the secret to redhat-ai-gateway-infra
+oc delete secret maas-db-config -n redhat-ai-gateway-infra --ignore-not-found
 ----
 
 === Remove Gateway and Kuadrant
@@ -178,6 +181,7 @@ Wait 60 seconds for the RHOAI operator to clean up managed resources, then remov
 ----
 oc delete namespace redhat-ods-applications --ignore-not-found
 oc delete namespace redhat-ods-monitoring --ignore-not-found
+oc delete namespace redhat-ai-gateway-infra --ignore-not-found  # RHOAI 3.5+
 oc delete namespace rhods-notebooks --ignore-not-found
 oc delete namespace rhoai-model-registries --ignore-not-found
 oc delete namespace models-as-a-service --ignore-not-found

--- a/content/modules/ROOT/pages/claude-code.adoc
+++ b/content/modules/ROOT/pages/claude-code.adoc
@@ -11,7 +11,7 @@ The skill works with any AI coding tool that supports skill definitions:
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Prerequisites
 

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -117,8 +117,13 @@ For end-to-end deployment using a single script, see the xref:quick-start.adoc[A
 
 | `granite-tiny-gpu`
 | Yes
-| < 40 GiB
+| ~8 GiB
 | Small GPU (L4, L40)
+
+| `gemma`
+| Yes
+| ~12 GiB
+| Mid GPU (L4, L40, L40S)
 
 | `gpt-oss-20b`
 | Yes

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 = RHOAI Models-as-a-Service (MaaS) Guide
 
-Guide to deploy {rhoai} 3.4 {maas} on {ocp-short}.
+Guide to deploy {rhoai} 3.4 / 3.5 {maas} on {ocp-short}.
 
 * Kustomize manifests with status gates between every phase
 * Single automation script for end-to-end deployment
@@ -8,7 +8,7 @@ Guide to deploy {rhoai} 3.4 {maas} on {ocp-short}.
 
 Requires OpenShift 4.19+ with cluster-admin access.
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Getting Started
 
@@ -128,6 +128,7 @@ For end-to-end deployment using a single script, see the xref:quick-start.adoc[A
 
 == Documentation
 
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.5 MaaS Official Docs]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.4 MaaS Official Docs]
 * link:https://opendatahub-io.github.io/models-as-a-service/latest/[Upstream MaaS Documentation]
 * link:https://opendatahub-io.github.io/models-as-a-service/latest/concepts/architecture/[Upstream MaaS Architecture]

--- a/content/modules/ROOT/pages/quick-start.adoc
+++ b/content/modules/ROOT/pages/quick-start.adoc
@@ -50,7 +50,7 @@ This runs Phases 0-6 automatically. The script detects what's already installed 
 | `3.5`
 
 | `--from-phase <N>`
-| Start from phase N (0-7), skipping earlier phases
+| Start from phase N (0-8), skipping earlier phases
 | `0`
 
 | `--skip-models`
@@ -63,6 +63,10 @@ This runs Phases 0-6 automatically. The script detects what's already installed 
 
 | `--with-observability`
 | Also run Phase 7 (COO + Gateway telemetry)
+|
+
+| `--with-external-models`
+| Also run Phase 8 (ExternalModel deployment via OpenAI, Gemini, or Bedrock)
 |
 
 | `--dry-run`
@@ -107,6 +111,10 @@ This runs Phases 0-6 automatically. The script detects what's already installed 
 | 7
 | Observability - COO subscription + Gateway TelemetryPolicy
 | 2-3 min
+
+| 8
+| External Models - ExternalModel CRs + MaaS governance (only with `--with-external-models`)
+| 5-10 min
 |===
 
 == Common Usage Patterns
@@ -181,7 +189,7 @@ These wrap individual phases for standalone use:
 | Send inference requests to a deployed model endpoint
 
 | `scripts/verify-maas.sh`
-| Phase 6 only - wrapper for `manifests/manifests/06-verification/verify.sh`
+| Phase 6 only - wrapper for `manifests/06-verification/verify.sh`
 |===
 
 == State Detection

--- a/content/modules/ROOT/pages/quick-start.adoc
+++ b/content/modules/ROOT/pages/quick-start.adoc
@@ -2,7 +2,7 @@
 
 `setup-maas.sh` is a single script that handles the entire MaaS lifecycle, from operator installation through model deployment and verification. Each phase is idempotent; re-running skips what's already done.
 
-IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[official {rhoai} {maas} documentation]. It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
 == Clone and Run
 
@@ -10,8 +10,28 @@ IMPORTANT: This guide is not a replacement for the link:https://docs.redhat.com/
 ----
 git clone https://github.com/rh-aiservices-bu/rhoai-maas-guide.git
 cd rhoai-maas-guide
+----
+
+[tabs]
+====
+RHOAI 3.5+ (default)::
++
+--
+[source,bash]
+----
 ./scripts/setup-maas.sh
 ----
+--
+
+RHOAI 3.4::
++
+--
+[source,bash]
+----
+./scripts/setup-maas.sh --rhoai-version 3.4
+----
+--
+====
 
 This runs Phases 0-6 automatically. The script detects what's already installed and skips completed phases.
 
@@ -24,6 +44,10 @@ This runs Phases 0-6 automatically. The script detects what's already installed 
 | `--model <name>`
 | Model to deploy: `simulator` (CPU), `granite-tiny-gpu` (small GPU), `gpt-oss-20b` (large GPU), `auto` (auto-detect by GPU VRAM)
 | `auto`
+
+| `--rhoai-version <v>`
+| RHOAI version: `3.4` or `3.5`. Auto-detects if already installed.
+| `3.5`
 
 | `--from-phase <N>`
 | Start from phase N (0-7), skipping earlier phases

--- a/manifests/00-disconnected/gpu-machineset.yaml
+++ b/manifests/00-disconnected/gpu-machineset.yaml
@@ -7,16 +7,16 @@
 #   export SUBNET=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.subnet.id}')
 #   export REGION=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.region}')
 #   export AZ=$(oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}')
-#   export INSTANCE_TYPE=g5.2xlarge   # or g5.12xlarge for 4xA10G (96GB VRAM)
+#   export INSTANCE_TYPE=g6.2xlarge   # or g6e.2xlarge for L40S (48GB VRAM)
 #   export MS_NAME=${INFRA_ID}-gpu-${AZ}
 #   export IAM_PROFILE=${INFRA_ID}-worker-profile
 #   export SG=${INFRA_ID}-node
 #
 #   envsubst < manifests/00-disconnected/gpu-machineset.yaml | oc apply -f -
 #
-# Instance types:
-#   g5.2xlarge   1x A10G  (24 GB VRAM) - fits Gemma 9B FP8, Granite tiny
-#   g5.12xlarge  4x A10G  (96 GB VRAM) - fits GPT-oss-20b and larger models
+# Instance types (vLLM FP8 requires compute capability >= 80, do NOT use g5/A10G):
+#   g6.2xlarge   1x L4    (24 GB VRAM) - fits Gemma 9B FP8, Granite tiny
+#   g6e.2xlarge  1x L40S  (48 GB VRAM) - fits GPT-oss-20b
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:

--- a/manifests/04-rhoai-config/datasciencecluster-34.yaml
+++ b/manifests/04-rhoai-config/datasciencecluster-34.yaml
@@ -15,14 +15,11 @@ spec:
     # -- Feast Operator (feature store) --
     feastoperator:
       managementState: Managed
-    # -- AI Gateway (MaaS modularization, RHOAI 3.5+) --
-    aigateway:
-      managementState: Managed
-      modelsAsAService:
-        managementState: Managed
-    # -- KServe (model serving) --
+    # -- KServe (model serving) + MaaS --
     kserve:
       managementState: Managed
+      modelsAsService:
+        managementState: Managed
       nim:
         managementState: Managed
       rawDeploymentServiceConfig: Headed

--- a/manifests/04-rhoai-config/odh-dashboard-config.yaml
+++ b/manifests/04-rhoai-config/odh-dashboard-config.yaml
@@ -14,7 +14,6 @@ spec:
     disableModelRegistry: false
     disableTracking: false
     genAiStudio: true
-    maasAuthPolicies: true
     modelAsService: true
     observabilityDashboard: true
   hardwareProfileOrder: []

--- a/manifests/06-verification/verify.sh
+++ b/manifests/06-verification/verify.sh
@@ -79,6 +79,13 @@ done
 NAMESPACE=redhat-ods-applications
 MODEL_NS=llm
 MAAS_NS=models-as-a-service
+
+# Auto-detect maas-api namespace (3.5+ uses redhat-ai-gateway-infra)
+if oc get deployment maas-api -n redhat-ai-gateway-infra &>/dev/null; then
+    MAAS_API_NS=redhat-ai-gateway-infra
+else
+    MAAS_API_NS="$NAMESPACE"
+fi
 MODEL_NAME=facebook-opt-125m-simulated
 
 if [ "$DISCONNECTED" = true ]; then
@@ -237,7 +244,7 @@ else
 fi
 
 # maas-api
-MAAS_API_READY=$(oc get deployment maas-api -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+MAAS_API_READY=$(oc get deployment maas-api -n "$MAAS_API_NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 if [ "${MAAS_API_READY:-0}" -ge 1 ]; then
     log_pass "maas-api is running ($MAAS_API_READY replica(s))"
 else
@@ -260,12 +267,15 @@ else
     log_fail "Authorino not ready"
 fi
 
-# ModelsAsServiceReady
-MAAS_READY=$(oc get datasciencecluster default-dsc -o jsonpath='{.status.conditions[?(@.type=="ModelsAsServiceReady")].status}' 2>/dev/null || echo "Unknown")
+# ModelsAsServiceReady (3.4) or ModelsAsAServiceReady (3.5+)
+MAAS_READY=$(oc get datasciencecluster default-dsc -o jsonpath='{.status.conditions[?(@.type=="ModelsAsServiceReady")].status}' 2>/dev/null || echo "")
+if [ -z "$MAAS_READY" ]; then
+    MAAS_READY=$(oc get datasciencecluster default-dsc -o jsonpath='{.status.conditions[?(@.type=="ModelsAsAServiceReady")].status}' 2>/dev/null || echo "Unknown")
+fi
 if [ "$MAAS_READY" = "True" ]; then
-    log_pass "ModelsAsServiceReady=True"
+    log_pass "ModelsAs(A)ServiceReady=True"
 else
-    log_fail "ModelsAsServiceReady=$MAAS_READY"
+    log_fail "ModelsAs(A)ServiceReady=$MAAS_READY"
 fi
 
 # Health endpoint (try with --resolve to bypass DNS cache for cloud LB hostnames)

--- a/scripts/cleanup-maas.sh
+++ b/scripts/cleanup-maas.sh
@@ -429,6 +429,7 @@ if should_run 7 && [ "$KEEP_OPERATORS" = false ]; then
     # Clean up RHOAI-managed namespaces
     delete_namespace "redhat-ods-applications"
     delete_namespace "redhat-ods-monitoring"
+    delete_namespace "redhat-ai-gateway-infra"
     delete_namespace "rhods-notebooks"
     delete_namespace "rhoai-model-registries"
     # models-as-a-service may have Tenant CRs with finalizers stuck if operator is gone

--- a/scripts/cleanup-maas.sh
+++ b/scripts/cleanup-maas.sh
@@ -300,6 +300,11 @@ if should_run 5; then
     delete_if_exists secret postgres-creds "$NAMESPACE"
     delete_if_exists secret maas-db-config "$NAMESPACE"
 
+    # Clean up 3.5+ mirrored secret and namespace
+    if oc get secret maas-db-config -n redhat-ai-gateway-infra &>/dev/null 2>&1; then
+        delete_if_exists secret maas-db-config redhat-ai-gateway-infra
+    fi
+
     log_info "MaaS platform cleanup complete"
 fi
 
@@ -340,11 +345,12 @@ if should_run 6; then
         fi
     fi
 
-    # Remove gateway-access label from redhat-ods-applications
+    # Remove gateway-access labels from both possible namespaces
     if [ "$DRY_RUN" = false ]; then
         oc label namespace "$NAMESPACE" maas.opendatahub.io/gateway-access- 2>/dev/null || true
+        oc label namespace redhat-ai-gateway-infra maas.opendatahub.io/gateway-access- 2>/dev/null || true
     else
-        log_info "[DRY RUN] Would remove gateway-access label from $NAMESPACE"
+        log_info "[DRY RUN] Would remove gateway-access label from $NAMESPACE and redhat-ai-gateway-infra"
     fi
 
     # MetalLB (if installed by setup-maas.sh)

--- a/scripts/deploy-model.sh
+++ b/scripts/deploy-model.sh
@@ -5,13 +5,14 @@
 # Supports auto-detection of GPU capabilities to select the appropriate model:
 #   - No GPU             -> simulator (CPU-only mock)
 #   - GPU VRAM >= 40 GiB -> gpt-oss-20b
-#   - GPU VRAM <  40 GiB -> granite-tiny-gpu
+#   - GPU VRAM >= 16 GiB -> gemma
+#   - GPU VRAM <  16 GiB -> granite-tiny-gpu
 #
 # Usage:
 #   ./scripts/deploy-model.sh [OPTIONS]
 #
 # Options:
-#   --model <name>  Model to deploy: simulator, granite-tiny-gpu, gpt-oss-20b, auto (default: auto)
+#   --model <name>  Model to deploy: simulator, granite-tiny-gpu, gemma, gpt-oss-20b, auto (default: auto)
 #   --dry-run       Preview without applying
 #   -h, --help      Show this help message
 #

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -61,6 +61,7 @@ WITH_EXTERNAL_MODELS=false
 MAAS_HOSTNAME="${MAAS_HOSTNAME:-}"
 EXTERNAL_MODEL_PROVIDER="${EXTERNAL_MODEL_PROVIDER:-openai}"
 EXTERNAL_MODEL_API_KEY="${EXTERNAL_MODEL_API_KEY:-}"
+RHOAI_TARGET_VERSION=""
 DISCONNECTED=${DISCONNECTED:-false}
 DRY_RUN=false
 
@@ -75,18 +76,20 @@ while [[ $# -gt 0 ]]; do
         --maas-hostname) MAAS_HOSTNAME="$2"; shift 2 ;;
         --external-model-provider) EXTERNAL_MODEL_PROVIDER="$2"; shift 2 ;;
         --external-model-api-key) EXTERNAL_MODEL_API_KEY="$2"; shift 2 ;;
+        --rhoai-version) RHOAI_TARGET_VERSION="$2"; shift 2 ;;
         --disconnected) DISCONNECTED=true; shift ;;
         --dry-run) DRY_RUN=true; shift ;;
         -h|--help)
             cat <<'EOF'
 Usage: setup-maas.sh [OPTIONS]
 
-End-to-end MaaS deployment on RHOAI 3.4. Runs all phases from operator
+End-to-end MaaS deployment on RHOAI 3.4/3.5. Runs all phases from operator
 installation through model deployment and verification. Each phase is
 idempotent  - re-running skips what's already done.
 
 Options:
   --model <name>       Model: simulator, granite-tiny-gpu, gpt-oss-20b, gemma, auto (default: auto)
+  --rhoai-version <v>  RHOAI version: 3.4 or 3.5 (default: 3.5). Auto-detects if already installed.
   --from-phase <N>     Start from phase N (0-8, default: 0)
   --maas-hostname <h>  Custom gateway hostname (default: maas.<cluster-domain>, or MAAS_HOSTNAME env var)
   --skip-models        Skip Phase 5 (model deployment)
@@ -103,7 +106,7 @@ Phases:
   0  Preflight          Detect cluster state, decide which phases to run
   1  Operators          Install required operator subscriptions (RHOAI, RHCL, etc.)
   2  Platform config    Kuadrant, UWM, GatewayClass, Gateway
-  3  RHOAI config       DSC with modelsAsService: Managed, Dashboard flags
+  3  RHOAI config       DSC with MaaS: Managed, Dashboard flags
   4  MaaS platform      PostgreSQL secrets/deployment, Authorino TLS
   5  Deploy model       Auto-detect GPU, apply model Kustomize manifests
   6  Verify             6-phase E2E verification (API, auth, rate limits)
@@ -201,6 +204,34 @@ log_info "Platform type: ${PLATFORM_TYPE} (cloud LB: ${IS_CLOUD_PLATFORM})"
 # Note: avoid grep -q in pipelines  - with pipefail, grep -q causes SIGPIPE (exit 141)
 RHOAI_CSVS=$(oc get csv -n redhat-ods-operator --no-headers 2>/dev/null || true)
 echo "$RHOAI_CSVS" | grep rhods >/dev/null 2>&1 && HAS_RHOAI_CSV=true
+
+# Detect installed RHOAI version and resolve effective version
+RHOAI_INSTALLED_VERSION=""
+if [ "$HAS_RHOAI_CSV" = true ]; then
+    RHOAI_INSTALLED_VERSION=$(echo "$RHOAI_CSVS" | grep rhods | awk '{print $1}' | grep -oE '[0-9]+\.[0-9]+' | head -1)
+fi
+if [ -n "$RHOAI_INSTALLED_VERSION" ]; then
+    RHOAI_MAJOR_MINOR="$RHOAI_INSTALLED_VERSION"
+    if [ -n "$RHOAI_TARGET_VERSION" ] && [ "$RHOAI_TARGET_VERSION" != "$RHOAI_MAJOR_MINOR" ]; then
+        log_warn "RHOAI $RHOAI_MAJOR_MINOR already installed, ignoring --rhoai-version $RHOAI_TARGET_VERSION"
+    fi
+elif [ -n "$RHOAI_TARGET_VERSION" ]; then
+    RHOAI_MAJOR_MINOR="$RHOAI_TARGET_VERSION"
+else
+    RHOAI_MAJOR_MINOR="3.5"
+fi
+
+# Derive namespace layout based on RHOAI version
+GATEWAY_INFRA_NS=redhat-ai-gateway-infra
+IS_35_PLUS=false
+if printf '%s\n' "3.5" "$RHOAI_MAJOR_MINOR" | sort -V | head -1 | grep -qx "3.5"; then
+    IS_35_PLUS=true
+fi
+if [ "$IS_35_PLUS" = true ]; then
+    MAAS_API_NS="$GATEWAY_INFRA_NS"
+else
+    MAAS_API_NS="$NAMESPACE"
+fi
 RHCL_CSVS=$(oc get csv -n openshift-operators --no-headers 2>/dev/null || true)
 echo "$RHCL_CSVS" | grep rhcl >/dev/null 2>&1 && HAS_RHCL_CSV=true
 oc get kuadrant kuadrant -n kuadrant-system &>/dev/null && HAS_KUADRANT=true
@@ -211,11 +242,18 @@ oc get gateway maas-default-gateway -n openshift-ingress &>/dev/null && HAS_GATE
 oc get datasciencecluster default-dsc &>/dev/null && HAS_DSC=true
 if [ "$HAS_DSC" = true ]; then
     MAAS_STATE=$(oc get datasciencecluster default-dsc -o jsonpath='{.spec.components.kserve.modelsAsService.managementState}' 2>/dev/null || echo "")
-    [ "$MAAS_STATE" = "Managed" ] && HAS_MAAS_MANAGED=true
+    MAAS_STATE_35=$(oc get datasciencecluster default-dsc -o jsonpath='{.spec.components.aigateway.modelsAsAService.managementState}' 2>/dev/null || echo "")
+    [ "$MAAS_STATE" = "Managed" ] || [ "$MAAS_STATE_35" = "Managed" ] && HAS_MAAS_MANAGED=true
 fi
 oc get deployment postgres -n "$NAMESPACE" &>/dev/null && HAS_POSTGRES=true
-oc get deployment maas-api -n "$NAMESPACE" &>/dev/null && HAS_MAAS_API=true
-oc get tenant -n models-as-a-service &>/dev/null && HAS_TENANT=true
+oc get deployment maas-api -n "$MAAS_API_NS" &>/dev/null && HAS_MAAS_API=true
+if [ "$HAS_MAAS_API" = false ]; then
+    oc get deployment maas-api -n "$NAMESPACE" &>/dev/null && HAS_MAAS_API=true && MAAS_API_NS="$NAMESPACE"
+fi
+# 3.5+ uses Config CR, 3.4 uses Tenant CR
+TENANT_COUNT=$(oc get tenant -n models-as-a-service --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+CONFIG_COUNT=$(oc get configs.maas.opendatahub.io --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+{ [ "$TENANT_COUNT" -gt 0 ] || [ "$CONFIG_COUNT" -gt 0 ]; } 2>/dev/null && HAS_TENANT=true
 MODEL_COUNT=$(oc get llminferenceservice -n llm --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
 [ "$MODEL_COUNT" -gt 0 ] 2>/dev/null && HAS_MODELS=true
 METALLB_CSVS=$(oc get csv -n metallb-system --no-headers 2>/dev/null || true)
@@ -223,6 +261,8 @@ echo "$METALLB_CSVS" | grep "metallb-operator" >/dev/null 2>&1 && HAS_METALLB=tr
 
 echo ""
 log_info "Detected state:"
+log_info "  RHOAI version:      ${RHOAI_MAJOR_MINOR} (3.5+: ${IS_35_PLUS})"
+log_info "  maas-api namespace: ${MAAS_API_NS}"
 log_info "  RHOAI operator:     $([ "$HAS_RHOAI_CSV" = true ] && echo "installed" || echo "not found")"
 log_info "  RHCL operator:      $([ "$HAS_RHCL_CSV" = true ] && echo "installed" || echo "not found")"
 log_info "  Kuadrant CR:        $([ "$HAS_KUADRANT" = true ] && echo "ready" || echo "not found")"
@@ -268,6 +308,14 @@ if should_run 1; then
     if [ "$HAS_RHOAI_CSV" = true ] && [ "$HAS_RHCL_CSV" = true ]; then
         log_info "Required operators already installed, skipping"
     else
+        RESTORE_SUB=false
+        if [ "$IS_35_PLUS" = false ] && [ "$HAS_RHOAI_CSV" != true ]; then
+            sed -i.bak 's/channel: stable-3.x/channel: stable-3.4/' \
+                "$MANIFESTS_DIR/01-prerequisites/operators/rhoai-operator/subscription.yaml"
+            log_info "Patched RHOAI subscription to channel: stable-3.4"
+            RESTORE_SUB=true
+        fi
+
         log_info "Applying operator subscriptions..."
         run_cmd oc apply -k "$MANIFESTS_DIR/01-prerequisites/operators/"
         log_info "Operator subscriptions applied"
@@ -351,6 +399,11 @@ for item in data.get('items',[]):
             else
                 log_warn "  Could not find RELATED_IMAGE_WASMSHIM in RHCL CSV - WASM shim may fail on disconnected"
             fi
+        fi
+        if [ "${RESTORE_SUB:-false}" = true ]; then
+            mv "$MANIFESTS_DIR/01-prerequisites/operators/rhoai-operator/subscription.yaml.bak" \
+               "$MANIFESTS_DIR/01-prerequisites/operators/rhoai-operator/subscription.yaml"
+            log_info "Restored RHOAI subscription to channel: stable-3.x"
         fi
     fi
 fi
@@ -593,8 +646,31 @@ if should_run 2; then
         fi
     fi
 
-    # Label redhat-ods-applications for Gateway route binding (best practice: least privilege)
-    oc label namespace redhat-ods-applications maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
+    # Step 7: Ensure Kuadrant sees the Gateway API provider (Istio race fix)
+    # If Kuadrant was pre-existing but Istio was just installed via GatewayClass,
+    # the operator may not have discovered it. Restart if MissingDependency.
+    if [ "$DRY_RUN" = false ]; then
+        KUADRANT_READY=$(oc get kuadrant kuadrant -n kuadrant-system \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+        if [ "$KUADRANT_READY" != "True" ]; then
+            KUADRANT_REASON=$(oc get kuadrant kuadrant -n kuadrant-system \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' 2>/dev/null || echo "")
+            if [ "$KUADRANT_REASON" = "MissingDependency" ]; then
+                log_warn "Kuadrant reports MissingDependency after Gateway setup - restarting operator pod..."
+                KUADRANT_POD=$(oc get pods -n openshift-operators --no-headers 2>/dev/null \
+                    | grep kuadrant-operator-controller | awk '{print $1}' | head -1)
+                if [ -n "$KUADRANT_POD" ]; then
+                    oc delete pod "$KUADRANT_POD" -n openshift-operators 2>/dev/null || true
+                    sleep 10
+                    oc wait kuadrant/kuadrant -n kuadrant-system --for=condition=Ready --timeout=120s 2>/dev/null || \
+                        log_warn "Kuadrant still not Ready after operator restart"
+                fi
+            fi
+        fi
+    fi
+
+    # Label namespace for Gateway route binding (best practice: least privilege)
+    oc label namespace "$MAAS_API_NS" maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
 fi
 
 # =============================================================================
@@ -618,6 +694,14 @@ if should_run 3; then
             -n "$NAMESPACE" \
             --from-literal=DB_CONNECTION_URL="postgresql://maas:${POSTGRES_PASSWORD}@postgres.${NAMESPACE}.svc:5432/maas?sslmode=disable"
         log_info "PostgreSQL secrets created"
+
+        if [ "$IS_35_PLUS" = true ]; then
+            oc create namespace "$GATEWAY_INFRA_NS" --dry-run=client -o yaml | oc apply -f - >/dev/null 2>&1 || true
+            run_cmd oc create secret generic maas-db-config \
+                -n "$GATEWAY_INFRA_NS" \
+                --from-literal=DB_CONNECTION_URL="postgresql://maas:${POSTGRES_PASSWORD}@postgres.${NAMESPACE}.svc:5432/maas?sslmode=disable"
+            log_info "Mirrored maas-db-config to ${GATEWAY_INFRA_NS} (RHOAI 3.5+ maas-api location)"
+        fi
     fi
 
     # Step 2: PostgreSQL deployment
@@ -668,17 +752,23 @@ if should_run 3; then
 fi
 
 # =============================================================================
-# Phase 4: RHOAI Configuration (DSC enables modelsAsService after DB exists)
+# Phase 4: RHOAI Configuration (DSC enables MaaS after DB exists)
 # =============================================================================
 if should_run 4; then
     log_phase 4 "RHOAI Configuration"
 
     if [ "$HAS_MAAS_MANAGED" = true ]; then
-        log_info "DSC already has modelsAsService: Managed, skipping"
+        log_info "DSC already has MaaS: Managed, skipping"
     else
         log_step "Applying DSC and DSCI..."
         run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/dscinitialization.yaml"
-        run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/datasciencecluster.yaml"
+        if [ "$IS_35_PLUS" = true ]; then
+            log_info "Using RHOAI 3.5+ DSC (aigateway.modelsAsAService)"
+            run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/datasciencecluster.yaml"
+        else
+            log_info "Using RHOAI 3.4 DSC (kserve.modelsAsService)"
+            run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/datasciencecluster-34.yaml"
+        fi
         run_cmd oc apply -f "$MANIFESTS_DIR/04-rhoai-config/hardwareprofile.yaml"
         log_info "DSC/DSCI/HardwareProfile applied"
 
@@ -715,17 +805,25 @@ if should_run 4; then
         log_info "Dashboard config applied"
     fi
 
-    # Wait for maas-api (should start healthy since PostgreSQL was deployed in Phase 3)
+    # Wait for maas-api (probes both namespaces - 3.5+ uses redhat-ai-gateway-infra)
     log_step "Waiting for maas-api deployment"
     if [ "$HAS_MAAS_API" = true ]; then
-        log_info "maas-api already running"
+        log_info "maas-api already running in ${MAAS_API_NS}"
     elif [ "$DRY_RUN" = false ]; then
         TIMEOUT=300
         ELAPSED=0
+        MAAS_API_FOUND=false
         while [ $ELAPSED -lt $TIMEOUT ]; do
-            if oc get deployment maas-api -n "$NAMESPACE" &>/dev/null; then
-                log_info "maas-api deployment found"
-                oc rollout status deployment/maas-api -n "$NAMESPACE" --timeout=180s 2>/dev/null || \
+            for _ns in "$GATEWAY_INFRA_NS" "$NAMESPACE"; do
+                if oc get deployment maas-api -n "$_ns" &>/dev/null; then
+                    MAAS_API_NS="$_ns"
+                    MAAS_API_FOUND=true
+                    break
+                fi
+            done
+            if [ "$MAAS_API_FOUND" = true ]; then
+                log_info "maas-api deployment found in ${MAAS_API_NS}"
+                oc rollout status deployment/maas-api -n "$MAAS_API_NS" --timeout=180s 2>/dev/null || \
                     log_warn "maas-api rollout did not complete within 180s"
                 break
             fi
@@ -738,14 +836,22 @@ if should_run 4; then
         [ $ELAPSED -ge $TIMEOUT ] && log_warn "maas-api not found after ${TIMEOUT}s  - operator may still be reconciling"
     fi
 
-    # Verify Tenant CR
+    # Verify MaaS readiness (3.5+ uses Config CR, 3.4 uses Tenant CR)
     if [ "$DRY_RUN" = false ]; then
-        TENANT_READY=$(oc get tenant default-tenant -n models-as-a-service \
-            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
-        if [ "$TENANT_READY" = "True" ]; then
-            log_info "Tenant CR: Ready"
+        if [ "$IS_35_PLUS" = true ]; then
+            if oc get configs.maas.opendatahub.io default &>/dev/null; then
+                log_info "MaaS Config CR: exists"
+            else
+                log_warn "MaaS Config CR not found yet"
+            fi
         else
-            log_warn "Tenant CR not Ready yet (status: ${TENANT_READY:-not found})"
+            TENANT_READY=$(oc get tenant default-tenant -n models-as-a-service \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+            if [ "$TENANT_READY" = "True" ]; then
+                log_info "Tenant CR: Ready"
+            else
+                log_warn "Tenant CR not Ready yet (status: ${TENANT_READY:-not found})"
+            fi
         fi
     fi
 
@@ -1188,7 +1294,7 @@ else
     RHOAI_VERSION=$(oc get csv -n redhat-ods-operator -l operators.coreos.com/rhods-operator.redhat-ods-operator= -o jsonpath='{.items[0].spec.version}' 2>/dev/null || echo "unknown")
     GW_STATUS=$(oc get gateway maas-default-gateway -n openshift-ingress \
         -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null || echo "Unknown")
-    API_READY=$(oc get deployment maas-api -n "$NAMESPACE" \
+    API_READY=$(oc get deployment maas-api -n "$MAAS_API_NS" \
         -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
     HEALTH=$(curl -sk --connect-timeout 10 --max-time 15 -o /dev/null -w '%{http_code}' "${MAAS_URL}/maas-api/health" 2>/dev/null) || true
     [ -z "$HEALTH" ] && HEALTH="000"

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -106,8 +106,8 @@ Phases:
   0  Preflight          Detect cluster state, decide which phases to run
   1  Operators          Install required operator subscriptions (RHOAI, RHCL, etc.)
   2  Platform config    Kuadrant, UWM, GatewayClass, Gateway
-  3  RHOAI config       DSC with MaaS: Managed, Dashboard flags
-  4  MaaS platform      PostgreSQL secrets/deployment, Authorino TLS
+  3  MaaS platform      PostgreSQL secrets/deployment, Authorino TLS
+  4  RHOAI config       DSC with MaaS: Managed, Dashboard flags
   5  Deploy model       Auto-detect GPU, apply model Kustomize manifests
   6  Verify             6-phase E2E verification (API, auth, rate limits)
   7  Observability      Tempo + OpenTelemetry + COO + Gateway telemetry (only with --with-observability)
@@ -116,8 +116,8 @@ Phases:
 Auto-detection (--model auto):
   No GPU             -> simulator (CPU-only, ~30s startup)
   GPU VRAM >= 40 GiB -> gpt-oss-20b (L40S, A100, H100)
-  GPU VRAM >= 16 GiB -> gemma (A10G, L4)
-  GPU VRAM <  16 GiB -> granite-tiny-gpu (T4)
+  GPU VRAM >= 16 GiB -> gemma (L4, L40)
+  GPU VRAM <  16 GiB -> granite-tiny-gpu (L4)
 EOF
             exit 0
             ;;

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -426,20 +426,19 @@ if should_run 2; then
         run_cmd oc apply -f "$MANIFESTS_DIR/02-platform-config/kuadrant/kuadrant.yaml"
 
         if [ "$DRY_RUN" = false ]; then
-            if ! oc wait --for=condition=Ready kuadrant/kuadrant -n kuadrant-system --timeout=60s 2>/dev/null; then
+            if oc wait --for=condition=Ready kuadrant/kuadrant -n kuadrant-system --timeout=60s 2>/dev/null; then
+                log_info "Kuadrant: Ready"
+            else
                 KUADRANT_REASON=$(oc get kuadrant kuadrant -n kuadrant-system \
                     -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' 2>/dev/null || echo "")
                 if [ "$KUADRANT_REASON" = "MissingDependency" ]; then
-                    log_warn "Kuadrant reports MissingDependency (Istio race)  - restarting operator pod..."
-                    oc delete pod -n openshift-operators \
-                        $(oc get pods -n openshift-operators --no-headers 2>/dev/null | grep kuadrant-operator | awk '{print $1}' | head -1) 2>/dev/null || \
-                        oc delete pod -n openshift-operators -l control-plane=controller-manager,app=kuadrant 2>/dev/null || true
-                    log_info "Operator pod restarted, waiting for Kuadrant Ready..."
+                    log_warn "Kuadrant reports MissingDependency - expected on fresh install (Istio not yet installed via GatewayClass)"
+                    log_info "Kuadrant will be reconciled after GatewayClass creates the Istio provider (Step 7)"
+                else
+                    log_error "Kuadrant did not become Ready (reason: $KUADRANT_REASON) - check: oc get kuadrant kuadrant -n kuadrant-system -o yaml"
+                    exit 1
                 fi
-                oc wait --for=condition=Ready kuadrant/kuadrant -n kuadrant-system --timeout=180s 2>/dev/null || \
-                    { log_error "Kuadrant did not become Ready  - check: oc get kuadrant kuadrant -n kuadrant-system -o yaml"; exit 1; }
             fi
-            log_info "Kuadrant: Ready"
         else
             log_info "[DRY RUN] Would wait for Kuadrant Ready"
         fi
@@ -647,8 +646,9 @@ if should_run 2; then
     fi
 
     # Step 7: Ensure Kuadrant sees the Gateway API provider (Istio race fix)
-    # If Kuadrant was pre-existing but Istio was just installed via GatewayClass,
-    # the operator may not have discovered it. Restart if MissingDependency.
+    # On fresh installs, Kuadrant CR was created before GatewayClass (which provisions Istio).
+    # On pre-existing clusters, Kuadrant may have been installed before Istio too.
+    # Either way, restart the operator if it still reports MissingDependency now that Gateway is up.
     if [ "$DRY_RUN" = false ]; then
         KUADRANT_READY=$(oc get kuadrant kuadrant -n kuadrant-system \
             -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
@@ -663,8 +663,11 @@ if should_run 2; then
                     oc delete pod "$KUADRANT_POD" -n openshift-operators 2>/dev/null || true
                     sleep 10
                     oc wait kuadrant/kuadrant -n kuadrant-system --for=condition=Ready --timeout=120s 2>/dev/null || \
-                        log_warn "Kuadrant still not Ready after operator restart"
+                        { log_error "Kuadrant did not become Ready after Gateway setup and operator restart"; exit 1; }
+                    log_info "Kuadrant: Ready (after operator restart)"
                 fi
+            else
+                log_warn "Kuadrant not Ready (reason: $KUADRANT_REASON) - may need manual investigation"
             fi
         fi
     fi


### PR DESCRIPTION
## Summary

RHOAI 3.5 modularized the AI Gateway component - `kserve.modelsAsService` becomes `aigateway.modelsAsAService` in the DSC (RHOAIENG-88589). This PR adds dual-version support so the guide and scripts work on both 3.4 and 3.5.

Main changes:
- **setup-maas.sh**: auto-detects RHOAI version from CSV, new `--rhoai-version` flag, mirrors `maas-db-config` secret to `redhat-ai-gateway-infra` for 3.5+, fixes Kuadrant MissingDependency race condition after Istio install, handles Config CR (3.5) vs Tenant CR (3.4)
- **DSC manifests**: `datasciencecluster.yaml` is 3.5 (aigateway), new `datasciencecluster-34.yaml` for 3.4 (kserve)
- **verify.sh**: checks both `ModelsAsServiceReady` (3.4) and `ModelsAsAServiceReady` (3.5) condition names, auto-detects maas-api namespace
- **cleanup-maas.sh**: cleans mirrored secret and gateway-access label from both namespaces, adds `redhat-ai-gateway-infra` namespace teardown
- **AsciiDoc docs**: version tabs on DSC/platform-config/verification/quick-start pages, dual doc links for 3.4/3.5
- **GPU references**: fixed stale A10G/T4 references across scripts and disconnected guide, added gemma model tier
- **OdhDashboardConfig**: removed `maasAuthPolicies` field (dropped from CRD in 3.5 GA)

## Testing

Validated across 10 walkthroughs on different cluster configurations:

| Cluster | Platform | OCP | RHOAI | GPU | Result |
|---------|----------|-----|-------|-----|--------|
| cluster-p25bj | None (SNO) | 4.21.29 | 3.5 nightly | No | 15/15 |
| cluster-5sqvv | None (SNO) | 4.21.29 | 3.4.3 | No | 15/15 |
| sandbox1390 | AWS | 4.21.29 | 3.5 nightly | L40S | 15/15 + GPU inference |
| cluster-v9sn7 | None (SNO) | 4.21.29 | 3.5.0 GA | No | 36/36 |

Key validations:
- RHOAI 3.5.0 GA from `stable-3.x` channel works end to end
- Kuadrant MissingDependency race fix validated on fresh installs
- `maasAuthPolicies` removal validated against 3.5 GA admission webhook
- Config CR (3.5) and Tenant CR (3.4) both handled correctly
- Secret mirroring to `redhat-ai-gateway-infra` works
- Full E2E review of guide content, scripts, manifests, and Antora site build - all clean

Closes #73