### PR TITLE
feat: add Phase 9 - External OIDC Authentication with Keycloak

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -20,6 +20,9 @@
 .External Models
 * xref:08-external-models.adoc[Phase 8: External Models]
 
+.External OIDC Authentication
+* xref:09-external-oidc.adoc[Phase 9: External OIDC Authentication]
+
 .Reference
 * xref:08-architecture.adoc[Architecture & Request Flow]
 * xref:10-post-upgrade-troubleshooting.adoc[Post-Upgrade Troubleshooting]

--- a/content/modules/ROOT/pages/09-external-oidc.adoc
+++ b/content/modules/ROOT/pages/09-external-oidc.adoc
@@ -109,7 +109,7 @@ Get the Keycloak route hostname and construct the issuer URL:
 
 [source,bash]
 ----
-KEYCLOAK_HOST=$(oc get route keycloak -n maas-keycloak -o jsonpath='{.spec.host}')
+KEYCLOAK_HOST=$(oc get route -n maas-keycloak -o jsonpath='{.items[0].spec.host}')
 KEYCLOAK_ISSUER="https://${KEYCLOAK_HOST}/realms/maas"
 echo "Issuer URL: ${KEYCLOAK_ISSUER}"
 ----
@@ -297,7 +297,7 @@ Expected output:
 
 [source,bash]
 ----
