### PR TITLE
feat: add Loki-based usage dashboards for RHOAI 3.5+

### DIFF
--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -12,6 +12,8 @@ This phase adds *optional* observability enhancements on top of UWM:
 
 . *Gateway Telemetry* - per-model, per-user, per-subscription usage metrics on the MaaS gateway. Adds fine-grained labels (`model`, `user`, `subscription`, `organization_id`, `cost_center`) to gateway metrics for usage attribution and billing.
 
+. *Loki Operator + Usage Dashboards* (RHOAI 3.5+ only) - log-based per-request usage tracking. The gateway emits structured OTLP access logs with token counts, user identity, and subscription info. Logs are shipped to a LokiStack via an OpenTelemetry Collector. The RHOAI console shows admin and user-scoped usage dashboards under *Observe & monitor*.
+
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
 
 IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
@@ -111,9 +113,78 @@ Once COO is installed and the MaaS gateway is running:
 oc apply -k manifests/07-observability/telemetry/
 ----
 
+== Step 6: Usage Dashboards with Loki (RHOAI 3.5+ Only)
+
+RHOAI 3.5 introduces log-based usage dashboards that provide per-request token consumption, user attribution, and subscription tracking. Unlike the Prometheus-based metrics (which aggregate data), this approach emits structured OTLP access logs from the gateway and stores them in Loki for exact per-call granularity.
+
+When enabled, the RHOAI operator automatically creates:
+
+* *EnvoyFilter* `maas-model-access-logs` - emits OTLP structured access logs from the gateway on every inference request
+* *OpenTelemetry Collector* `usage-logs` - collects the access logs and exports them to the LokiStack
+* *Tenancy Proxy* `usage-logs-tenancy-proxy` - filters user-scoped usage data so non-admin users only see their own consumption
+* *Perses Dashboards* - admin (`dashboard-4-maas-usage-logs-admin`) and user-scoped (`dashboard-5-maas-usage-logs`) dashboards visible in the RHOAI console under *Observe & monitor*
+
+=== Step 6a: Install the Loki Operator
+
+[source,bash]
+----
+oc apply -k manifests/07-observability/loki/
+----
+
+Wait for the operator CSV:
+
+[source,bash]
+----
+oc wait csv -n openshift-operators-redhat \
+  -l operators.coreos.com/loki-operator.openshift-operators-redhat="" \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+----
+
+=== Step 6b: Deploy S3 Storage for Loki
+
+Loki requires S3-compatible object storage. For non-production deployments, the guide includes a MinIO setup:
+
+[source,bash]
+----
+oc apply -k manifests/07-observability/usage-logging/
+----
+
+This deploys MinIO in `redhat-ods-monitoring`, creates a `loki` bucket, a storage secret, and the LokiStack CR.
+
+NOTE: The LokiStack manifest uses `gp3-csi` as default StorageClass (common on AWS). If your cluster uses a different default (e.g. `ocs-external-storagecluster-ceph-rbd` on OCS), edit `manifests/07-observability/usage-logging/lokistack.yaml` before applying. For production, replace MinIO with an ObjectBucketClaim (NooBaa/ODF) or a cloud S3 bucket and update `minio-secret` with the real credentials.
+
+Wait for the LokiStack to be ready:
+
+[source,bash]
+----
+oc wait lokistack/usage -n redhat-ods-monitoring \
+  --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=True --timeout=300s
+----
+
+=== Step 6c: Enable Usage Logging
+
+Patch the MaaS Config to enable the usage logging pipeline:
+
+[source,bash]
+----
+oc patch configs.maas.opendatahub.io default --type=merge \
+  -p '{"spec":{"usageLogging":true}}'
+----
+
+The RHOAI operator will create the EnvoyFilter, OTEL Collector, Tenancy Proxy, and Perses Dashboards automatically. Verify:
+
+[source,bash]
+----
+oc get envoyfilter maas-model-access-logs -n openshift-ingress
+oc get opentelemetrycollector usage-logs -n redhat-ods-monitoring
+oc get persesdashboard -n redhat-ods-monitoring | grep usage-logs
+----
+
+The usage dashboards will appear in the RHOAI console under *Observe & monitor > Dashboard*, showing per-model token consumption, per-user breakdowns, and subscription usage.
+
 == Verification
 
