### PR TITLE
Add dual 3.4/3.5 support for External Models

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -339,7 +339,8 @@ oc label namespace redhat-ods-applications \
 
 NOTE: Model namespaces (`llm`, `external-models`) are labeled in their respective deployment phases.
 
-*Step 5e:* Create Passthrough Route (Non-Cloud Platforms Only)
+[id=step-5e-passthrough-route]
+=== Step 5e: Create Passthrough Route (Non-Cloud Platforms Only)
 
 If your platform type from Step 5a was `None`, `BareMetal`, or `OpenStack`, you must create a passthrough Route. This routes external traffic through the OpenShift ingress controller to the Gateway's LoadBalancer service.
 

--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -12,6 +12,29 @@ IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} docum
 
 == How It Works
 
+[tabs]
+====
+RHOAI 3.5+::
++
+--
+An external model deployment requires six resources:
+
+. *Secret* - stores the provider API key. Must have the label `inference.networking.k8s.io/bbr-managed=true` so the BBR ext-proc can inject the credential into upstream requests.
+
+. *ExternalProvider* - defines the provider endpoint and authentication configuration (API type, secret reference).
+
+. *ExternalModel* - references the provider and maps the model with routing config (`apiFormat`, `path`, `targetModel`). The BBR (Backend Binding Resolver) handles path rewriting and authentication header injection.
+
+. *MaaSModelRef* - registers the external model in the MaaS catalog so it appears in the API and can be governed.
+
+. *MaaSAuthPolicy* - grants access to specific users or groups.
+
+. *MaaSSubscription* - sets rate limits (tokens per hour) and priority.
+--
+
+RHOAI 3.4::
++
+--
 An external model deployment requires five resources:
 
 . *Secret* - stores the provider API key. Must have the label `inference.networking.k8s.io/bbr-managed=true` so the BBR ext-proc can inject the credential into upstream requests.
@@ -23,6 +46,8 @@ An external model deployment requires five resources:
 . *MaaSAuthPolicy* - grants access to specific users or groups.
 
 . *MaaSSubscription* - sets rate limits (tokens per hour) and priority.
+--
+====
 
 == Step 1: Create the Namespace and Secret
 
@@ -50,11 +75,57 @@ oc label secret openai-api-key -n external-models \
 
 IMPORTANT: The `inference.networking.k8s.io/bbr-managed=true` label is required. Without it, the BBR ext-proc will not inject the API key into upstream requests and the provider will reject calls with 401.
 
-== Step 2: Apply the ExternalModel CR
+== Step 2: Apply the External Model Resources
 
+[tabs]
+====
+RHOAI 3.5+::
++
+--
 [source,bash]
 ----
 oc apply -k manifests/08-external-models/openai/model/
+----
+
+This creates two resources - the `ExternalProvider` and `ExternalModel`:
+
+[source,yaml]
+----
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: openai
+  namespace: external-models
+spec:
+  provider: openai
+  endpoint: api.openai.com
+  auth:
+    type: apikey
+    secretRef:
+      name: openai-api-key
+---
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: gpt-4o-mini
+  namespace: external-models
+spec:
+  modelName: gpt-4o-mini
+  externalProviderRefs:
+    - ref:
+        name: openai
+      targetModel: gpt-4o-mini
+      apiFormat: openai-chat
+      path: /v1/chat/completions
+----
+--
+
+RHOAI 3.4::
++
+--
+[source,bash]
+----
+oc apply -f manifests/08-external-models/openai/model/external-model-34.yaml
 ----
 
 This creates the `ExternalModel` resource:
@@ -73,6 +144,8 @@ spec:
   credentialRef:
     name: openai-api-key
 ----
+--
+====
 
 == Step 3: Apply MaaS Governance
 
@@ -213,11 +286,58 @@ oc label secret bedrock-api-key -n external-models \
     inference.networking.k8s.io/bbr-managed=true --overwrite
 ----
 
-Apply the ExternalModel and MaaS governance resources:
+Apply the external model and MaaS governance resources:
 
