### PR TITLE
fix two bugs in the 3.4 to 3.5 upgrade path

### DIFF
--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -403,6 +403,8 @@ for item in data.get('items',[]):
         if [ "${RESTORE_SUB:-false}" = true ]; then
             mv "$MANIFESTS_DIR/01-prerequisites/operators/rhoai-operator/subscription.yaml.bak" \
                "$MANIFESTS_DIR/01-prerequisites/operators/rhoai-operator/subscription.yaml"
+            run_cmd oc patch sub rhods-operator -n redhat-ods-operator \
+                --type merge -p '{"spec":{"channel":"stable-3.x"}}'
             log_info "Restored RHOAI subscription to channel: stable-3.x"
         fi
     fi
@@ -760,7 +762,8 @@ fi
 if should_run 4; then
     log_phase 4 "RHOAI Configuration"
 
-    if [ "$HAS_MAAS_MANAGED" = true ]; then
+    if [ "$HAS_MAAS_MANAGED" = true ] && \
+       { [ "$IS_35_PLUS" = false ] || [ "$MAAS_STATE_35" = "Managed" ]; }; then
         log_info "DSC already has MaaS: Managed, skipping"
     else
         log_step "Applying DSC and DSCI..."


### PR DESCRIPTION
## Summary

Found two bugs during a 3.4 -> 3.5 upgrade battle-test on cluster-ftnvn (OCP 4.21 SNO):

- **Channel not restored on cluster**: after `--rhoai-version 3.4`, the script restored the local subscription.yaml file but never patched the live cluster subscription. The operator stayed on `stable-3.4` and never upgraded to 3.5. Fixed by adding `oc patch sub` after file restoration.
- **DSC not updated during upgrade**: `--from-phase 4` detected `kserve.modelsAsService: Managed` and skipped the DSC update. When running on 3.5, it should switch to `aigateway.modelsAsAService`. Fixed with a condition check so it only skips if the 3.5 path is already Managed.

## Test plan

- [ ] Run `setup-maas.sh --rhoai-version 3.4` on a clean cluster
- [ ] Verify subscription channel is `stable-3.x` after install (not `stable-3.4`)
- [ ] Wait for auto-upgrade to 3.5
- [ ] Run `setup-maas.sh --from-phase 4` and verify DSC switches to `aigateway.modelsAsAService`
- [ ] 15/15 verification checks pass