-Check all three observability operators are installed:
+Check all four observability operators are installed:
 
 [source,bash]
 ----
@@ -125,6 +196,9 @@ oc get csv -n openshift-opentelemetry-operator | grep opentelemetry
 
 oc get csv -n openshift-cluster-observability-operator | grep cluster-observability-operator
 # Expected: cluster-observability-operator   Succeeded
+
+oc get csv -n openshift-operators-redhat | grep loki
+# Expected: loki-operator   Succeeded
 ----
 
 Check the required CRDs are registered:
@@ -139,6 +213,9 @@ oc get crd opentelemetrycollectors.opentelemetry.io
 
 # COO / Perses
 oc get crd perses.perses.dev
+
+# Loki
+oc get crd lokistacks.loki.grafana.com
 ----
 
 Check the TelemetryPolicy exists:
@@ -177,10 +254,20 @@ manifests/07-observability/
     namespace.yaml               # COO namespace
     operatorgroup.yaml           # COO OperatorGroup
     subscription.yaml            # COO Subscription
+  loki/
+    kustomization.yaml               # Loki operator subscription
+    namespace.yaml                   # openshift-operators-redhat namespace
+    operatorgroup.yaml               # Loki OperatorGroup
+    subscription.yaml                # Loki Subscription
   telemetry/
     gateway-telemetry-policy.yaml    # Kuadrant TelemetryPolicy
     istio-gateway-telemetry.yaml     # Istio Telemetry CR
     kustomization.yaml
+  usage-logging/
+    kustomization.yaml               # MinIO + LokiStack
+    minio.yaml                       # MinIO deployment + bucket job
+    minio-secret.yaml                # S3 credentials for Loki
+    lokistack.yaml                   # LokiStack CR (edit storageClassName for your cluster)
 ----
 
 == References
@@ -191,6 +278,8 @@ manifests/07-observability/
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index#maas-observability_maas-deploy[RHOAI 3.5 Observability dashboard]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index#maas-observability_maas-deploy[RHOAI 3.4 Observability dashboard]
 * link:https://docs.kuadrant.io/dev/kuadrant-operator/doc/reference/telemetrypolicy/[Kuadrant TelemetryPolicy]
+* link:https://developers.redhat.com/articles/2026/07/06/track-model-usage-openshift-ai-usage-dashboard[Track model usage with the OpenShift AI Usage Dashboard]
+* link:https://opendatahub-io.github.io/models-as-a-service/dev/observability/setup/#logs-based-usage-dashboards[MaaS upstream - Logs-based Usage Dashboards]
 
 == Next step
 

--- a/manifests/07-observability/loki/kustomization.yaml
+++ b/manifests/07-observability/loki/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription.yaml

--- a/manifests/07-observability/loki/namespace.yaml
+++ b/manifests/07-observability/loki/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat

--- a/manifests/07-observability/loki/operatorgroup.yaml
+++ b/manifests/07-observability/loki/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-operators-redhat
+  namespace: openshift-operators-redhat
+spec:
+  upgradeStrategy: Default

--- a/manifests/07-observability/loki/subscription.yaml
+++ b/manifests/07-observability/loki/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: loki-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: stable-6.6
+  installPlanApproval: Automatic
+  name: loki-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/manifests/07-observability/usage-logging/kustomization.yaml
+++ b/manifests/07-observability/usage-logging/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - minio.yaml
+  - minio-secret.yaml
+  - lokistack.yaml

--- a/manifests/07-observability/usage-logging/lokistack.yaml
+++ b/manifests/07-observability/usage-logging/lokistack.yaml
@@ -1,0 +1,29 @@
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: usage
+  namespace: redhat-ods-monitoring
+spec:
+  limits:
+    global:
+      otlp:
+        streamLabels:
+          resourceAttributes:
+            - name: service.name
+            - name: subscription
+            - name: model
+            - name: response_type
+            - name: kubernetes_namespace_name
+  managementState: Managed
+  size: 1x.demo
+  storage:
+    schemas:
+      - effectiveDate: "2024-10-01"
+        version: v13
+    secret:
+      credentialMode: static
+      name: minio-secret
+      type: s3
+  storageClassName: gp3-csi
+  tenants:
+    mode: openshift-logging

