### PR TITLE
ci: add supplemental-ui to gh-pages trigger paths

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - 'content/**'
+      - 'supplemental-ui/**'
       - 'site.yml'
       - '.github/workflows/gh-pages.yml'
   pull_request:
     branches: [main]
     paths:
       - 'content/**'
+      - 'supplemental-ui/**'
       - 'site.yml'
       - '.github/workflows/gh-pages.yml'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add `supplemental-ui/**` to the push/PR paths filter in the gh-pages workflow
- Without this, changes to the logo or header overrides don't trigger a site rebuild (e.g. PR #123 logo change didn't deploy until PR #124 touched content files)