### PR TITLE
docs: add gateway proxy workaround for OCP < 4.22

### DIFF
--- a/content/modules/ROOT/pages/02-platform-config.adoc
+++ b/content/modules/ROOT/pages/02-platform-config.adoc
@@ -401,6 +401,77 @@ maas-default-gateway-https   maas.apps.<cluster-domain>                    maas-
 ----
 
 
+[id=step-5f-proxy]
+=== Step 5f: Corporate Proxy Configuration (OCP < 4.22 Only)
+
+On OCP versions before 4.22, the OpenShift Gateway controller does not propagate the cluster-wide proxy settings (`config.openshift.io/v1 Proxy`) into the gateway pod. If your cluster sits behind a corporate HTTP proxy, the istio-proxy container cannot reach external endpoints - this breaks ExternalModel provider calls and WASM plugin OCI image pulls.
+
+This is tracked as link:https://redhat.atlassian.net/browse/OCPBUGS-77457[OCPBUGS-77457^] and is fixed in OCP 4.22+. On earlier versions, you must inject the proxy env vars manually through the gateway ConfigMap.
+
+NOTE: If your cluster is **not** behind a corporate proxy, or you are on OCP 4.22+, skip this step.
+
+*Detect if this applies to you:*
+
+[source,bash]
+----
+# Check OCP version
+oc get clusterversion version -o jsonpath='{.status.desired.version}'
+
+# Check if the cluster has a proxy configured
+oc get proxy/cluster -o jsonpath='{.spec.httpProxy}'
+----
+
+If the OCP version is below 4.22 and `httpProxy` returns a value, apply the proxy-aware ConfigMap.
+
+*Step 5f.1:* Extract the proxy values from the cluster-wide Proxy config:
+
+[source,bash]
+----
+export HTTP_PROXY=$(oc get proxy/cluster -o jsonpath='{.spec.httpProxy}')
+export HTTPS_PROXY=$(oc get proxy/cluster -o jsonpath='{.spec.httpsProxy}')
+export NO_PROXY=$(oc get proxy/cluster -o jsonpath='{.spec.noProxy}')
+echo "HTTP_PROXY=${HTTP_PROXY}"
+echo "HTTPS_PROXY=${HTTPS_PROXY}"
+echo "NO_PROXY=${NO_PROXY}"
+----
+
+*Step 5f.2:* Apply the proxy-aware ConfigMap (this replaces the `gateway-resources.yaml` applied in Step 5b - it includes the same 2Gi memory limit plus the proxy env vars):
+
+[source,bash]
+----
+envsubst '${HTTP_PROXY} ${HTTPS_PROXY} ${NO_PROXY}' \
+  < manifests/02-platform-config/gateway-resources-proxy.yaml.tmpl \
+  | oc apply -f -
+----
+
+The gateway pod will restart automatically. Wait for it to come back:
+
+[source,bash]
+----
+oc rollout status deployment/maas-default-gateway-openshift-default \
+  -n openshift-ingress --timeout=120s
+----
+
+*Step 5f.3:* Verify the proxy env vars are set on the gateway pod:
+
+[source,bash]
+----
+GATEWAY_POD=$(oc get pods -n openshift-ingress \
+  -l gateway.networking.k8s.io/gateway-name=maas-default-gateway \
+  -o jsonpath='{.items[0].metadata.name}')
+oc exec "${GATEWAY_POD}" -n openshift-ingress -c istio-proxy \
+  -- env | grep -i proxy
+----
+
+You should see `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` with the correct values.
+
+[NOTE]
+====
+*How it works:* The `gateway-resources-proxy.yaml.tmpl` produces the same `maas-gateway-options` ConfigMap that the Gateway already references via `spec.infrastructure.parametersRef`. The gateway controller merges this ConfigMap into the generated Deployment, injecting the proxy env vars into the istio-proxy container alongside the 2Gi memory limit.
+
+If you already applied `gateway-resources.yaml` in Step 5b, this step overwrites it with the proxy-aware version. The ConfigMap name (`maas-gateway-options`) and the Gateway's `parametersRef` remain unchanged.
+====
+
 == Verification
 
 After completing all steps, confirm the full platform state:
@@ -483,6 +554,7 @@ curl -vsk https://maas.${CLUSTER_DOMAIN} 2>&1 | grep -E "SSL connection|Connecte
 ----
 manifests/02-platform-config/
   gateway-resources.yaml         # ConfigMap: gateway proxy resource overrides (2Gi memory)
+  gateway-resources-proxy.yaml.tmpl  # ConfigMap: proxy-aware variant (2Gi memory + HTTP_PROXY env vars, OCP < 4.22)
   gateway.yaml.tmpl              # Gateway template (envsubst, references ConfigMap via parametersRef)
   gatewayclass.yaml              # GatewayClass resource
   kustomization.yaml             # Aggregates all subdirectories

--- a/manifests/02-platform-config/gateway-resources-proxy.yaml.tmpl
+++ b/manifests/02-platform-config/gateway-resources-proxy.yaml.tmpl
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maas-gateway-options
+  namespace: openshift-ingress
+data:
+  deployment: |
+    spec:
+      template:
+        spec:
+          containers:
+          - name: istio-proxy
+            env:
+            - name: HTTP_PROXY
+              value: "${HTTP_PROXY}"
+            - name: HTTPS_PROXY
+              value: "${HTTPS_PROXY}"
+            - name: NO_PROXY
+              value: "${NO_PROXY}"
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: "2"
+                memory: 2Gi


### PR DESCRIPTION
Closes #136

## Summary

- On OCP < 4.22 behind corporate proxy, the gateway pod does not get the cluster-wide proxy settings (OCPBUGS-77457). ExternalModel calls and WASM OCI pulls fail.
- Added Step 5f in `02-platform-config.adoc` as a conditional step (same pattern as MetalLB and passthrough route steps) - users check OCP version + proxy config, skip if not needed.
- New `gateway-resources-proxy.yaml.tmpl` template that extends the existing ConfigMap with HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars alongside the 2Gi memory limit.
- Credit to pierDipi and Erkan Ercan for the original workaround.

## Test plan

- [x] Applied proxy template on cluster-rkrnk (OCP 4.21.30, non-proxy) - env vars injected into gateway pod
- [x] Deployed tinyproxy as a forward proxy on the cluster, pointed gateway at it - gateway routes through proxy, tinyproxy access logs confirm traffic
- [x] Internal MaaS API traffic bypasses proxy via NO_PROXY - HTTP 200, 3 models returned
- [x] Gateway stays Programmed=True through apply and revert cycles
- [x] Reverted to original ConfigMap - clean, no leftover env vars
- [x] Template renders valid YAML with envsubst for both empty and real proxy values