### PR TITLE
fix: make CAI Team logo clickable

### DIFF
--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -1,9 +1,9 @@
 <header class="header">
   <nav class="navbar">
     <div class="navbar-brand">
-      <span class="navbar-item navbar-logo">
+      <a class="navbar-item navbar-logo" href="https://rh-aiservices-bu.github.io/cai/" target="_blank">
         <img src="{{uiRootPath}}/img/logo-demo-platform.svg" alt="Red Hat CAI Team" class="navbar-logo-img">
-      </span>
+      </a>
       <a class="navbar-item site-title" target="_blank" href="{{{or site.url (or siteRootUrl siteRootPath)}}}">{{site.title}}</a>
     </div>
     <div id="topbar-nav" class="navbar-menu">


### PR DESCRIPTION
## Summary
- Wrap the CAI Team navbar logo in a link to https://rh-aiservices-bu.github.io/cai/
- Consistent with the footer which already links to the CAI team