### PR TITLE
fix: 13 doc fixes from full guide review

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -10,7 +10,7 @@ IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} docum
 
 == Prerequisites
 
-* OpenShift 4.17+ cluster with `oc` CLI authenticated as cluster-admin
+* OpenShift 4.19+ cluster with `oc` CLI authenticated as cluster-admin
 * Red Hat Connectivity Link (RHCL) operator already installed (see link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link[RHCL docs])
 * xref:01-prerequisites.adoc[Phase 1] (operators) completed
 
@@ -266,6 +266,7 @@ oc wait --for=condition=Programmed gateway/maas-default-gateway \
   -n openshift-ingress --timeout=120s
 ----
 
+[[_gateway_pod_oomkill_prevention]]
 [NOTE]
 ====
 *Gateway Pod OOMKill Prevention*

--- a/content/modules/ROOT/pages/03-maas-platform.adoc
+++ b/content/modules/ROOT/pages/03-maas-platform.adoc
@@ -45,7 +45,7 @@ oc create secret generic maas-db-config \
   --from-literal=DB_CONNECTION_URL="postgresql://maas:${POSTGRES_PASSWORD}@postgres:5432/maas?sslmode=disable"
 ----
 
-NOTE: On RHOAI 3.5+, the `maas-api` deployment runs in `redhat-ai-gateway-infra`. The `maas-db-config` secret must also exist in that namespace. The `setup-maas.sh` script handles this mirroring automatically. If installing manually, create the same secret in `redhat-ai-gateway-infra` after the one above.
+NOTE: On RHOAI 3.5+, the `maas-api` deployment runs in `redhat-ai-gateway-infra`. The `maas-db-config` secret must also exist in that namespace. When creating the cross-namespace copy, use the fully-qualified service hostname `postgres.redhat-ods-applications.svc:5432` in the `DB_CONNECTION_URL` instead of the short name `postgres:5432` (which won't resolve from a different namespace). The `setup-maas.sh` script handles this mirroring automatically. If installing manually, create the same secret in `redhat-ai-gateway-infra` after the one above.
 
 === Step 2: Deploy PostgreSQL
 

--- a/content/modules/ROOT/pages/04-rhoai-config.adoc
+++ b/content/modules/ROOT/pages/04-rhoai-config.adoc
@@ -98,7 +98,7 @@ With the Data Science Cluster created we can now apply the dashboard configurati
 oc apply -f manifests/04-rhoai-config/odh-dashboard-config.yaml
 ----
 
-NOTE: On subsequent runs (CRDs already exist), `oc apply -k manifests/04-rhoai-config/` works in one shot.
+NOTE: On subsequent runs (CRDs already exist), `oc apply -k manifests/04-rhoai-config/` works in one shot. The kustomization includes the 3.5+ DSC by default - for RHOAI 3.4, apply the individual files as shown above.
 
 == Verify
 
@@ -204,8 +204,9 @@ oc get odhdashboardconfig odh-dashboard-config -n redhat-ods-applications \
 Verify the following flags are set:
 
 * `modelAsService: true` - enables the Models as a Service tab
-* `genAiStudio: true` - enables the GenAI Studio tab (requires llamastackoperator Managed)
+* `genAiStudio: true` - enables the GenAI Studio tab (requires `ogx` Managed on 3.5+ or `llamastackoperator` Managed on 3.4)
 * `observabilityDashboard: true` - enables the Observability tab (requires COO + monitoring configured)
+* `externalModels: true` - enables surfacing regular model deployments as AI asset endpoints alongside MaaS models
 
 NOTE: The `maasAuthPolicies` flag was removed from the OdhDashboardConfig CRD in RHOAI 3.5. Do not include it in the manifest - the admission webhook will reject it.
 

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -12,7 +12,7 @@ IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} docum
 * MaaS Gateway available in `openshift-ingress` namespace
 * `maas-api` and `maas-controller` pods running (in `redhat-ai-gateway-infra` on RHOAI 3.5+, or `redhat-ods-applications` on 3.4)
 
-IMPORTANT: GPU models use FP8 quantization, which requires NVIDIA GPUs with compute capability >= 80 (Ampere architecture or newer). T4 GPUs (compute capability 75) and A10G GPUs are *not supported* with the current vLLM version. Use L4, L40, L40S, A100, or H100 GPUs.
+IMPORTANT: GPU models use FP8 quantization, which requires NVIDIA GPUs with compute capability >= 80 (Ampere architecture or newer). T4 GPUs (compute capability 75) are *not supported* with the current vLLM version. Use A10G, L4, L40, L40S, A100, or H100 GPUs.
 
 == Available Models
 
