### PR TITLE
Add Qwen3-0.6B as a CPU-only model

### DIFF
--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -58,6 +58,19 @@ OpenAI gpt-oss-20b running on the Red Hat AI Inference Server (vLLM CUDA). Requi
 * *GPU memory*: ~16GB required
 * *Startup time*: 5-15 minutes (image pull + model loading)
 
+=== qwen3-06b
+
+Qwen3-0.6B running on the Red Hat AI Inference Server (vLLM CPU). A small but capable 0.6B parameter model that runs entirely on CPU - no GPU required. Good for clusters without GPU infrastructure that still need a real (non-simulated) LLM endpoint.
+
+* *Runtime*: vLLM CPU (registry.redhat.io/rhaiis/vllm-cpu-rhel9)
+* *Model weights*: HuggingFace `hf://Qwen/Qwen3-0.6B`
+* *Resources*: 4-8 CPU, 16Gi memory
+* *GPU*: Not required
+* *Context length*: 2048 tokens
+* *Startup time*: 2-5 minutes (HuggingFace download + CPU model loading)
+
+NOTE: This model downloads weights from HuggingFace (`hf://`), so it is subject to the same HuggingFace Xet download hang described above for the simulator. If the pod is stuck in `Init:0/1`, apply the `HF_HUB_DISABLE_XET` workaround.
+
 === simulator-disconnected
 
 A variant of the simulator for air-gapped clusters. Uses `oci://` storage URI instead of `hf://` because HuggingFace is unreachable in disconnected environments. Functionally identical to the connected simulator - the inference container generates random responses regardless of the model URI.
@@ -159,6 +172,14 @@ For disconnected (air-gapped) clusters, use the disconnected simulator variant:
 [source,bash]
 ----
 oc apply -k manifests/05-maas-models/simulator-disconnected/
+----
+
+Or deploy a CPU model that provides real inference without GPU:
+
+[source,bash]
+----
+# Qwen3-0.6B (CPU-only, no GPU required)
+oc apply -k manifests/05-maas-models/qwen3-06b/
 ----
 
 Or deploy a GPU model if your cluster has NVIDIA GPUs:

--- a/manifests/05-maas-models/qwen3-06b/kustomization.yaml
+++ b/manifests/05-maas-models/qwen3-06b/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - llm
+  - maas

--- a/manifests/05-maas-models/qwen3-06b/llm/kustomization.yaml
+++ b/manifests/05-maas-models/qwen3-06b/llm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: llm
+resources:
+  - model.yaml

--- a/manifests/05-maas-models/qwen3-06b/llm/model.yaml
+++ b/manifests/05-maas-models/qwen3-06b/llm/model.yaml
@@ -1,0 +1,77 @@
+# Qwen3-0.6B on vLLM CPU
+# A small Qwen3 model (~0.6B params) that runs on CPU without GPU
+# Model weights: HuggingFace hf://Qwen/Qwen3-0.6B
+# Runtime: Red Hat AI Inference Server (vLLM CPU)
+# Requires: 4-8 CPU cores, 16Gi memory, no GPU needed
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: qwen3-06b
+  annotations:
+    openshift.io/display-name: "Qwen/Qwen3-0.6B"
+    opendatahub.io/model-type: generative
+    security.opendatahub.io/enable-auth: "true"
+  labels:
+    opendatahub.io/dashboard: "true"
+    opendatahub.io/genai-asset: "true"
+spec:
+  model:
+    name: qwen3-06b
+    uri: hf://Qwen/Qwen3-0.6B
+  replicas: 1
+  router:
+    route: {}
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
+  template:
+    containers:
+      - name: main
+        image: registry.redhat.io/rhaiis/vllm-cpu-rhel9@sha256:f05e773647dddd37ec6c2215cb14bec87e4ab5a7d37f2e110d16cd92355427d3
+        command:
+          - python
+          - -m
+          - vllm.entrypoints.openai.api_server
+        args:
+          - "--served-model-name={{.Name}}"
+          - --model=/mnt/models
+          - --max-model-len=2048
+          - --enable-ssl-refresh
+          - --ssl-certfile=/var/run/kserve/tls/tls.crt
+          - --ssl-keyfile=/var/run/kserve/tls/tls.key
+          - --enable-force-include-usage
+        env:
+          - name: HF_HOME
+            value: /tmp/hf_home
+          - name: VLLM_CPU_KVCACHE_SPACE
+            value: "4"
+        ports:
+          - containerPort: 8000
+            name: http
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          initialDelaySeconds: 300
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          initialDelaySeconds: 300
+          periodSeconds: 15
+          timeoutSeconds: 15
+          failureThreshold: 30
+        resources:
+          requests:
+            cpu: "4"
+            memory: 16Gi
+          limits:
+            cpu: "8"
+            memory: 16Gi