--- a/manifests/07-observability/usage-logging/minio-secret.yaml
+++ b/manifests/07-observability/usage-logging/minio-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+  namespace: redhat-ods-monitoring
+stringData:
+  access_key_id: minio
+  access_key_secret: minio123
+  bucketnames: loki
+  endpoint: http://minio.redhat-ods-monitoring.svc:9000
+  region: us-east-1
+type: Opaque

--- a/manifests/07-observability/usage-logging/minio.yaml
+++ b/manifests/07-observability/usage-logging/minio.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+  namespace: redhat-ods-monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: redhat-ods-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: quay.io/minio/minio:latest
+          command:
+            - minio
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          env:
+            - name: MINIO_ROOT_USER
+              value: minio
+            - name: MINIO_ROOT_PASSWORD
+              value: minio123
+          ports:
+            - containerPort: 9000
+              name: api
+            - containerPort: 9001
+              name: console
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: redhat-ods-monitoring
+spec:
+  selector:
+    app: minio
+  ports:
+    - port: 9000
+      targetPort: 9000
+      name: api
+    - port: 9001
+      targetPort: 9001
+      name: console
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-create-bucket
+  namespace: redhat-ods-monitoring
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: quay.io/minio/mc:latest
+          env:
+            - name: HOME
+              value: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until mc alias set local http://minio.redhat-ods-monitoring.svc:9000 minio minio123; do
+                echo "Waiting for MinIO..."
+                sleep 5
+              done
+              mc mb local/loki --ignore-existing
+              echo "Bucket 'loki' ready"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+  backoffLimit: 5

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -23,7 +23,7 @@
 #   --from-phase <N>     Start from phase N (default: 0)
 #   --skip-models        Skip Phase 5 (model deployment)
 #   --skip-verify        Skip Phase 6 (verification)
-#   --with-observability Also run Phase 7 (Tempo + OpenTelemetry + COO + telemetry)
+#   --with-observability Also run Phase 7 (Tempo + OpenTelemetry + COO + telemetry + Loki usage dashboards)
 #   --with-external-models Also run Phase 8 (ExternalModel deployment)
 #   --maas-hostname <h>  Custom gateway hostname (default: maas.<cluster-domain>, or MAAS_HOSTNAME env var)
 #   --external-model-api-key <key>  API key for external provider (or EXTERNAL_MODEL_API_KEY env var)
