### PR TITLE
fix: add warning for missing OGX CRD on RHOAI 3.5.0

### DIFF
--- a/content/modules/ROOT/pages/12-platform-upgrade.adoc
+++ b/content/modules/ROOT/pages/12-platform-upgrade.adoc
@@ -107,6 +107,15 @@ oc patch datasciencecluster default-dsc --type=merge \
 
 NOTE: Without `ogx`, the AI Playground section will not appear in the Dashboard. The old `llamastackoperator` field can be left as-is in the DSC - it is ignored in 3.5.
 
+WARNING: On some RHOAI 3.5.0 installations, the OGX CRD may not be available yet. If the DSC reports `OGXReady: False` with `no matches for kind "OGX"` after this step, set ogx back to `Removed` to unblock the DSC. This does not affect {maas} functionality - only the AI Playground feature.
+
+[source,bash]
+----
+# Only if OGX is blocking DSC Ready:
+oc patch datasciencecluster default-dsc --type=merge \
+  -p '{"spec":{"components":{"ogx":{"managementState":"Removed"}}}}'
+----
+
 == Step 4: Handle the Frozen kserve.modelsAsService Field
 
 The old `kserve.modelsAsService` field is frozen by CEL validation (`self == oldSelf`). You cannot change its value in-place. This is by design - it prevents accidental removal of a running {maas} configuration during the transition period.


### PR DESCRIPTION
## Summary

- On some RHOAI 3.5.0 installations, the OGX CRD (`components.platform.opendatahub.io/v1alpha1 OGX`) does not exist. Setting `ogx: Managed` in the DSC causes `OGXReady: False` with `no matches for kind "OGX"`, which blocks the DSC from becoming Ready.
- Adds a WARNING to Step 3 of the migration guide with a rollback command so users can unblock the DSC without being stuck.
- Does not affect MaaS functionality - only the AI Playground feature.

## How it was found

Full migration guide validation on cluster-f5ccl (OCP 4.21.30 SNO, RHOAI 3.5.0). All other steps (1-2, 4-10) passed. Step 3 blocked DSC Ready until ogx was set back to Removed.

## Test plan

- [x] Validated on live cluster (cluster-f5ccl) - ogx Removed unblocks DSC
- [x] All 10 migration steps pass after the fix
- [x] Post-migration inference works
- [x] Dashboard shows AI asset endpoints with model Ready
- [x] Antora build passes