### PR TITLE
Document governance pairing requirement for auth policy and subscription

### DIFF
--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -92,6 +92,18 @@ Defines rate-limiting tiers for model access. Each model ships with two tiers:
 
 Higher-priority subscriptions take precedence. You can adjust limits, windows, and subject groups to match your usage policies.
 
+[[governance-pairing]]
+=== Governance Pairing: Why Both Are Required
+
+[IMPORTANT]
+====
+A `MaaSModelRef` reaches `Ready` phase only when *both* a `MaaSSubscription` AND a `MaaSAuthPolicy` reference it. This is called *governance pairing*. If only one of them references a model, the model stays in `Pending` phase with the condition `No active subscription and auth policy pairing found`, and inference requests will fail.
+
+These two CRDs are intentionally separate - they serve different purposes (access control vs rate limiting) and can target different groups. For example, you can grant all users access via one `MaaSAuthPolicy` while having separate `MaaSSubscription` resources with different rate limits per department.
+
+However, *updating one does NOT auto-update the other*. If you add a model to a `MaaSSubscription` (via CLI or UI), you must also add it to a `MaaSAuthPolicy`. The controller does not sync them automatically.
+====
+
 == Deploying a Model
 
 [NOTE]
@@ -228,6 +240,31 @@ For GPU models, replace the model name with `granite-4-tiny` or `gpt-oss-20b` as
 ----
 oc delete -k manifests/05-maas-models/simulator/
 ----
+
+== Adding a Model to an Existing Subscription
+
+If you already have a `MaaSSubscription` and `MaaSAuthPolicy` for one model and want to add a second model, you need to update *both* resources. This is a common Day 2 operation that catches people off guard.
+
+Deploy the new model (LLMInferenceService + MaaSModelRef) as usual, then update both the subscription and the auth policy:
+
+[source,bash]
+----
+# 1. Add the new model to the existing MaaSSubscription
+oc patch maassubscription <subscription-name> -n models-as-a-service --type=json \
+  -p '[{"op":"add","path":"/spec/modelRefs/-","value":{"name":"<new-model-ref>","namespace":"llm","tokenRateLimits":[{"limit":100,"window":"1m"}]}}]'
+
+# 2. Add the new model to the existing MaaSAuthPolicy
+oc patch maasauthpolicy <policy-name> -n models-as-a-service --type=json \
+  -p '[{"op":"add","path":"/spec/modelRefs/-","value":{"name":"<new-model-ref>","namespace":"llm"}}]'
+
+# 3. Verify the new model reaches Ready
+oc get maasmodelref -n llm -o wide
+----
+
+[WARNING]
+====
+If you update only the `MaaSSubscription` without updating the `MaaSAuthPolicy`, the new model will stay in `Pending` phase. The `MaaSModelRef` condition will show `No active subscription and auth policy pairing found`. This applies to both CLI and UI edits. See <<governance-pairing>> for details.
+====
 
 == Appendix
 

--- a/content/modules/ROOT/pages/11-model-migration.adoc
+++ b/content/modules/ROOT/pages/11-model-migration.adoc
@@ -116,7 +116,7 @@ The MaaSModelRef goes through these phases:
 | The resource spec is missing or structurally invalid.
 |===
 
-Governance means at least one `MaaSSubscription` AND one `MaaSAuthPolicy` both reference the same MaaSModelRef. Both are required for the model to reach `Ready` phase.
+Governance means at least one `MaaSSubscription` AND one `MaaSAuthPolicy` both reference the same MaaSModelRef. Both are required for the model to reach `Ready` phase. These two CRDs are independent - updating one does NOT auto-update the other. For details on keeping them in sync, see xref:05-maas-models.adoc#governance-pairing[Governance Pairing] in Phase 5.
 
 == What Changes vs What Stays the Same
 


### PR DESCRIPTION
## Summary

- New "Governance Pairing" section in 05-maas-models.adoc explaining that both MaaSAuthPolicy AND MaaSSubscription must reference the same model for it to reach Ready
- Warning that updating one does NOT auto-update the other (applies to both CLI and UI edits)
- New "Day 2: Adding a Model to an Existing Subscription" section with exact `oc patch` commands for both CRDs
- Cross-reference from the model migration page (11-model-migration.adoc)

## Why

When a user adds a model to a MaaSSubscription via the UI, the MaaSAuthPolicy is not auto-updated. The model stays in Pending with a generic "No active governance pairing found" message and no clear indication that the auth policy needs updating too.

This is by design (flexibility for different groups/rate limits), but the docs never warned about it. Related: RHOAIENG-91162

## Test plan

- [x] Antora build clean (no warnings from modified pages)
- [x] Cross-reference from 11-model-migration.adoc to governance-pairing anchor resolves correctly

Closes #116