+[tabs]
+====
+RHOAI 3.5+::
++
+--
 [source,bash]
 ----
 oc apply -k manifests/08-external-models/bedrock/model/
+oc apply -k manifests/08-external-models/bedrock/maas/
+----
+
+The ExternalProvider and ExternalModel CRs:
+
+[source,yaml]
+----
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: bedrock
+  namespace: external-models
+spec:
+  provider: bedrock-openai
+  endpoint: bedrock-mantle.us-east-2.api.aws
+  auth:
+    type: apikey
+    secretRef:
+      name: bedrock-api-key
+---
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: aws-gpt-oss-20b
+  namespace: external-models
+spec:
+  modelName: openai.gpt-oss-20b
+  externalProviderRefs:
+    - ref:
+        name: bedrock
+      targetModel: openai.gpt-oss-20b
+      apiFormat: openai-chat
+      path: /v1/chat/completions
+----
+--
+
+RHOAI 3.4::
++
+--
+[source,bash]
+----
+oc apply -f manifests/08-external-models/bedrock/model/external-model-34.yaml
 oc apply -k manifests/08-external-models/bedrock/maas/
 ----
 
@@ -237,6 +357,8 @@ spec:
   credentialRef:
     name: bedrock-api-key
 ----
+--
+====
 
 NOTE: The `endpoint` must match your AWS region. Replace `us-east-2` with your region if different.
 
@@ -283,6 +405,8 @@ curl -sk "${MAAS_GW}/external-models/aws-gpt-oss-20b/v1/chat/completions" \
 
 The BBR `openai` provider hardcodes the upstream path to `/v1/chat/completions`, but Gemini requires `/v1beta/openai/chat/completions`. See the <<google-gemini,Google Gemini>> section above for details. Tracked in link:https://redhat.atlassian.net/browse/RHOAIENG-68592[RHOAIENG-68592].
 
+NOTE: On RHOAI 3.5+, the `ExternalModel` CRD includes a `path` field in `externalProviderRefs` that allows overriding the upstream path. The Gemini manifest sets `path: /v1beta/openai/chat/completions`, which may resolve this issue without needing a dedicated Gemini provider translator in the BBR.
+
 == Appendix
 
 === Directory Structure
@@ -294,8 +418,10 @@ manifests/08-external-models/
     kustomization.yaml           # Top-level: namespace + model + maas
     namespace.yaml               # external-models namespace
     model/
-      kustomization.yaml
-      external-model.yaml        # ExternalModel CR (gpt-4o-mini)
+      kustomization.yaml         # References 3.5+ manifests (ExternalProvider + ExternalModel)
+      external-provider.yaml     # ExternalProvider CR (3.5+)
+      external-model.yaml        # ExternalModel CR (3.5+, references provider)
+      external-model-34.yaml     # ExternalModel CR (3.4, standalone with credentialRef)
     maas/
       kustomization.yaml
       maas-model.yaml            # MaaSModelRef
@@ -306,7 +432,9 @@ manifests/08-external-models/
     namespace.yaml
     model/
       kustomization.yaml
-      external-model.yaml        # ExternalModel CR (gemini-2.5-flash)
+      external-provider.yaml     # ExternalProvider CR (3.5+)
+      external-model.yaml        # ExternalModel CR (3.5+)
+      external-model-34.yaml     # ExternalModel CR (3.4)
     maas/
       kustomization.yaml
       maas-model.yaml
@@ -317,7 +445,9 @@ manifests/08-external-models/
     namespace.yaml
     model/
       kustomization.yaml
-      external-model.yaml        # ExternalModel CR (openai.gpt-oss-20b via Mantle)
+      external-provider.yaml     # ExternalProvider CR (3.5+)
+      external-model.yaml        # ExternalModel CR (3.5+)
+      external-model-34.yaml     # ExternalModel CR (3.4)
     maas/
       kustomization.yaml
       maas-model.yaml