-KEYCLOAK_HOST=$(oc get route keycloak -n maas-keycloak -o jsonpath='{.spec.host}')
+KEYCLOAK_HOST=$(oc get route -n maas-keycloak -o jsonpath='{.items[0].spec.host}')
 KEYCLOAK_ISSUER="https://${KEYCLOAK_HOST}/realms/maas"
 
 TOKEN=$(curl -sSk -X POST "${KEYCLOAK_ISSUER}/protocol/openid-connect/token" \
@@ -335,7 +335,7 @@ API_KEY_RESPONSE=$(curl -sSk -X POST \
     "https://maas.${CLUSTER_DOMAIN}/maas-api/v1/api-keys")
 
 echo "$API_KEY_RESPONSE" | jq .
-API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.apiKey')
+API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.key')
 ----
 
 IMPORTANT: API keys capture the user's group memberships at the time of creation. If a user is removed from a group in Keycloak, their existing API keys retain the original group associations until they expire or are manually revoked.

--- a/content/modules/ROOT/pages/09-external-oidc.adoc
+++ b/content/modules/ROOT/pages/09-external-oidc.adoc
@@ -1,0 +1,417 @@
+= Phase 9: External OIDC Authentication (Optional)
+
+NOTE: This phase requires a completed MaaS installation (through xref:04-rhoai-config.adoc[Phase 4]) and at least one model deployed (xref:05-maas-models.adoc[Phase 5]) to verify the OIDC flow end-to-end.
+
+By default, MaaS authenticates users via OpenShift tokens (TokenReview). External OIDC lets you integrate with identity providers like Keycloak, Okta, or Azure AD so users can access MaaS with their corporate credentials - no OpenShift accounts needed.
+
+TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
+
+IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service#configuring-maas-external-oidc_maas-deploy[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
+
+== How It Works
+
+MaaS uses a two-tier authentication model with external OIDC:
+
+. *Platform API access* - Users get an OIDC token from the identity provider and use it as a Bearer token to call the MaaS API (list models, create API keys, manage subscriptions).
+
+. *Model inference* - Users create an API key through the MaaS API using their OIDC token. The API key is then used for inference requests (`/v1/chat/completions`). API keys capture the user's group memberships at creation time.
+
+Group-based access control works through OIDC token claims:
+
+. The OIDC provider defines user groups (e.g., `data-scientists`, `ml-engineers`)
+. The OIDC token includes a `groups` claim with the user's group memberships
+. MaaS subscriptions and authorization policies reference these group names
+. MaaS validates group memberships directly from the OIDC token - no OpenShift group sync needed
+
+NOTE: Group names in MaaS subscriptions must match the group names in the OIDC token `groups` claim exactly.
+
+IMPORTANT: When using external OIDC, users create API keys through the MaaS API using `curl` or other HTTP clients. The {rhoai} dashboard uses OpenShift OAuth and does not support API key creation for external OIDC users.
+
+== Automated Setup
+
+To deploy Keycloak, configure OIDC, and run verification in one go:
+
+[source,bash]
+----
+# Deploy Keycloak + configure MaaS for OIDC
+./manifests/09-external-oidc/setup-keycloak.sh
+
+# Verify the OIDC flow
+./manifests/09-external-oidc/test-external-oidc.sh
+----
+
+To tear everything down:
+
+[source,bash]
+----
+./manifests/09-external-oidc/setup-keycloak.sh --cleanup
+----
+
+The rest of this page walks through each step manually.
+
+== Step 1: Deploy Keycloak
+
+This section deploys Red Hat Build of Keycloak (RHBK) as the OIDC provider. If you already have an external identity provider, skip to <<step-3-configure-maas-for-external-oidc,Step 3>>.
+
+=== Install the RHBK operator
+
+[source,bash]
+----
+oc create namespace maas-keycloak --dry-run=client -o yaml | oc apply -f -
+oc apply -k manifests/09-external-oidc/keycloak/operator/
+----
+
+Wait for the operator to install:
+
+[source,bash]
+----
+# Watch until PHASE shows "Succeeded"
+oc get csv -n maas-keycloak -w
+----
+
+=== Deploy Keycloak and PostgreSQL
+
+[source,bash]
+----
+oc apply -k manifests/09-external-oidc/keycloak/instance/
+----
+
+This creates:
+
+* A PostgreSQL database for Keycloak storage
+* A Keycloak instance connected to PostgreSQL
+* A `KeycloakRealmImport` that creates the `maas` realm with test users and groups
+
+Wait for Keycloak to be ready:
+
+[source,bash]
+----
+# Wait for PostgreSQL
+oc rollout status deployment/keycloak-pgsql -n maas-keycloak --timeout=120s
+
+# Wait for Keycloak (check Ready condition)
+oc get keycloak keycloak -n maas-keycloak -w
+----
+
+The `READY` column should show `True`. Then check the realm import:
+
+[source,bash]
+----
+oc get keycloakrealmimport maas -n maas-keycloak \
+    -o jsonpath='{.status.conditions[?(@.type=="Done")].status}'
+----
+
+Should return `True`.
+
+== Step 2: Discover the Keycloak Issuer URL
+
+Get the Keycloak route hostname and construct the issuer URL:
+
+[source,bash]
+----
+KEYCLOAK_HOST=$(oc get route keycloak -n maas-keycloak -o jsonpath='{.spec.host}')
+KEYCLOAK_ISSUER="https://${KEYCLOAK_HOST}/realms/maas"
+echo "Issuer URL: ${KEYCLOAK_ISSUER}"
+----
+
+Verify the OIDC discovery endpoint is accessible:
+
+[source,bash]
+----
+curl -sSk "${KEYCLOAK_ISSUER}/.well-known/openid-configuration" | jq .
+----
+
+You should see a JSON document with `issuer`, `authorization_endpoint`, `token_endpoint`, and other OIDC metadata.
+
+=== Test users and groups
+
+The imported realm includes two test users:
+
+[cols="1,1,1", options="header"]
+|===
+| Username | Password | Groups
+
+| `maas-user`
+| `maas-user`
+| `data-scientists`, `ml-engineers`
+
+| `restricted-user`
+| `restricted-user`
+| `data-scientists`
+|===
+
+You can verify the groups claim by getting a token:
+
+[source,bash]
+----
+# Get a token for maas-user
+TOKEN=$(curl -sSk -X POST "${KEYCLOAK_ISSUER}/protocol/openid-connect/token" \
+    -d "grant_type=password" \
+    -d "client_id=maas-oidc" \
+    -d "username=maas-user" \
+    -d "password=maas-user" \
+    -d "scope=openid groups" | jq -r '.access_token')
+
+# Decode the JWT payload and check groups
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '{groups, preferred_username}'
+----
+
+Expected output:
+
+[source,json]
+----
+{
+  "groups": [
+    "data-scientists",
+    "ml-engineers"
+  ],
+  "preferred_username": "maas-user"
+}
+----
+
+[[step-3-configure-maas-for-external-oidc]]
+== Step 3: Configure MaaS for External OIDC
+
+Patch the MaaS tenant resource with the OIDC provider configuration:
+
+[tabs]
+====
+RHOAI 3.5+::
++
+--
+[source,bash]
+----
+oc patch aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants \
+    --type merge \
+    -p "{\"spec\": {\"oidc\": {\"clientId\": \"maas-oidc\", \"issuerUrl\": \"${KEYCLOAK_ISSUER}\", \"ttl\": 300}}}"
+----
+
+Verify the patch was applied:
+
+[source,bash]
+----
+oc get aitenant models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc}' | jq .
+----
+
+Expected output:
+
+[source,json]
+----
+{
+  "clientId": "maas-oidc",
+  "issuerUrl": "https://keycloak-maas-keycloak.apps.<cluster-domain>/realms/maas",
+  "ttl": 300
+}
+----
+
+The fields:
+
+* `clientId` - The Keycloak client ID registered for MaaS (`maas-oidc`)
+* `issuerUrl` - The OIDC issuer URL. MaaS fetches JWKS keys from `<issuerUrl>/.well-known/openid-configuration` to verify token signatures
+* `ttl` - How long (seconds) MaaS caches the OIDC provider's signing keys before refreshing (default: 300, minimum: 30)
+--
+
+RHOAI 3.4::
++
+--
+[source,bash]
+----
+oc patch tenants.maas.opendatahub.io default-tenant -n models-as-a-service \
+    --type merge \
+    -p "{\"spec\": {\"externalOIDC\": {\"clientId\": \"maas-oidc\", \"issuerUrl\": \"${KEYCLOAK_ISSUER}\"}}}"
+----
+
+Verify the patch was applied:
+
+[source,bash]
+----
+oc get tenant default-tenant -n models-as-a-service -o jsonpath='{.spec.externalOIDC}' | jq .
+----
+
+Expected output:
+
+[source,json]
+----
+{
+  "clientId": "maas-oidc",
+  "issuerUrl": "https://keycloak-maas-keycloak.apps.<cluster-domain>/realms/maas"
+}
+----
+--
+====
+
+== Step 4: Create Subscriptions for OIDC Groups
+
+MaaS subscriptions control which groups can access which models and at what rate limits. Create subscriptions that reference the OIDC group names:
+
+[source,bash]
+----
+oc apply -k manifests/09-external-oidc/maas-oidc/
+----
+
+This creates:
+
+* Two `MaaSSubscription` resources targeting the `data-scientists` and `ml-engineers` groups
+* Two `MaaSAuthPolicy` resources granting those groups access to the simulator model
+
+NOTE: The group names in subscriptions (`data-scientists`, `ml-engineers`) must match exactly the group names in the OIDC token `groups` claim. MaaS validates group memberships directly from the token without any OpenShift group sync.
+
+Verify the resources were created:
+
+[source,bash]
+----
+oc get maassubscription,maasauthpolicy -n models-as-a-service
+----
+
+You should see the OIDC subscriptions and auth policies alongside any existing ones.
+
+If you have models other than the simulator deployed, you can edit the subscription and auth policy manifests to reference your model names and namespaces before applying.
+
+== Step 5: Verify External OIDC
+
+=== Automated verification
+
+[source,bash]
+----
+./manifests/09-external-oidc/test-external-oidc.sh
+----
+
+Expected output:
+
+[source]
+----
+=========================================
+  External OIDC Test Summary
+=========================================
+  MaaS URL:    https://maas.<cluster-domain>
+  Keycloak:    https://keycloak-maas-keycloak.apps.<cluster-domain>
+  Passed:      6
+  Failed:      0
+  Status:      ALL CHECKS PASSED
+=========================================
+----
+
+=== Manual verification
+
+==== Get an OIDC token
+
+[source,bash]
+----
+KEYCLOAK_HOST=$(oc get route keycloak -n maas-keycloak -o jsonpath='{.spec.host}')
+KEYCLOAK_ISSUER="https://${KEYCLOAK_HOST}/realms/maas"
+
+TOKEN=$(curl -sSk -X POST "${KEYCLOAK_ISSUER}/protocol/openid-connect/token" \
+    -d "grant_type=password" \
+    -d "client_id=maas-oidc" \
+    -d "username=maas-user" \
+    -d "password=maas-user" \
+    -d "scope=openid groups" | jq -r '.access_token')
+
+echo "Token: ${TOKEN:0:50}..."
+----
+
+==== List available models
+
+[source,bash]
+----
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+
+curl -sSk \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    "https://maas.${CLUSTER_DOMAIN}/maas-api/v1/models" | jq .
+----
+
+If authentication is successful, the API returns a list of models available to the groups in your token. An empty list means the token is valid but the user's groups have no matching subscriptions.
+
+==== Create an API key
+
+[source,bash]
+----
+API_KEY_RESPONSE=$(curl -sSk -X POST \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "my-oidc-key", "expiresInDays": 7}' \
+    "https://maas.${CLUSTER_DOMAIN}/maas-api/v1/api-keys")
+
+echo "$API_KEY_RESPONSE" | jq .
+API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.apiKey')
+----
+
+IMPORTANT: API keys capture the user's group memberships at the time of creation. If a user is removed from a group in Keycloak, their existing API keys retain the original group associations until they expire or are manually revoked.
+
+==== Run inference with the API key
+
+[source,bash]
+----
+curl -sSk -X POST \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{"model": "simulator", "messages": [{"role": "user", "content": "Hello from OIDC!"}], "max_tokens": 20}' \
+    "https://maas.${CLUSTER_DOMAIN}/v1/chat/completions" | jq .
+----
+
+== Cleanup
+
+To remove the OIDC configuration and Keycloak:
+
+[source,bash]
+----
+# Automated cleanup
+./manifests/09-external-oidc/setup-keycloak.sh --cleanup
+----
+
+Or manually:
+
+[tabs]
+====
+RHOAI 3.5+::
++
+--
+[source,bash]
+----
+# Remove OIDC config from tenant
+oc patch aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants \
+    --type json \
+    -p '[{"op": "remove", "path": "/spec/oidc"}]'
+
+# Remove OIDC subscriptions and auth policies
+oc delete maassubscription oidc-data-scientists oidc-ml-engineers -n models-as-a-service
+oc delete maasauthpolicy oidc-data-scientists-access oidc-ml-engineers-access -n models-as-a-service
+
+# Remove Keycloak
+oc delete namespace maas-keycloak
+----
+--
+
+RHOAI 3.4::
++
+--
+[source,bash]
+----
+# Remove OIDC config from tenant
+oc patch tenants.maas.opendatahub.io default-tenant -n models-as-a-service \
+    --type json \
+    -p '[{"op": "remove", "path": "/spec/externalOIDC"}]'
+
+# Remove OIDC subscriptions and auth policies
+oc delete maassubscription oidc-data-scientists oidc-ml-engineers -n models-as-a-service
+oc delete maasauthpolicy oidc-data-scientists-access oidc-ml-engineers-access -n models-as-a-service
+
+# Remove Keycloak
+oc delete namespace maas-keycloak
+----
+--
+====
+
+After removing the OIDC configuration, MaaS falls back to the default OpenShift TokenReview authentication. Existing API keys created by OIDC users will stop working once revoked or expired.
+
+== Bring Your Own Identity Provider
+
+If you have an existing OIDC provider (Okta, Azure AD, etc.) instead of Keycloak, you only need:
+
+. A public (or confidential) OIDC client registered for MaaS
+. The client configured to include the `groups` claim in ID/access tokens
+. User groups that map to MaaS subscription group names
+
+Skip Steps 1-2 and go directly to <<step-3-configure-maas-for-external-oidc,Step 3>>, replacing the `clientId` and `issuerUrl` with your provider's values.

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -100,6 +100,17 @@ Each phase has step-by-step instructions, status gates, and troubleshooting.
 | 5-10 min
 |===
 