@@ -29,7 +29,7 @@ A CPU-only mock LLM that requires no GPU. It uses the `llm-d-inference-sim` cont
 
 Red Hat AI Granite 4.0-h-tiny FP8 Dynamic, a small Granite model (~1B parameters) running on the Red Hat AI Inference Server (vLLM CUDA). Suitable for clusters with modest GPU resources.
 
-* *Runtime*: vLLM CUDA (registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0)
+* *Runtime*: vLLM CUDA (registry.redhat.io/rhaii/vllm-cuda-rhel9:3.3.0)
 * *Model weights*: OCI modelcar from registry.redhat.io
 * *Resources*: 2-4 CPU, 8Gi-24Gi memory, 1x NVIDIA GPU
 * *GPU memory*: ~8GB required
@@ -39,7 +39,7 @@ Red Hat AI Granite 4.0-h-tiny FP8 Dynamic, a small Granite model (~1B parameters
 
 Google Gemma 2 9B IT FP8 running on the Red Hat AI Inference Server (vLLM CUDA). A 9B parameter instruction-tuned model with FP8 quantization, suitable for general-purpose text generation and code tasks. Fits on a single L4 GPU (24GB VRAM).
 
-* *Runtime*: vLLM CUDA (registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0)
+* *Runtime*: vLLM CUDA (registry.redhat.io/rhaii/vllm-cuda-rhel9:3.3.0)
 * *Model weights*: OCI modelcar `registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5`
 * *Resources*: 2-4 CPU, 8Gi-24Gi memory, 1x NVIDIA GPU
 * *GPU memory*: ~12GB required (FP8 quantized)
@@ -52,7 +52,7 @@ NOTE: Gemma is a US-origin model, making it suitable for deployments with export
 
 OpenAI gpt-oss-20b running on the Red Hat AI Inference Server (vLLM CUDA). Requires a capable GPU node (L4 or better) with sufficient VRAM.
 
-* *Runtime*: vLLM CUDA (registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0)
+* *Runtime*: vLLM CUDA (registry.redhat.io/rhaii/vllm-cuda-rhel9:3.3.0)
 * *Model weights*: OCI modelcar from registry.redhat.io (~8GB download)
 * *Resources*: 2-4 CPU, 16Gi-60Gi memory, 1x NVIDIA GPU
 * *GPU memory*: ~16GB required

--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -167,7 +167,7 @@ Patch the MaaS Config to enable the usage logging pipeline:
 
 [source,bash]
 ----
-oc patch configs.maas.opendatahub.io default --type=merge \
+oc patch configs.maas.opendatahub.io default -n models-as-a-service --type=merge \
   -p '{"spec":{"usageLogging":true}}'
 ----
 

--- a/content/modules/ROOT/pages/08-architecture.adoc
+++ b/content/modules/ROOT/pages/08-architecture.adoc
@@ -133,4 +133,5 @@ Built by link:https://github.com/noyitz[Noy Itzikowitz^]
 
 * link:https://opendatahub-io.github.io/models-as-a-service/latest/concepts/architecture/[Upstream MaaS Architecture]
 * link:https://noyitz.github.io/ai-gateway-docs/ai-gateway-flow.html[AI Gateway Flow Visualizer]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.5 MaaS Official Docs]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[RHOAI 3.4 MaaS Official Docs]

--- a/content/modules/ROOT/pages/09-cleanup.adoc
+++ b/content/modules/ROOT/pages/09-cleanup.adoc
@@ -4,7 +4,7 @@ Remove {maas} and its dependencies from your OpenShift cluster.
 
 == Automated Cleanup
 
-The cleanup script reverses `setup-maas.sh` in reverse order, checking whether each resource exists before deleting.
+The cleanup script undoes `setup-maas.sh` in reverse order, checking whether each resource exists before deleting.
 
 [source,bash]
 ----

--- a/content/modules/ROOT/pages/10-post-upgrade-troubleshooting.adoc
+++ b/content/modules/ROOT/pages/10-post-upgrade-troubleshooting.adoc
@@ -149,7 +149,7 @@ metadata:
   namespace: <model-ns>
 spec:
   endpoint: "your-provider-endpoint.com"
-  provider: "openai"  # or anthropic, azure, aws-bedrock, vertex
+  provider: "openai"  # or anthropic, azure-openai, bedrock-openai
   auth:
     type: apikey
     secretRef:

--- a/content/modules/ROOT/pages/claude-code.adoc
+++ b/content/modules/ROOT/pages/claude-code.adoc
@@ -6,7 +6,7 @@ The skill works with any AI coding tool that supports skill definitions:
 
 * link:https://claude.ai/code[Claude Code] / link:https://opencode.ai[Open Code]
 * link:https://cursor.com[Cursor]
-* link:https://roosoft.com[Roo Code]
+* link:https://roocode.com[Roo Code]
 * Other AI coding agents with skill support
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).