@@ -336,7 +466,8 @@ The `provider` field in the ExternalModel spec maps to a BBR payload translator.
 
 == References
 
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index#maas-external-model_maas-deploy[RHOAI ExternalModel documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index#maas-external-model_maas-deploy[RHOAI 3.5 ExternalProvider documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index#maas-external-model_maas-deploy[RHOAI 3.4 ExternalModel documentation]
 * link:https://github.com/opendatahub-io/ai-gateway-payload-processing[BBR (ai-gateway-payload-processing) repository]
 * link:https://redhat.atlassian.net/browse/RHOAIENG-68592[RHOAIENG-68592 - Gemini BBR path incompatibility]
 

--- a/manifests/08-external-models/bedrock/model/external-model-34.yaml
+++ b/manifests/08-external-models/bedrock/model/external-model-34.yaml
@@ -1,0 +1,11 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: aws-gpt-oss-20b
+  namespace: external-models
+spec:
+  provider: bedrock-openai
+  targetModel: openai.gpt-oss-20b
+  endpoint: bedrock-mantle.us-east-2.api.aws
+  credentialRef:
+    name: bedrock-api-key

--- a/manifests/08-external-models/bedrock/model/external-model.yaml
+++ b/manifests/08-external-models/bedrock/model/external-model.yaml
@@ -1,11 +1,13 @@
-apiVersion: maas.opendatahub.io/v1alpha1
+apiVersion: inference.opendatahub.io/v1alpha1
 kind: ExternalModel
 metadata:
   name: aws-gpt-oss-20b
   namespace: external-models
 spec:
-  provider: bedrock-openai
-  targetModel: openai.gpt-oss-20b
-  endpoint: bedrock-mantle.us-east-2.api.aws
-  credentialRef:
-    name: bedrock-api-key
+  modelName: openai.gpt-oss-20b
+  externalProviderRefs:
+    - ref:
+        name: bedrock
+      targetModel: openai.gpt-oss-20b
+      apiFormat: openai-chat
+      path: /v1/chat/completions

--- a/manifests/08-external-models/bedrock/model/external-provider.yaml
+++ b/manifests/08-external-models/bedrock/model/external-provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: bedrock
+  namespace: external-models
+spec:
+  provider: bedrock-openai
+  endpoint: bedrock-mantle.us-east-2.api.aws
+  auth:
+    type: apikey
+    secretRef:
+      name: bedrock-api-key

--- a/manifests/08-external-models/bedrock/model/kustomization.yaml
+++ b/manifests/08-external-models/bedrock/model/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - external-provider.yaml
   - external-model.yaml

--- a/manifests/08-external-models/gemini/model/external-model-34.yaml
+++ b/manifests/08-external-models/gemini/model/external-model-34.yaml
@@ -1,0 +1,11 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: gemini-2-5-flash
+  namespace: external-models
+spec:
+  provider: openai
+  targetModel: gemini-2.5-flash
+  endpoint: generativelanguage.googleapis.com
+  credentialRef:
+    name: gemini-api-key

--- a/manifests/08-external-models/gemini/model/external-model.yaml
+++ b/manifests/08-external-models/gemini/model/external-model.yaml
@@ -1,11 +1,13 @@
-apiVersion: maas.opendatahub.io/v1alpha1
+apiVersion: inference.opendatahub.io/v1alpha1
 kind: ExternalModel
 metadata:
   name: gemini-2-5-flash
   namespace: external-models
 spec:
-  provider: openai
-  targetModel: gemini-2.5-flash
-  endpoint: generativelanguage.googleapis.com
-  credentialRef:
-    name: gemini-api-key
+  modelName: gemini-2.5-flash
+  externalProviderRefs:
+    - ref:
+        name: gemini
+      targetModel: gemini-2.5-flash
+      apiFormat: openai-chat
+      path: /v1beta/openai/chat/completions

--- a/manifests/08-external-models/gemini/model/external-provider.yaml
+++ b/manifests/08-external-models/gemini/model/external-provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: gemini
+  namespace: external-models
+spec:
+  provider: openai
+  endpoint: generativelanguage.googleapis.com
+  auth:
+    type: apikey
+    secretRef:
+      name: gemini-api-key

