### PR TITLE
fix: skip ModelControllerReady check on RHOAI 3.5+

### DIFF
--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -781,10 +781,12 @@ if should_run 4; then
                 datasciencecluster/default-dsc --timeout=300s 2>/dev/null || \
                 log_warn "KserveReady did not become True within 300s"
 
-            log_info "Waiting for ModelControllerReady condition..."
-            oc wait --for=jsonpath='{.status.conditions[?(@.type=="ModelControllerReady")].status}'=True \
-                datasciencecluster/default-dsc --timeout=300s 2>/dev/null || \
-                log_warn "ModelControllerReady did not become True within 300s"
+            if [ "$IS_35_PLUS" = false ]; then
+                log_info "Waiting for ModelControllerReady condition..."
+                oc wait --for=jsonpath='{.status.conditions[?(@.type=="ModelControllerReady")].status}'=True \
+                    datasciencecluster/default-dsc --timeout=300s 2>/dev/null || \
+                    log_warn "ModelControllerReady did not become True within 300s"
+            fi
 
             if oc get crd maasmodelrefs.maas.opendatahub.io &>/dev/null; then
                 log_info "MaaS CRDs registered"


### PR DESCRIPTION
## Summary

- `ModelControllerReady` DSC condition was removed in RHOAI 3.5 - the setup script was waiting 300s for it on every fresh 3.5 install for nothing
- Gate the check behind `IS_35_PLUS=false` so it only runs for 3.4 where the condition still exists
- `KserveReady` is still present in 3.5 so that check stays unconditional

Thanks Liming Tsai for flagging this.

Closes #77

## Test plan

- [x] Syntax check (`bash -n`) passes
- [x] Fresh 3.5 install on RHPDS SNO (cluster-twhbb) - all 6 phases completed
- [x] `ModelControllerReady` check skipped (not in output), `KserveReady` passed
- [x] Verified DSC conditions on live 3.5 cluster - `ModelControllerReady` absent, `KserveReady` present
- [x] E2E verification: 15/15 checks passed