--- a/content/modules/ROOT/pages/quick-start.adoc
+++ b/content/modules/ROOT/pages/quick-start.adoc
@@ -160,6 +160,21 @@ Or use the standalone model script for more control:
 ./scripts/deploy-model.sh --model simulator
 ----
 
+=== With external OIDC authentication
+
+After the base installation, add Keycloak-based OIDC authentication so users can access MaaS with their corporate credentials instead of OpenShift tokens:
+
+[source,bash]
+----
+# Deploy Keycloak + configure MaaS for OIDC
+./manifests/09-external-oidc/setup-keycloak.sh
+
+# Verify the OIDC flow (tokens, API keys, inference, group access)
+./manifests/09-external-oidc/test-external-oidc.sh
+----
+
+See xref:09-external-oidc.adoc[Phase 9: External OIDC Authentication] for the full manual walkthrough and Bring Your Own IdP instructions.
+
 === Verify only
 
 [source,bash]
@@ -190,6 +205,12 @@ These wrap individual phases for standalone use:
 
 | `scripts/verify-maas.sh`
 | Phase 6 only - wrapper for `manifests/06-verification/verify.sh`
+
+| `manifests/09-external-oidc/setup-keycloak.sh`
+| Phase 9 - deploy Keycloak + configure OIDC on the MaaS tenant (`--cleanup` to revert)
+
+| `manifests/09-external-oidc/test-external-oidc.sh`
+| Phase 9 verification - 6-test OIDC flow (tokens, API keys, inference, group access)
 |===
 
 == State Detection
@@ -206,7 +227,7 @@ Override with `--from-phase N` to force re-running from a specific phase.
 
 == AI-Assisted Installation
 
-If you use an AI coding tool (link:https://claude.ai/code[Claude Code], link:https://opencode.ai[Open Code], link:https://cursor.com[Cursor], link:https://roosoft.com[Roo Code]), the `/install-maas` skill wraps the same script with an interactive, AI-assisted workflow. Clone the repo, open it in your tool, and run:
+If you use an AI coding tool (link:https://claude.ai/code[Claude Code], link:https://opencode.ai[Open Code], link:https://cursor.com[Cursor], link:https://roocode.com[Roo Code]), the `/install-maas` skill wraps the same script with an interactive, AI-assisted workflow. Clone the repo, open it in your tool, and run:
 
 [source]
 ----


### PR DESCRIPTION
## Summary

Full page-by-page review of all 16 guide pages. Found and fixed 13 issues across 10 files. E2E validated on cluster-b72dq (OCP 4.21, SNO, platform=None) - all phases pass.

### Critical fixes (broken/wrong)
- **Broken xref**: `_gateway_pod_oomkill_prevention` - 3 xrefs pointed at a non-existent anchor in 02-platform-config. Added the `[[_gateway_pod_oomkill_prevention]]` anchor before the NOTE block
- **Wrong URL**: Roo Code pointed to `roosoft.com` instead of `roocode.com` (quick-start + claude-code)
- **Missing namespace**: `oc patch configs.maas.opendatahub.io default` in observability page was missing `-n models-as-a-service`
- **Stale ref**: `llamastackoperator` mentioned without the 3.5 `ogx` equivalent in RHOAI config page
- **Missing flag**: `externalModels: true` not listed in the dashboard flag verification checklist
- **Wrong OCP version**: 02-platform-config said 4.17+, should be 4.19+ (matches index.adoc)
- **Wrong GPU support**: A10G listed as "not supported" but it has compute capability 86 (Ampere) and works fine
- **Wrong registry path**: vLLM image path said `rhaiis` but manifests use `rhaii` (3 occurrences)

### Medium fixes (unclear/confusing)
- **Cross-namespace DNS**: maas-db-config note didn't mention FQDN requirement for cross-namespace secret copy
- **Kustomize caveat**: `oc apply -k` note didn't warn that the kustomization uses 3.5+ DSC by default
- **Missing docs link**: Architecture page referenced only 3.4 docs, added 3.5
- **Redundant wording**: Cleanup page said "reverses in reverse"
- **Provider name mismatch**: Troubleshooting page used `azure`/`aws-bedrock` vs external-models page's `azure-openai`/`bedrock-openai`

## Test plan

- [x] Antora build: 0 FATAL/ERROR
- [x] Grep `roosoft` = 0 results
- [x] Grep `_gateway_pod_oomkill_prevention` = 1 anchor + 3 references
- [x] Grep `rhaiis` = 0 results in docs (only `rhaii`)
- [x] E2E on cluster-b72dq: setup-maas.sh 14/14, manual deploy + inference + auth all pass