--- a/manifests/05-maas-models/qwen3-06b/maas/kustomization.yaml
+++ b/manifests/05-maas-models/qwen3-06b/maas/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - maas-model.yaml
+  - maas-auth-policy.yaml
+  - maas-subscription-free.yaml
+  - maas-subscription-premium.yaml

--- a/manifests/05-maas-models/qwen3-06b/maas/maas-auth-policy.yaml
+++ b/manifests/05-maas-models/qwen3-06b/maas/maas-auth-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: qwen3-06b-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Qwen3-0.6B Access"
+    openshift.io/description: "Grants all authenticated users access to Qwen3-0.6B"
+spec:
+  modelRefs:
+    - name: qwen3-06b
+      namespace: llm
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []

--- a/manifests/05-maas-models/qwen3-06b/maas/maas-model.yaml
+++ b/manifests/05-maas-models/qwen3-06b/maas/maas-model.yaml
@@ -1,0 +1,12 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: qwen3-06b
+  namespace: llm
+  annotations:
+    openshift.io/display-name: "Qwen/Qwen3-0.6B"
+    openshift.io/description: "Qwen3 0.6B model on vLLM CPU - no GPU required"
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: qwen3-06b

--- a/manifests/05-maas-models/qwen3-06b/maas/maas-subscription-free.yaml
+++ b/manifests/05-maas-models/qwen3-06b/maas/maas-subscription-free.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: qwen3-06b-free
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Qwen3-0.6B Free Tier"
+    openshift.io/description: "Free tier: 100 tokens/min for all authenticated users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: qwen3-06b
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100
+          window: 1m
+  priority: 10

--- a/manifests/05-maas-models/qwen3-06b/maas/maas-subscription-premium.yaml
+++ b/manifests/05-maas-models/qwen3-06b/maas/maas-subscription-premium.yaml
@@ -1,0 +1,20 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: qwen3-06b-premium
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Qwen3-0.6B Premium Tier"
+    openshift.io/description: "Premium tier: 100000 tokens/min for all authenticated users"
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: qwen3-06b
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100000
+          window: 1m
+  priority: 20


### PR DESCRIPTION
## Summary

- Adds Qwen3-0.6B running on vLLM CPU to the model catalog. This is the first real model in the guide that does not need a GPU - good for clusters that have no GPU nodes but still want actual inference (not just the simulator).
- Converted from the InferenceService + ServingRuntime pair in the fed-aura workshop repo into a single LLMInferenceService following the guide pattern.
- Full kustomize layout: LLMInferenceService, MaaSModelRef, MaaSAuthPolicy, free and premium subscriptions.
- Updated the Phase 5 adoc page with the model listing and deploy command.

## Details

- Image: `registry.redhat.io/rhaiis/vllm-cpu-rhel9` (Red Hat vLLM CPU runtime)
- Model weights: `hf://Qwen/Qwen3-0.6B` (downloaded from HuggingFace)
- Resources: 4-8 CPU, 16Gi memory, no GPU
- Context length: 2048 tokens
- `spec.model.name` set to `qwen3-06b` to match what `{{.Name}}` resolves to in vLLM's `--served-model-name`

## Test plan

- [x] Deployed on a live RHPDS cluster (cluster-rkrnk)
- [x] LLMInferenceService reaches Ready
- [x] MaaSModelRef reaches Ready phase
- [x] MaaSAuthPolicy and MaaSSubscriptions are Active
- [x] Inference works through the MaaS API (`/v1/chat/completions`)
- [ ] Verify kustomize build: `oc kustomize manifests/05-maas-models/qwen3-06b/`
- [ ] Antora build renders the new model section correctly