### PR TITLE
fix: Step 5d gateway-access label not auto-applied by operator

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -317,7 +317,13 @@ Label the namespace where the MaaS API route is created:
 RHOAI 3.5+::
 +
 --
-No action needed. The `redhat-ai-gateway-infra` namespace is created and labeled automatically by the RHOAI operator when MaaS is enabled in xref:04-rhoai-config.adoc[Phase 4]. The operator applies `maas.opendatahub.io/gateway-access=true` as part of the namespace setup.
+The `redhat-ai-gateway-infra` namespace does not exist yet - it is created by the RHOAI operator when MaaS is enabled in xref:04-rhoai-config.adoc[Phase 4]. After completing Phase 4, come back and label it:
+
+[source,bash]
+----
+oc label namespace redhat-ai-gateway-infra \
+  maas.opendatahub.io/gateway-access=true --overwrite
+----
 --
 
 RHOAI 3.4::


### PR DESCRIPTION
## Summary

- Step 5d (RHOAI 3.5+ tab) incorrectly said the operator auto-labels `redhat-ai-gateway-infra` with `maas.opendatahub.io/gateway-access=true`. It doesn't.
- Confirmed on cluster-v6mmc and cluster-wdgjh - both had the namespace created without the label.
- Updated to tell users the namespace does not exist yet and to come back after Phase 4 to label it manually.

The `setup-maas.sh` already handles this with the Phase 4 safety-net from PR #101, so automated installs are fine. This fix is for users following the guide manually.

Closes #102