+=== External OIDC Authentication
+
+[cols="1,3,1", options="header"]
+|===
+| Phase | Description | Time
+
+| xref:09-external-oidc.adoc[9. External OIDC Authentication] _(optional)_
+| Integrate MaaS with Keycloak or other OIDC providers for corporate authentication
+| 10-15 min
+|===
+
 == Automated Setup
 
 For end-to-end deployment using a single script, see the xref:quick-start.adoc[Automated Setup] page.

--- a/manifests/09-external-oidc/keycloak/instance/keycloak-db-secret.yaml
+++ b/manifests/09-external-oidc/keycloak/instance/keycloak-db-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-db-secret
+  namespace: maas-keycloak
+type: Opaque
+stringData:
+  username: keycloak
+  password: keycloak
+  dbname: keycloak

--- a/manifests/09-external-oidc/keycloak/instance/keycloak-postgresql.yaml
+++ b/manifests/09-external-oidc/keycloak/instance/keycloak-postgresql.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-pgsql
+  namespace: maas-keycloak
+  labels:
+    app: keycloak-pgsql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak-pgsql
+  template:
+    metadata:
+      labels:
+        app: keycloak-pgsql
+    spec:
+      containers:
+        - name: pgsql
+          image: registry.redhat.io/rhel9/postgresql-16:latest
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-db-secret
+                  key: username
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-db-secret
+                  key: password
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-db-secret
+                  key: dbname
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-pgsql
+  namespace: maas-keycloak
+  labels:
+    app: keycloak-pgsql
+spec:
+  selector:
+    app: keycloak-pgsql
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/manifests/09-external-oidc/keycloak/instance/keycloak.yaml
+++ b/manifests/09-external-oidc/keycloak/instance/keycloak.yaml
@@ -1,0 +1,24 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: keycloak
+  namespace: maas-keycloak
+spec:
+  instances: 1
+  db:
+    vendor: postgres
+    host: keycloak-pgsql
+    database: keycloak
+    usernameSecret:
+      name: keycloak-db-secret
+      key: username
+    passwordSecret:
+      name: keycloak-db-secret
+      key: password
+  http:
+    httpEnabled: true
+  hostname:
+    strict: false
+    strictBackchannel: false
+  proxy:
+    headers: xforwarded