@@ -95,7 +95,7 @@ Options:
   --skip-models        Skip Phase 5 (model deployment)
   --skip-verify        Skip Phase 6 (verification)
   --disconnected       Disconnected/air-gapped mode (oci:// URIs, skip Phase 8)
-  --with-observability Also run Phase 7 (Tempo + OpenTelemetry + COO + Gateway telemetry)
+  --with-observability Also run Phase 7 (Tempo + OpenTelemetry + COO + telemetry + Loki usage dashboards)
   --with-external-models Also run Phase 8 (ExternalModel deployment + test)
   --external-model-provider <p>   Provider: openai (default), gemini, bedrock (or set EXTERNAL_MODEL_PROVIDER)
   --external-model-api-key <key>  API key for external provider (or set EXTERNAL_MODEL_API_KEY)
@@ -110,7 +110,7 @@ Phases:
   4  RHOAI config       DSC with MaaS: Managed, Dashboard flags
   5  Deploy model       Auto-detect GPU, apply model Kustomize manifests
   6  Verify             6-phase E2E verification (API, auth, rate limits)
-  7  Observability      Tempo + OpenTelemetry + COO + Gateway telemetry (only with --with-observability)
+  7  Observability      Tempo + OpenTelemetry + COO + telemetry + Loki usage dashboards (only with --with-observability)
   8  External models    ExternalModel + governance (only with --with-external-models, skipped in --disconnected)
 
 Auto-detection (--model auto):
@@ -1130,6 +1130,58 @@ if should_run 7 && [ "$WITH_OBSERVABILITY" = true ]; then
     log_step "Applying Gateway telemetry..."
     run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/telemetry/"
     log_info "Gateway telemetry applied"
+
+    # Usage Dashboards with Loki (3.5+ only)
+    if [ "$IS_35_PLUS" = true ]; then
+        log_step "Installing Loki Operator (usage dashboards)..."
+        run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/loki/"
+        if [ "$DRY_RUN" = false ]; then
+            log_info "Waiting for Loki CSV..."
+            TIMEOUT=300
+            ELAPSED=0
+            while [ $ELAPSED -lt $TIMEOUT ]; do
+                LOKI_PHASE=$(oc get csv -n openshift-operators-redhat --no-headers 2>/dev/null \
+                    | grep loki-operator | awk '{print $NF}' || echo "")
+                [ "$LOKI_PHASE" = "Succeeded" ] && break
+                sleep 10
+                ELAPSED=$((ELAPSED + 10))
+            done
+            if [ "${LOKI_PHASE:-}" = "Succeeded" ]; then
+                log_info "Loki CSV: Succeeded"
+            else
+                log_warn "Loki CSV not Succeeded after ${TIMEOUT}s"
+            fi
+        fi
+
+        log_step "Deploying MinIO + LokiStack for usage logging..."
+        LOKI_STORAGE_CLASS=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null || echo "")
+        if [ -z "$LOKI_STORAGE_CLASS" ]; then
+            LOKI_STORAGE_CLASS="gp3-csi"
+            log_warn "No default StorageClass found, using fallback: ${LOKI_STORAGE_CLASS}"
+        else
+            log_info "Using default StorageClass: ${LOKI_STORAGE_CLASS}"
+        fi
+        run_cmd oc apply -f "$MANIFESTS_DIR/07-observability/usage-logging/minio.yaml"
+        run_cmd oc apply -f "$MANIFESTS_DIR/07-observability/usage-logging/minio-secret.yaml"
+        if [ "$DRY_RUN" = true ]; then
+            log_info "[DRY RUN] lokistack.yaml with storageClassName=${LOKI_STORAGE_CLASS}"
+        else
+            sed "s/storageClassName: gp3-csi/storageClassName: ${LOKI_STORAGE_CLASS}/" \
+                "$MANIFESTS_DIR/07-observability/usage-logging/lokistack.yaml" | oc apply -f -
+        fi
+
+        if [ "$DRY_RUN" = false ]; then
+            log_info "Waiting for LokiStack to be ready..."
+            oc wait lokistack/usage -n redhat-ods-monitoring \
+                --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=True --timeout=300s 2>/dev/null || \
+                log_warn "LokiStack not ready within 300s (may still be provisioning)"
+        fi
+
+        log_step "Enabling usage logging on MaaS Config..."
+        run_cmd oc patch configs.maas.opendatahub.io default --type=merge \
+            -p '{"spec":{"usageLogging":true}}'
+        log_info "Usage logging enabled - operator will create EnvoyFilter, OTEL Collector, and Perses dashboards"
+    fi
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add Loki Operator subscription (stable-6.6) and usage logging manifests (MinIO, LokiStack) to Phase 7
- New Step 6 in observability guide covering the full pipeline: Loki install -> S3 storage -> enable usage logging
- Update `setup-maas.sh` Phase 7 to auto-detect default StorageClass and deploy Loki + usage logging (3.5+ only)
- When `usageLogging: true` is set on MaaS Config, the operator auto-creates EnvoyFilter, OTEL Collector, Tenancy Proxy, and Perses dashboards

## Test plan

- [x] Deployed on cluster-68d72 (SNO, OCP 4.20, RHOAI 3.5)
- [x] LokiStack `usage` reaches Ready in `redhat-ods-monitoring`
- [x] OTEL Collector `usage-logs` running (2/2 replicas)
- [x] EnvoyFilter `maas-model-access-logs` created by operator
- [x] Perses dashboards visible (admin + user-scoped)
- [x] Test inference traffic generates log records in OTEL collector
- [x] StorageClass auto-detection works (sed substitution, no file modification)

Closes #95