### PR TITLE
fix: use MAAS_HOSTNAME in gateway envsubst instructions

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -232,7 +232,8 @@ Now create the Gateway. The Gateway template includes `spec.infrastructure.param
 ----
 export CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster \
   -o jsonpath='{.spec.domain}')
-echo $CLUSTER_DOMAIN
+export MAAS_HOSTNAME="maas.${CLUSTER_DOMAIN}"
+echo $MAAS_HOSTNAME
 ----
 
 [source,bash]
@@ -246,7 +247,7 @@ echo $CERT_NAME
 
 [source,bash]
 ----
-envsubst '${CLUSTER_DOMAIN} ${CERT_NAME}' < manifests/02-platform-config/gateway.yaml.tmpl | oc apply -f -
+envsubst '${MAAS_HOSTNAME} ${CERT_NAME}' < manifests/02-platform-config/gateway.yaml.tmpl | oc apply -f -
 ----
 
 *Step 5c:* Annotate the Gateway for Authorino TLS bootstrap:
@@ -350,8 +351,9 @@ NOTE: If your platform type from Step 5a was `AWS`, `Azure`, `GCP`, or another c
 ----
 export CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster \
   -o jsonpath='{.spec.domain}')
+export MAAS_HOSTNAME="maas.${CLUSTER_DOMAIN}"
 
-envsubst '${CLUSTER_DOMAIN}' < manifests/03-maas-platform/openshift-gateway-setup/route.yaml.tmpl | oc apply -f -
+envsubst '${MAAS_HOSTNAME}' < manifests/03-maas-platform/openshift-gateway-setup/route.yaml.tmpl | oc apply -f -
 ----
 
 [NOTE]


### PR DESCRIPTION
## Summary

- The manual gateway setup instructions (Step 5b and Step 5e) told users to set `CLUSTER_DOMAIN` and pass it to `envsubst`, but the templates (`gateway.yaml.tmpl` and `route.yaml.tmpl`) actually use `${MAAS_HOSTNAME}` - not `${CLUSTER_DOMAIN}`. This meant anyone following the manual instructions got a Gateway with an empty hostname.
- Adds the `MAAS_HOSTNAME` derivation step (`maas.${CLUSTER_DOMAIN}`) matching what `setup-maas.sh` already does, and fixes the `envsubst` variable lists.
- No changes to the templates or the automation script - those were already correct.

## Rationale

The automation script (`setup-maas.sh` line 194) correctly derives `MAAS_HOSTNAME` from `CLUSTER_DOMAIN`:
```bash
MAAS_HOSTNAME="${MAAS_HOSTNAME:-maas.${CLUSTER_DOMAIN}}"
```
The manual docs just never included this derivation step - the templates were always expecting `MAAS_HOSTNAME`, but the docs only exported `CLUSTER_DOMAIN`.

## What changed

| File | Change |
|------|--------|
| `02-platform-config.adoc` Step 5b | Added `export MAAS_HOSTNAME="maas.${CLUSTER_DOMAIN}"`, fixed envsubst to pass `${MAAS_HOSTNAME} ${CERT_NAME}` |
| `02-platform-config.adoc` Step 5e | Added `export MAAS_HOSTNAME="maas.${CLUSTER_DOMAIN}"`, fixed envsubst to pass `${MAAS_HOSTNAME}` |

## Test plan

- [x] Verified `gateway.yaml.tmpl` uses `${MAAS_HOSTNAME}` (lines 18, 28) and `${CERT_NAME}` (line 41) - no `${CLUSTER_DOMAIN}`
- [x] Verified `route.yaml.tmpl` uses `${MAAS_HOSTNAME}` (line 7) - no `${CLUSTER_DOMAIN}`
- [x] Verified `setup-maas.sh` line 194 already derives `MAAS_HOSTNAME` from `CLUSTER_DOMAIN` the same way
- [x] Antora build passes with no errors or broken xrefs

Closes #118