--- a/manifests/09-external-oidc/keycloak/instance/keycloakrealmimport.yaml
+++ b/manifests/09-external-oidc/keycloak/instance/keycloakrealmimport.yaml
@@ -1,0 +1,109 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: maas
+  namespace: maas-keycloak
+spec:
+  keycloakCRName: keycloak
+  realm:
+    realm: maas
+    id: maas
+    enabled: true
+    sslRequired: none
+    registrationAllowed: false
+    loginWithEmailAllowed: true
+    duplicateEmailsAllowed: false
+    resetPasswordAllowed: false
+    editUsernameAllowed: false
+    bruteForceProtected: true
+    accessTokenLifespan: 1800
+    ssoSessionMaxLifespan: 1800
+    groups:
+      - name: data-scientists
+        subGroups: []
+      - name: ml-engineers
+        subGroups: []
+    clients:
+      - clientId: maas-oidc
+        name: MaaS OIDC Client
+        enabled: true
+        publicClient: true
+        directAccessGrantsEnabled: true
+        standardFlowEnabled: true
+        implicitFlowEnabled: false
+        redirectUris:
+          - "http://localhost:*"
+          - "http://127.0.0.1:*"
+          - "https://localhost:*"
+        webOrigins:
+          - "*"
+        protocol: openid-connect
+        attributes:
+          pkce.code.challenge.method: S256
+          client.secret.creation.time: "0"
+        defaultClientScopes:
+          - openid
+          - groups
+        protocolMappers:
+          - name: preferred_username
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              user.attribute: username
+              claim.name: preferred_username
+              jsonType.label: String
+              id.token.claim: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+              userinfo.token.claim: "true"
+          - name: sub
+            protocol: openid-connect
+            protocolMapper: oidc-sub-mapper
+            consentRequired: false
+            config:
+              introspection.token.claim: "true"
+              access.token.claim: "true"
+    clientScopes:
+      - name: groups
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+        protocolMappers:
+          - name: groups
+            protocol: openid-connect
+            protocolMapper: oidc-group-membership-mapper
+            consentRequired: false
+            config:
+              full.path: "false"
+              introspection.token.claim: "true"
+              userinfo.token.claim: "true"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: groups
+    users:
+      - username: maas-user
+        email: maas-user@example.com
+        firstName: MaaS
+        lastName: User
+        enabled: true
+        emailVerified: true
+        credentials:
+          - type: password
+            value: maas-user
+            temporary: false
+        groups:
+          - data-scientists
+          - ml-engineers
+      - username: restricted-user
+        email: restricted@example.com
+        firstName: Restricted
+        lastName: User
+        enabled: true
+        emailVerified: true
+        credentials:
+          - type: password
+            value: restricted-user
+            temporary: false
+        groups:
+          - data-scientists

--- a/manifests/09-external-oidc/keycloak/instance/kustomization.yaml
+++ b/manifests/09-external-oidc/keycloak/instance/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - keycloak-db-secret.yaml
+  - keycloak-postgresql.yaml
+  - keycloak.yaml
+  - keycloakrealmimport.yaml

--- a/manifests/09-external-oidc/keycloak/operator/kustomization.yaml
+++ b/manifests/09-external-oidc/keycloak/operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - operatorgroup.yaml
+  - subscription.yaml

--- a/manifests/09-external-oidc/keycloak/operator/operatorgroup.yaml
+++ b/manifests/09-external-oidc/keycloak/operator/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhbk-og
+  namespace: maas-keycloak
+spec:
+  targetNamespaces:
+    - maas-keycloak

--- a/manifests/09-external-oidc/keycloak/operator/subscription.yaml
+++ b/manifests/09-external-oidc/keycloak/operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhbk-operator
+  namespace: maas-keycloak
+spec:
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  name: rhbk-operator
+  channel: stable-v26.4

--- a/manifests/09-external-oidc/maas-oidc/aitenant-oidc-patch.yaml
+++ b/manifests/09-external-oidc/maas-oidc/aitenant-oidc-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: AITenant
+metadata:
+  name: models-as-a-service
+  namespace: ai-tenants
+spec:
+  oidc:
+    clientId: maas-oidc
+    issuerUrl: https://keycloak-maas-keycloak.apps.${CLUSTER_DOMAIN}/realms/maas
+    ttl: 300

--- a/manifests/09-external-oidc/maas-oidc/kustomization.yaml
+++ b/manifests/09-external-oidc/maas-oidc/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - maas-subscription-oidc.yaml
+  - maas-authpolicy-oidc.yaml

--- a/manifests/09-external-oidc/maas-oidc/maas-authpolicy-oidc.yaml
+++ b/manifests/09-external-oidc/maas-oidc/maas-authpolicy-oidc.yaml
@@ -1,0 +1,33 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: oidc-data-scientists-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "OIDC Data Scientists Access"
+    openshift.io/description: "Grants data-scientists OIDC group access to the simulator model"
+spec:
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+  subjects:
+    groups:
+      - name: data-scientists
+    users: []
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: oidc-ml-engineers-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "OIDC ML Engineers Access"
+    openshift.io/description: "Grants ml-engineers OIDC group access to the simulator model"
+spec:
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+  subjects:
+    groups:
+      - name: ml-engineers
+    users: []

