### PR TITLE
fix: move gateway-access namespace labeling to Phase 4 for RHOAI 3.5+

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -317,13 +317,7 @@ Label the namespace where the MaaS API route is created:
 RHOAI 3.5+::
 +
 --
-[source,bash]
-----
-oc label namespace redhat-ai-gateway-infra \
-  maas.opendatahub.io/gateway-access=true --overwrite
-----
-
-In RHOAI 3.5+, the MaaS API route is created in `redhat-ai-gateway-infra`.
+No action needed. The `redhat-ai-gateway-infra` namespace is created and labeled automatically by the RHOAI operator when MaaS is enabled in xref:04-rhoai-config.adoc[Phase 4]. The operator applies `maas.opendatahub.io/gateway-access=true` as part of the namespace setup.
 --
 
 RHOAI 3.4::

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -675,7 +675,11 @@ if should_run 2; then
     fi
 
     # Label namespace for Gateway route binding (best practice: least privilege)
-    oc label namespace "$MAAS_API_NS" maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
+    # For 3.5+, skip here - redhat-ai-gateway-infra does not exist yet (created in Phase 4)
+    # and the operator auto-labels it. For 3.4, redhat-ods-applications already exists.
+    if [ "$IS_35_PLUS" = false ]; then
+        oc label namespace "$MAAS_API_NS" maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
+    fi
 fi
 
 # =============================================================================
@@ -842,6 +846,11 @@ if should_run 4; then
             fi
         done
         [ $ELAPSED -ge $TIMEOUT ] && log_warn "maas-api not found after ${TIMEOUT}s  - operator may still be reconciling"
+    fi
+
+    # Ensure gateway-access label on MaaS API namespace (safety net for 3.5+)
+    if [ "$IS_35_PLUS" = true ] && oc get namespace "$MAAS_API_NS" &>/dev/null; then
+        oc label namespace "$MAAS_API_NS" maas.opendatahub.io/gateway-access=true --overwrite 2>/dev/null || true
     fi
 
     # Verify MaaS readiness (3.5+ uses Config CR, 3.4 uses Tenant CR)


### PR DESCRIPTION
## Summary

- In RHOAI 3.5, Phase 2 tells users to label `redhat-ai-gateway-infra` but the namespace does not exist yet - it is created by the operator in Phase 4
- The operator also auto-labels it with `maas.opendatahub.io/gateway-access=true`, so the manual step was broken and unnecessary
- Guide: replaced the 3.5+ `oc label` command with a note that the operator handles it
- Script: skip Phase 2 labeling for 3.5+ and add a safety-net re-label in Phase 4 after namespace detection

Found during a POC. Confirmed on cluster-wdgjh (OCP 4.21.29, RHOAI 3.5.0).

Fixes #100

## Test plan

- [ ] Run `setup-maas.sh` on a fresh RHOAI 3.5 cluster - no labeling error in Phase 2
- [ ] Verify `redhat-ai-gateway-infra` has `maas.opendatahub.io/gateway-access=true` after Phase 4
- [ ] Verify the gateway health endpoint works (`/maas-api/health` returns 200)
- [ ] Run verify.sh - 15/15 pass