--- a/manifests/08-external-models/gemini/model/kustomization.yaml
+++ b/manifests/08-external-models/gemini/model/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - external-provider.yaml
   - external-model.yaml

--- a/manifests/08-external-models/openai/model/external-model-34.yaml
+++ b/manifests/08-external-models/openai/model/external-model-34.yaml
@@ -1,0 +1,11 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: gpt-4o-mini
+  namespace: external-models
+spec:
+  provider: openai
+  targetModel: gpt-4o-mini
+  endpoint: api.openai.com
+  credentialRef:
+    name: openai-api-key

--- a/manifests/08-external-models/openai/model/external-model.yaml
+++ b/manifests/08-external-models/openai/model/external-model.yaml
@@ -1,11 +1,13 @@
-apiVersion: maas.opendatahub.io/v1alpha1
+apiVersion: inference.opendatahub.io/v1alpha1
 kind: ExternalModel
 metadata:
   name: gpt-4o-mini
   namespace: external-models
 spec:
-  provider: openai
-  targetModel: gpt-4o-mini
-  endpoint: api.openai.com
-  credentialRef:
-    name: openai-api-key
+  modelName: gpt-4o-mini
+  externalProviderRefs:
+    - ref:
+        name: openai
+      targetModel: gpt-4o-mini
+      apiFormat: openai-chat
+      path: /v1/chat/completions

--- a/manifests/08-external-models/openai/model/external-provider.yaml
+++ b/manifests/08-external-models/openai/model/external-provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: openai
+  namespace: external-models
+spec:
+  provider: openai
+  endpoint: api.openai.com
+  auth:
+    type: apikey
+    secretRef:
+      name: openai-api-key

--- a/manifests/08-external-models/openai/model/kustomization.yaml
+++ b/manifests/08-external-models/openai/model/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - external-provider.yaml
   - external-model.yaml

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -1200,8 +1200,13 @@ if should_run 8 && [ "$WITH_EXTERNAL_MODELS" = true ]; then
                     log_info "Secret ${EXTMODEL_SECRET} created/updated (bbr-managed label applied)"
                 fi
 
-                log_step "Applying ExternalModel CR..."
-                run_cmd oc apply -k "${PROVIDER_DIR}/model/"
+                if [ "$IS_35_PLUS" = true ]; then
+                    log_step "Applying ExternalProvider + ExternalModel CRs (3.5+)..."
+                    run_cmd oc apply -k "${PROVIDER_DIR}/model/"
+                else
+                    log_step "Applying ExternalModel CR (3.4)..."
+                    run_cmd oc apply -f "${PROVIDER_DIR}/model/external-model-34.yaml"
+                fi
 
                 log_step "Applying MaaS governance (MaaSModelRef, AuthPolicy, Subscription)..."
                 run_cmd oc apply -k "${PROVIDER_DIR}/maas/"


### PR DESCRIPTION
## Summary

- Added ExternalProvider + ExternalModel manifests for RHOAI 3.5 (openai, gemini, bedrock) using the new `inference.opendatahub.io/v1alpha1` API
- Renamed existing 3.4 manifests to `-34` suffix (follows the DSC naming pattern)
- Added `[tabs]` blocks in `08-external-models.adoc` for version-specific YAML and commands (same pattern as `04-rhoai-config.adoc`)
- Added `IS_35_PLUS` branching in `setup-maas.sh` Phase 8 to apply correct manifests per version
- Made Step 5e heading more visible in platform-config page
- Note: the 3.5 Gemini `path` field (`/v1beta/openai/chat/completions`) may fix the Gemini 404 issue (RHOAIENG-68592) without needing a dedicated BBR translator

## Test plan

- [x] Deployed ExternalProvider + ExternalModel (3.5 API) on RHOAI 3.5 cluster (cluster-2nvj5)
- [x] Both reached `Ready` state
- [x] MaaSModelRef reached `Ready` with gateway endpoint
- [x] Inference tested through MaaS gateway - received successful response from gpt-4o-mini
- [ ] Verify tabs render correctly in Antora build
- [ ] Test setup-maas.sh automation with `--from-phase 8`

Closes #87