--- a/manifests/09-external-oidc/maas-oidc/maas-subscription-oidc.yaml
+++ b/manifests/09-external-oidc/maas-oidc/maas-subscription-oidc.yaml
@@ -1,0 +1,41 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: oidc-data-scientists
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "OIDC Data Scientists"
+    openshift.io/description: "Subscription for external OIDC data-scientists group"
+spec:
+  owner:
+    groups:
+      - name: data-scientists
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100000
+          window: 1m
+  priority: 10
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: oidc-ml-engineers
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "OIDC ML Engineers"
+    openshift.io/description: "Subscription for external OIDC ml-engineers group"
+spec:
+  owner:
+    groups:
+      - name: ml-engineers
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100000
+          window: 1m
+  priority: 20

--- a/manifests/09-external-oidc/setup-keycloak.sh
+++ b/manifests/09-external-oidc/setup-keycloak.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# setup-keycloak.sh - Deploy Keycloak for MaaS External OIDC Authentication
+#
+# Deploys Red Hat Build of Keycloak (RHBK) with a PostgreSQL database and
+# imports a realm configured for MaaS group-based OIDC authentication.
+#
+# Prerequisites:
+#   - oc logged into cluster
+#   - MaaS installed and working (Phases 1-5)
+#
+# Usage:
+#   ./setup-keycloak.sh [OPTIONS]
+#
+# Options:
+#   --cleanup         Remove Keycloak and OIDC configuration
+#   -h, --help        Show this help message
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_step()  { echo -e "${BLUE}[STEP]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+KEYCLOAK_NS=maas-keycloak
+MAAS_NS=models-as-a-service
+
+# Auto-detect RHOAI version
+if oc get crd aitenants.maas.opendatahub.io &>/dev/null; then
+    RHOAI_35=true
+    AI_TENANTS_NS=ai-tenants
+    log_info "Detected RHOAI 3.5+ (AITenant CRD found)"
+else
+    RHOAI_35=false
+    AI_TENANTS_NS=""
+    log_info "Detected RHOAI 3.4 (using Tenant CRD)"
+fi
+
+# Parse arguments
+CLEANUP=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --cleanup)    CLEANUP=true; shift ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# *//'
+            exit 0
+            ;;
+        *) log_error "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+if [ "$CLEANUP" = true ]; then
+    log_step "Removing OIDC configuration from MaaS tenant"
+    if [ "$RHOAI_35" = true ]; then
+        oc patch aitenants.maas.opendatahub.io models-as-a-service -n "$AI_TENANTS_NS" \
+            --type json \
+            -p '[{"op": "remove", "path": "/spec/oidc"}]' 2>/dev/null || log_warn "OIDC config already removed or not present"
+    else
+        oc patch tenants.maas.opendatahub.io default-tenant -n "$MAAS_NS" \
+            --type json \
+            -p '[{"op": "remove", "path": "/spec/externalOIDC"}]' 2>/dev/null || log_warn "OIDC config already removed or not present"
+    fi
+
+    log_step "Removing OIDC subscriptions and auth policies"
+    oc delete maassubscription oidc-data-scientists oidc-ml-engineers -n "$MAAS_NS" 2>/dev/null || true
+    oc delete maasauthpolicy oidc-data-scientists-access oidc-ml-engineers-access -n "$MAAS_NS" 2>/dev/null || true
+
+    log_step "Removing Keycloak namespace"
+    oc delete namespace "$KEYCLOAK_NS" 2>/dev/null || true
+    log_info "Cleanup complete"
+    exit 0
+fi
+
+# =============================================================================
+# Step 1: Create namespace
+# =============================================================================
+log_step "Step 1: Creating namespace $KEYCLOAK_NS"
+oc create namespace "$KEYCLOAK_NS" --dry-run=client -o yaml | oc apply -f -
+
+# =============================================================================
+# Step 2: Deploy RHBK operator
+# =============================================================================
+log_step "Step 2: Deploying Red Hat Build of Keycloak operator"
+oc apply -k "$SCRIPT_DIR/keycloak/operator/"
+
+log_info "Waiting for RHBK operator CSV to succeed..."
+for i in $(seq 1 60); do
+    CSV=$(oc get csv -n "$KEYCLOAK_NS" -o name 2>/dev/null | grep rhbk || true)
+    if [ -n "$CSV" ]; then
+        PHASE=$(oc get "$CSV" -n "$KEYCLOAK_NS" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+        if [ "$PHASE" = "Succeeded" ]; then
+            log_info "RHBK operator installed: $CSV"
+            break
+        fi
+    fi
+    if [ "$i" -eq 60 ]; then
+        log_error "Timed out waiting for RHBK operator"
+        exit 1
+    fi
+    sleep 5
+done
+
+# =============================================================================
+# Step 3: Deploy Keycloak instance
+# =============================================================================
+log_step "Step 3: Deploying Keycloak instance (PostgreSQL + Keycloak + realm)"
+
+# Detect cluster domain for Keycloak hostname
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+KEYCLOAK_HOSTNAME="keycloak-${KEYCLOAK_NS}.${CLUSTER_DOMAIN}"
+
+oc apply -k "$SCRIPT_DIR/keycloak/instance/"
+
+# Set the hostname so the RHBK operator creates an Ingress with a host,
+# which OCP then auto-converts into a Route with edge TLS
+log_info "Setting Keycloak hostname: ${KEYCLOAK_HOSTNAME}"
+oc patch keycloak keycloak -n "$KEYCLOAK_NS" --type merge \
+    -p "{\"spec\": {\"hostname\": {\"hostname\": \"${KEYCLOAK_HOSTNAME}\", \"strict\": false, \"strictBackchannel\": false}}}"
+
+log_info "Waiting for PostgreSQL..."
+oc rollout status deployment/keycloak-pgsql -n "$KEYCLOAK_NS" --timeout=120s
+
+log_info "Waiting for Keycloak to be ready..."
+for i in $(seq 1 90); do
+    READY=$(oc get keycloak keycloak -n "$KEYCLOAK_NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)
+    if [ "$READY" = "True" ]; then
+        log_info "Keycloak is ready"
+        break
+    fi
+    if [ "$i" -eq 90 ]; then
+        log_error "Timed out waiting for Keycloak"
+        log_warn "Check: oc get keycloak keycloak -n $KEYCLOAK_NS -o yaml"
+        exit 1
+    fi
+    sleep 5
+done
+
+log_info "Waiting for realm import..."
+for i in $(seq 1 60); do
+    DONE=$(oc get keycloakrealmimport maas -n "$KEYCLOAK_NS" -o jsonpath='{.status.conditions[?(@.type=="Done")].status}' 2>/dev/null || true)
+    if [ "$DONE" = "True" ]; then
+        log_info "Realm 'maas' imported"
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        log_error "Timed out waiting for realm import"
+        exit 1
+    fi
+    sleep 5
+done
+
+# =============================================================================
+# Step 4: Get Keycloak issuer URL
+# =============================================================================
+log_step "Step 4: Discovering Keycloak issuer URL"
+
+# Wait for Route to be created from the Ingress
+KEYCLOAK_HOST=""
+for i in $(seq 1 30); do
+    KEYCLOAK_HOST=$(oc get route -n "$KEYCLOAK_NS" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || true)
+    if [ -n "$KEYCLOAK_HOST" ]; then
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        log_error "No Route created for Keycloak"
+        exit 1
+    fi
+    sleep 2
+done
+
+KEYCLOAK_ISSUER="https://${KEYCLOAK_HOST}/realms/maas"
+log_info "Keycloak issuer URL: $KEYCLOAK_ISSUER"
+
+# Verify the OIDC discovery endpoint
+HTTP_CODE=$(curl -sSk -o /dev/null -w "%{http_code}" "${KEYCLOAK_ISSUER}/.well-known/openid-configuration" 2>/dev/null || echo "000")
+if [ "$HTTP_CODE" = "200" ]; then
+    log_info "OIDC discovery endpoint is accessible"
+else
+    log_error "OIDC discovery endpoint returned HTTP $HTTP_CODE"
+    exit 1
+fi
+
+# =============================================================================
+# Step 5: Configure MaaS for OIDC
+# =============================================================================
+log_step "Step 5: Configuring MaaS tenant for external OIDC"
+if [ "$RHOAI_35" = true ]; then
+    oc patch aitenants.maas.opendatahub.io models-as-a-service -n "$AI_TENANTS_NS" \
+        --type merge \
+        -p "{\"spec\": {\"oidc\": {\"clientId\": \"maas-oidc\", \"issuerUrl\": \"${KEYCLOAK_ISSUER}\", \"ttl\": 300}}}"
+    log_info "Patched AITenant with OIDC config"
+else
+    oc patch tenants.maas.opendatahub.io default-tenant -n "$MAAS_NS" \
+        --type merge \
+        -p "{\"spec\": {\"externalOIDC\": {\"clientId\": \"maas-oidc\", \"issuerUrl\": \"${KEYCLOAK_ISSUER}\"}}}"
+    log_info "Patched Tenant with externalOIDC config"
+fi
+
+# =============================================================================
+# Step 6: Create OIDC subscriptions and auth policies
+# =============================================================================
+log_step "Step 6: Creating MaaS subscriptions and auth policies for OIDC groups"
+oc apply -k "$SCRIPT_DIR/maas-oidc/"
+log_info "Created OIDC subscriptions and auth policies"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "========================================="
+echo "  Keycloak OIDC Setup Complete"
+echo "========================================="
+echo "  Keycloak URL:    https://${KEYCLOAK_HOST}"
+echo "  Issuer URL:      ${KEYCLOAK_ISSUER}"
+echo "  Client ID:       maas-oidc"
+echo "  Realm:           maas"
+echo ""
+echo "  Test Users:"
+echo "    maas-user / maas-user"
+echo "      Groups: data-scientists, ml-engineers"
+echo "    restricted-user / restricted-user"
+echo "      Groups: data-scientists"
+echo ""
+echo "  Run test-external-oidc.sh to verify"
+echo "========================================="

--- a/manifests/09-external-oidc/test-external-oidc.sh
+++ b/manifests/09-external-oidc/test-external-oidc.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+#
+# test-external-oidc.sh - Verify External OIDC Authentication for MaaS
+#
+# Tests the full OIDC authentication flow:
+#   1. Get OIDC token from Keycloak (direct access grant)
+#   2. List models via MaaS API with OIDC Bearer token
+#   3. Create API key via MaaS API with OIDC Bearer token
+#   4. Run inference with API key
+#   5. Verify restricted user access control
+#
+# Prerequisites:
+#   - MaaS installed and working
+#   - Keycloak deployed via setup-keycloak.sh
+#   - At least one model deployed (simulator is fine)
+#
+# Usage:
+#   ./test-external-oidc.sh
+#
+
+set -euo pipefail
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_step()  { echo -e "${BLUE}[STEP]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_pass()  { echo -e "${GREEN}[PASS]${NC} $*"; PASSED=$((PASSED + 1)); }
+log_fail()  { echo -e "${RED}[FAIL]${NC} $*"; FAILED=$((FAILED + 1)); }
+
+PASSED=0
+FAILED=0
+KEYCLOAK_NS=maas-keycloak
+CLIENT_ID=maas-oidc
+
+# Detect cluster domain and MaaS hostname
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+MAAS_HOSTNAME="${MAAS_HOSTNAME:-maas.${CLUSTER_DOMAIN}}"
+MAAS_URL="https://${MAAS_HOSTNAME}"
+
+# Detect gateway IP for --resolve (cloud LB hostnames)
+GATEWAY_ADDR=$(oc get gateway maas-default-gateway -n openshift-ingress -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "")
+GATEWAY_IP=""
+if [ -n "$GATEWAY_ADDR" ]; then
+    if echo "$GATEWAY_ADDR" | grep -qE '[a-zA-Z]'; then
+        GATEWAY_IP=$(dig +short "$GATEWAY_ADDR" 2>/dev/null | head -1 || echo "")
+    fi
+fi
+
+maas_curl() {
+    if [ -n "${GATEWAY_IP:-}" ]; then
+        curl -sSk --connect-timeout 10 --max-time 30 \
+            --resolve "${MAAS_HOSTNAME}:443:${GATEWAY_IP}" \
+            "$@"
+    else
+        curl -sSk --connect-timeout 10 --max-time 30 "$@"
+    fi
+}
+
+# Discover Keycloak
+KEYCLOAK_HOST=$(oc get route -n "$KEYCLOAK_NS" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || true)
+if [ -z "$KEYCLOAK_HOST" ]; then
+    log_error "Keycloak route not found in namespace $KEYCLOAK_NS. Run setup-keycloak.sh first."
+    exit 1
+fi
+KEYCLOAK_TOKEN_URL="https://${KEYCLOAK_HOST}/realms/maas/protocol/openid-connect/token"
+
+log_info "MaaS URL:       ${MAAS_URL}"
+log_info "Keycloak URL:   https://${KEYCLOAK_HOST}"
+log_info "Token endpoint: ${KEYCLOAK_TOKEN_URL}"
+echo ""
+
+# =============================================================================
+# Helper: get OIDC token
+# =============================================================================
+get_oidc_token() {
+    local username="$1"
+    local password="$2"
+    curl -sSk -X POST "$KEYCLOAK_TOKEN_URL" \
+        -d "grant_type=password" \
+        -d "client_id=${CLIENT_ID}" \
+        -d "username=${username}" \
+        -d "password=${password}" \
+        -d "scope=openid groups" | jq -r '.access_token // empty'
+}
+
+# =============================================================================
+# Test 1: Get OIDC token for maas-user
+# =============================================================================
+log_step "Test 1: Get OIDC token for maas-user"
+TOKEN=$(get_oidc_token "maas-user" "maas-user")
+if [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ]; then
+    log_pass "Got OIDC token for maas-user"
+
+    # Decode and show groups claim
+    PAYLOAD_B64=$(echo "$TOKEN" | cut -d. -f2 | tr '_-' '/+')
+    MOD=$((${#PAYLOAD_B64} % 4))
+    [ "$MOD" -eq 2 ] && PAYLOAD_B64="${PAYLOAD_B64}==" || { [ "$MOD" -eq 3 ] && PAYLOAD_B64="${PAYLOAD_B64}="; }
+    GROUPS=$(echo "$PAYLOAD_B64" | base64 -d 2>/dev/null | jq -r '.groups // [] | join(", ")' 2>/dev/null || echo "decode failed")
+    log_info "Token groups: $GROUPS"
+else
+    log_fail "Failed to get OIDC token for maas-user"
+    log_error "Check Keycloak is running: oc get keycloak -n $KEYCLOAK_NS"
+    exit 1
+fi
+
+# =============================================================================
+# Test 2: List models with OIDC Bearer token
+# =============================================================================
+log_step "Test 2: List models with OIDC Bearer token"
+MODELS_RESPONSE=$(maas_curl \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    "${MAAS_URL}/maas-api/v1/models" 2>/dev/null) || true
+
+MODEL_COUNT=$(echo "$MODELS_RESPONSE" | jq -r '.data // [] | length' 2>/dev/null || echo "0")
+if [ "$MODEL_COUNT" -gt 0 ]; then
+    log_pass "Listed $MODEL_COUNT model(s) via OIDC token"
+    echo "$MODELS_RESPONSE" | jq -r '.data[]?.id // empty' 2>/dev/null | while read -r m; do
+        log_info "  - $m"
+    done
+else
+    HTTP_CODE=$(maas_curl -o /dev/null -w "%{http_code}" \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        "${MAAS_URL}/maas-api/v1/models" 2>/dev/null) || true
+    log_fail "Failed to list models (HTTP $HTTP_CODE)"
+    log_info "Response: $(echo "$MODELS_RESPONSE" | head -5)"
+fi
+
+# =============================================================================
+# Test 3: Create API key with OIDC Bearer token
+# =============================================================================
+log_step "Test 3: Create API key with OIDC Bearer token"
+API_KEY_RESPONSE=$(maas_curl -X POST \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "oidc-test-key", "expiresInDays": 1}' \
+    "${MAAS_URL}/maas-api/v1/api-keys" 2>/dev/null) || true
+
+API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.key // .apiKey // empty' 2>/dev/null || true)
+API_KEY_ID=$(echo "$API_KEY_RESPONSE" | jq -r '.id // empty' 2>/dev/null || true)
+
+if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ]; then
+    log_pass "Created API key via OIDC token (id: $API_KEY_ID)"
+else
+    HTTP_CODE=$(maas_curl -o /dev/null -w "%{http_code}" -X POST \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d '{"name": "oidc-test-key-2", "expiresInDays": 1}' \
+        "${MAAS_URL}/maas-api/v1/api-keys" 2>/dev/null) || true
+    log_fail "Failed to create API key (HTTP $HTTP_CODE)"
+    log_info "Response: $(echo "$API_KEY_RESPONSE" | head -5)"
+fi
+
+# =============================================================================
+# Test 4: Inference with API key (if we have one and a model)
+# =============================================================================
+if [ -n "${API_KEY:-}" ] && [ "$API_KEY" != "null" ] && [ "$MODEL_COUNT" -gt 0 ]; then
+    MODEL_ID=$(echo "$MODELS_RESPONSE" | jq -r '.data[0].id // empty' 2>/dev/null || true)
+    if [ -n "$MODEL_ID" ]; then
+        log_step "Test 4: Inference with API key (model: $MODEL_ID)"
+        INFERENCE_RESPONSE=$(maas_curl -X POST \
+            -H "Authorization: Bearer ${API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"model\": \"${MODEL_ID}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 10}" \
+            "${MAAS_URL}/v1/chat/completions" 2>/dev/null) || true
+
+        INFERENCE_OK=$(echo "$INFERENCE_RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)
+        if [ -n "$INFERENCE_OK" ]; then
+            log_pass "Inference succeeded with OIDC-created API key"
+        else
+            HTTP_CODE=$(maas_curl -o /dev/null -w "%{http_code}" -X POST \
+                -H "Authorization: Bearer ${API_KEY}" \
+                -H "Content-Type: application/json" \
+                -d "{\"model\": \"${MODEL_ID}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 10}" \
+                "${MAAS_URL}/v1/chat/completions" 2>/dev/null) || true
+            log_fail "Inference failed (HTTP $HTTP_CODE)"
+        fi
+    else
+        log_warn "Test 4: Skipped (no model ID found)"
+    fi
+else
+    log_warn "Test 4: Skipped (no API key or no models available)"
+fi
+
+# =============================================================================
+# Test 5: Get OIDC token for restricted-user
+# =============================================================================
+log_step "Test 5: Get OIDC token for restricted-user"
+RESTRICTED_TOKEN=$(get_oidc_token "restricted-user" "restricted-user")
+if [ -n "$RESTRICTED_TOKEN" ] && [ "$RESTRICTED_TOKEN" != "null" ]; then
+    log_pass "Got OIDC token for restricted-user"
+
+    PAYLOAD_B64=$(echo "$RESTRICTED_TOKEN" | cut -d. -f2 | tr '_-' '/+')
+    MOD=$((${#PAYLOAD_B64} % 4))
+    [ "$MOD" -eq 2 ] && PAYLOAD_B64="${PAYLOAD_B64}==" || { [ "$MOD" -eq 3 ] && PAYLOAD_B64="${PAYLOAD_B64}="; }
+    RESTRICTED_GROUPS=$(echo "$PAYLOAD_B64" | base64 -d 2>/dev/null | jq -r '.groups // [] | join(", ")' 2>/dev/null || echo "decode failed")
+    log_info "Token groups: $RESTRICTED_GROUPS"
+else
+    log_fail "Failed to get OIDC token for restricted-user"
+fi
+
+# =============================================================================
+# Test 6: Verify restricted-user can list models (only data-scientists group)
+# =============================================================================
+if [ -n "${RESTRICTED_TOKEN:-}" ] && [ "$RESTRICTED_TOKEN" != "null" ]; then
+    log_step "Test 6: Restricted user model listing"
+    RESTRICTED_MODELS=$(maas_curl \
+        -H "Authorization: Bearer ${RESTRICTED_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "${MAAS_URL}/maas-api/v1/models" 2>/dev/null) || true
+
+    RESTRICTED_COUNT=$(echo "$RESTRICTED_MODELS" | jq -r '.data // [] | length' 2>/dev/null || echo "0")
+    if [ "$RESTRICTED_COUNT" -ge 0 ]; then
+        log_pass "Restricted user can access API ($RESTRICTED_COUNT model(s) visible)"
+    else
+        log_fail "Restricted user failed to list models"
+    fi
+else
+    log_warn "Test 6: Skipped (no restricted-user token)"
+fi
+
+# =============================================================================
+# Cleanup: delete test API keys
+# =============================================================================
+if [ -n "${API_KEY_ID:-}" ]; then
+    log_info "Cleaning up test API key ($API_KEY_ID)"
+    maas_curl -X DELETE \
+        -H "Authorization: Bearer ${TOKEN}" \
+        "${MAAS_URL}/maas-api/v1/api-keys/${API_KEY_ID}" 2>/dev/null || true
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "========================================="
+echo "  External OIDC Test Summary"
+echo "========================================="
+echo "  MaaS URL:    ${MAAS_URL}"
+echo "  Keycloak:    https://${KEYCLOAK_HOST}"
+echo "  Passed:      ${PASSED}"
+echo "  Failed:      ${FAILED}"
+if [ "$FAILED" -eq 0 ]; then
+    echo "  Status:      ALL CHECKS PASSED"
+else
+    echo "  Status:      SOME CHECKS FAILED"
+fi
+echo "========================================="
+
+exit "$FAILED"


### PR DESCRIPTION
## Summary

- Adds Phase 9 to the guide covering External OIDC Authentication for MaaS
- Deploys Red Hat Build of Keycloak (RHBK) in a dedicated `maas-keycloak` namespace with PostgreSQL backend
- Realm import pre-configured with two groups (`data-scientists`, `ml-engineers`), two test users, and the `groups` JWT claim mapper that MaaS needs
- Automation script (`setup-keycloak.sh`) handles operator install, Keycloak deploy, realm import, route discovery, AITenant/Tenant OIDC patching, and subscription creation - auto-detects RHOAI 3.4 vs 3.5
- Test script (`test-external-oidc.sh`) validates 6 checks: token generation, model listing with Bearer token, API key creation, inference with API key, restricted user access control, and cleanup
- Guide page with 3.4/3.5 tabs, "Bring Your Own IDP" section, and cleanup instructions

## What I found during testing

The main gotcha was the Keycloak realm import. When you define `defaultClientScopes` on a client in the KeycloakRealmImport, the standard built-in scopes (`basic`, `profile`) are NOT auto-created in the realm. This means the JWT was missing `preferred_username` and `sub` claims, which the MaaS AuthPolicy needs to set the `X-MaaS-Username` header. Fixed by adding explicit `oidc-usermodel-attribute-mapper` (for `preferred_username`) and `oidc-sub-mapper` (for `sub`) protocol mappers directly on the client definition in the realm import.

Also the RHBK operator needs an explicit `spec.hostname.hostname` on the Keycloak CR for OCP to create a Route from the Ingress. The setup script handles this dynamically.

## Test plan

- [x] Fresh deploy on SNO cluster (cluster-kv2r6)
- [x] setup-keycloak.sh runs clean end to end
- [x] test-external-oidc.sh: 6/6 pass
- [x] verify.sh (standard MaaS checks): 15/15 pass - no regression
- [x] Cleanup (--cleanup flag) works
- [ ] Antora build renders correctly

Closes #97