### PR TITLE
fix: skip OperatorGroup when operators are pre-installed

### DIFF
--- a/content/modules/ROOT/pages/01-prerequisites.adoc
+++ b/content/modules/ROOT/pages/01-prerequisites.adoc
@@ -80,6 +80,21 @@ oc apply -k manifests/01-prerequisites/operators/
 
 This installs all four required operator subscriptions. OLM will resolve and install each operator automatically.
 
+[NOTE]
+====
+If any of these operators are already installed on your cluster (e.g. via OperatorHub), this command may fail with an OperatorGroup conflict - OLM only allows one OperatorGroup per namespace. In that case, delete the duplicate OperatorGroup that was just created:
+
+[source,bash]
+----
+# Check which namespaces have duplicate OperatorGroups
+for ns in redhat-ods-operator cert-manager-operator openshift-lws-operator; do
+  oc get operatorgroup -n "$ns" --no-headers 2>/dev/null
+done
+# Delete the one created by this guide (keep the existing one)
+oc delete operatorgroup <duplicate-name> -n <namespace>
+----
+====
+
 === Step 2 (Optional): Install GPU Operators
 
 If your cluster has GPU nodes (or you plan to add them), install the GPU operators:
@@ -164,6 +179,8 @@ Install the MetalLB operator:
 ----
 oc apply -k manifests/01-prerequisites/metallb/
 ----
+
+NOTE: If MetalLB is already installed on your cluster, this may fail with an OperatorGroup conflict. Delete the duplicate OperatorGroup from `metallb-system` namespace (see the note in Step 1 above).
 
 Wait for the MetalLB CSV to succeed, then create the MetalLB CR and configure an IP pool:
 

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -317,8 +317,23 @@ if should_run 1; then
         fi
 
         log_info "Applying operator subscriptions..."
-        run_cmd oc apply -k "$MANIFESTS_DIR/01-prerequisites/operators/"
-        log_info "Operator subscriptions applied"
+        # Apply each operator individually, skipping OperatorGroup if one already
+        # exists in the namespace to avoid OLM conflicts (GH #99)
+        for op_dir in "$MANIFESTS_DIR"/01-prerequisites/operators/*/; do
+            [ -d "$op_dir" ] || continue
+            for f in "$op_dir"*.yaml; do
+                [ -f "$f" ] || continue
+                if [ "$(basename "$f")" = "operatorgroup.yaml" ]; then
+                    og_ns=$(grep 'namespace:' "$f" | awk '{print $2}')
+                    if [ -n "$og_ns" ] && oc get operatorgroup -n "$og_ns" --no-headers 2>/dev/null | grep -q .; then
+                        log_info "OperatorGroup already exists in $og_ns, skipping"
+                        continue
+                    fi
+                fi
+                [ "$(basename "$f")" = "kustomization.yaml" ] && continue
+                run_cmd oc apply -f "$f"
+            done
+        done
 
         log_info "Waiting for operator CSVs (this may take 5-10 minutes)..."
         if [ "$DRY_RUN" = false ]; then
@@ -529,7 +544,19 @@ if should_run 2; then
 
                         if [ "$HAS_METALLB" = false ]; then
                             log_info "Installing MetalLB operator..."
-                            oc apply -k "$MANIFESTS_DIR/01-prerequisites/metallb/"
+                            # Apply MetalLB resources individually, skip OG if one exists (GH #99)
+                            for f in "$MANIFESTS_DIR"/01-prerequisites/metallb/*.yaml; do
+                                [ -f "$f" ] || continue
+                                [ "$(basename "$f")" = "kustomization.yaml" ] && continue
+                                [ "$(basename "$f")" = "metallb.yaml" ] && continue
+                                if [ "$(basename "$f")" = "operatorgroup.yaml" ]; then
+                                    if oc get operatorgroup -n metallb-system --no-headers 2>/dev/null | grep -q .; then
+                                        log_info "OperatorGroup already exists in metallb-system, skipping"
+                                        continue
+                                    fi
+                                fi
+                                oc apply -f "$f"
+                            done
                             log_info "Waiting for MetalLB CSV..."
                             METALLB_TIMEOUT=120
                             METALLB_ELAPSED=0


### PR DESCRIPTION
## Summary

- Fixes operator installation failing when RHOAI/MetalLB/cert-manager are already installed on the cluster (reported by @stefan-bergstein)
- OLM only allows one OperatorGroup per namespace - our `oc apply -k` was creating a second one with a different name, causing a conflict
- `setup-maas.sh` now applies each operator's resources individually, checking for existing OperatorGroups and skipping if one is already there
- Added a troubleshooting note to the guide (01-prerequisites.adoc) for users doing manual installs

## Test plan

- [x] Tested on cluster-v6mmc (operators already installed) - all OperatorGroups correctly skipped
- [x] Dry-run confirms only namespace + subscription are applied when OG exists
- [x] No temp file manipulation - safe with `set -e`

Closes #99