### PR TITLE
fix: rename llamastackoperator to ogx in 3.5 DSC

### DIFF
--- a/content/modules/ROOT/pages/10-post-upgrade-troubleshooting.adoc
+++ b/content/modules/ROOT/pages/10-post-upgrade-troubleshooting.adoc
@@ -35,6 +35,9 @@ The 3.5 release introduces several structural changes to the {maas} platform:
 
 | *Tenant CR*
 | `Tenant` is deprecated. Replaced by `MaasTenantConfig`. Legacy values are preserved during AITenant bootstrap.
+
+| *DSC component rename*
+| `llamastackoperator` is renamed to `ogx`. If upgrading from 3.4, update the DSC spec or the Playground section will not appear.
 |===
 
 [[issue-1]]

--- a/manifests/04-rhoai-config/datasciencecluster.yaml
+++ b/manifests/04-rhoai-config/datasciencecluster.yaml
@@ -31,8 +31,8 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Removed
-    # -- LlamaStack Operator (required for GenAI Studio) --
-    llamastackoperator:
+    # -- OGX (required for GenAI Studio / Playground) --
+    ogx:
       managementState: Managed
     # -- MLflow Operator --
     mlflowoperator:


### PR DESCRIPTION
## Summary

- Renamed `llamastackoperator` to `ogx` in the 3.5 DSC manifest - RHOAI 3.5 renamed this component and the old key is silently ignored
- Added the rename to the migration guide "What Changes" table so people upgrading from 3.4 know about it
- 3.4 DSC (`datasciencecluster-34.yaml`) unchanged - `llamastackoperator` is correct there

Without this fix the Playground section never appears in the dashboard.

## Test plan

- [x] Validated on cluster-kj2dd (clean SNO, OCP 4.21, RHOAI 3.5.0) - 15/15, OGXReady=True
- [x] Validated on cluster-cz7l6 (clean SNO) - OGXReady=True after re-applying DSC

Closes #109