### PR TITLE
docs: add Limitador persistence with Redis (#141)

### DIFF
--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -182,6 +182,94 @@ oc get persesdashboard -n redhat-ods-monitoring | grep usage-logs
 
 The usage dashboards will appear in the RHOAI console under *Observe & monitor > Dashboard*, showing per-model token consumption, per-user breakdowns, and subscription usage.
 
+== Step 7: Limitador Persistence with Redis (Optional)
+
+By default, Limitador stores rate-limit counters in memory. If the Limitador pod restarts, scales, or gets rescheduled, all counters reset to zero. For example, with a 7-day rate limit window, a pod restart on day 6 gives every user a full quota refresh for the remaining window period. For production deployments, configure Redis as a persistent backend so counters survive pod lifecycle events.
+
+NOTE: Limitador supports additional storage backends beyond Redis. See the link:https://github.com/Kuadrant/limitador/blob/main/doc/server/configuration.md[Limitador configuration documentation] for details. This guide focuses on Redis.
+
+=== Step 7a: Deploy Redis (Dev/Test)
+
+[source,bash]
+----
+oc apply -k manifests/07-observability/redis/
+----
+
+Wait for the Redis deployment:
+
+[source,bash]
+----
+oc wait --for=condition=available deployment/redis -n redis-limitador --timeout=120s
+----
+
+WARNING: This deploys a single-replica, non-HA Redis instance with persistence disabled (no RDB/AOF). Data is stored in memory only and will be lost if the Redis pod itself restarts. This is for development and testing. For production, use a supported Redis-based data store - see the production guidance below.
+
+=== Step 7b: Configure Limitador for Redis
+
+Patch the Limitador CR to use the Redis secret created by the kustomize manifests:
+
+[source,bash]
+----
+oc patch limitador limitador -n kuadrant-system --type=merge -p '{
+  "spec": {
+    "storage": {
+      "redis": {
+        "configSecretRef": {
+          "name": "redis-config"
+        }
+      }
+    }
+  }
+}'
+----
+
+The Limitador operator will restart the pod automatically.
+
+=== Step 7c: Verify Redis Connection
+
+Verify the Limitador CR has the Redis storage configured:
+
+[source,bash]
+----
+oc get limitador limitador -n kuadrant-system -o jsonpath='{.spec.storage}'
+# Expected: {"redis":{"configSecretRef":{"name":"redis-config"}}}
+----
+
+Test that counters survive a pod restart. First make a few inference requests (using an existing API key) to populate Redis, then restart Limitador:
+
+[source,bash]
+----
+# Check Redis has keys (should be > 0 after making requests):
+oc exec -n redis-limitador deploy/redis -- redis-cli DBSIZE
+
+# Restart Limitador:
+oc delete pod -n kuadrant-system -l app=limitador
+oc wait --for=condition=ready pod -n kuadrant-system -l app=limitador --timeout=60s
+
+# Check Redis still has keys after restart:
+oc exec -n redis-limitador deploy/redis -- redis-cli DBSIZE
+----
+
+If the DBSIZE is the same before and after the restart, counters survived and Redis persistence is working.
+
+=== Production Redis guidance
+
+For production deployments, use a supported Redis-based data store instead of the dev instance above. Supported options include Redis Enterprise, Amazon ElastiCache, and Dragonfly.
+
+The configuration is the same - create a Secret with the Redis URL and patch the Limitador CR:
+
+[source,bash]
+----
+# Example with a production Redis endpoint
+oc -n kuadrant-system create secret generic redis-config \
+  --from-literal=URL=rediss://user:password@your-redis.example.com:6380 \
+  --dry-run=client -o yaml | oc apply -f -
+----
+
+For complete production setup steps, see the link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1-latest/html/installing_on_openshift_container_platform/rhcl-install-on-ocp#configure-redis_installing-rhcl-on-ocp[Red Hat Connectivity Link - Configure Redis] documentation.
+
+TIP: The link:https://developers.redhat.com/articles/2026/07/06/track-model-usage-openshift-ai-usage-dashboard[Track model usage with the OpenShift AI Usage Dashboard] article explains how Limitador counters feed the usage dashboard metrics (`authorized_calls`, `rate_limited`, `authorized_hits`). Without Redis, these metrics reset on pod restart. For accurate long-term usage tracking, RHOAI 3.5 also provides logs-based usage dashboards (Step 6 above) which are independent of Limitador counter persistence.
+
 == Verification
 
 Check all four observability operators are installed:
@@ -232,6 +320,23 @@ Check the Istio Telemetry exists:
 oc get telemetry.telemetry.istio.io latency-per-subscription -n openshift-ingress
 ----
 
+Check Redis is running (if deployed):
+
+[source,bash]
+----
+oc get deployment redis -n redis-limitador
+# Expected: READY 1/1
+
+oc get secret redis-config -n kuadrant-system
+# Expected: secret exists
+
+oc get limitador limitador -n kuadrant-system -o jsonpath='{.spec.storage}'
+# Expected: {"redis":{"configSecretRef":{"name":"redis-config"}}}
+
+oc exec -n redis-limitador deploy/redis -- redis-cli DBSIZE
+# Expected: > 0 (after making at least one inference request)
+----
+
 == Appendix
 
 === Directory Structure
@@ -268,6 +373,12 @@ manifests/07-observability/
     minio.yaml                       # MinIO deployment + bucket job
     minio-secret.yaml                # S3 credentials for Loki
     lokistack.yaml                   # LokiStack CR (edit storageClassName for your cluster)
+  redis/
+    kustomization.yaml               # Redis dev instance for Limitador persistence
+    namespace.yaml                   # redis-limitador namespace
+    redis.yaml                       # Redis Deployment + Service (dev-only)
+    redis-secret.yaml                # Redis URL secret (in kuadrant-system)
+    limitador-patch.yaml             # Limitador CR patch reference (not applied by kustomize)
 ----
 
 == References
@@ -280,6 +391,9 @@ manifests/07-observability/
 * link:https://docs.kuadrant.io/dev/kuadrant-operator/doc/reference/telemetrypolicy/[Kuadrant TelemetryPolicy]
 * link:https://developers.redhat.com/articles/2026/07/06/track-model-usage-openshift-ai-usage-dashboard[Track model usage with the OpenShift AI Usage Dashboard]
 * link:https://opendatahub-io.github.io/models-as-a-service/dev/observability/setup/#logs-based-usage-dashboards[MaaS upstream - Logs-based Usage Dashboards]
+* link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1-latest/html/installing_on_openshift_container_platform/rhcl-install-on-ocp#configure-redis_installing-rhcl-on-ocp[RHCL - Configure Redis for Limitador]
+* link:https://opendatahub-io.github.io/models-as-a-service/dev/advanced-administration/limitador-persistence/[MaaS upstream - Limitador Persistence]
+* link:https://github.com/Kuadrant/limitador/blob/main/doc/server/configuration.md[Limitador server configuration (storage backends)]
 
 == Next step
 

--- a/manifests/07-observability/redis/kustomization.yaml
+++ b/manifests/07-observability/redis/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - redis.yaml
+  - redis-secret.yaml

--- a/manifests/07-observability/redis/limitador-patch.yaml
+++ b/manifests/07-observability/redis/limitador-patch.yaml
@@ -1,0 +1,13 @@
+# Reference patch for the Limitador CR.
+# Apply via: oc patch limitador limitador -n kuadrant-system --type=merge --patch-file manifests/07-observability/redis/limitador-patch.yaml
+# NOT included in kustomization.yaml because the Limitador CR is created by the Kuadrant operator.
+apiVersion: limitador.kuadrant.io/v1alpha1
+kind: Limitador
+metadata:
+  name: limitador
+  namespace: kuadrant-system
+spec:
+  storage:
+    redis:
+      configSecretRef:
+        name: redis-config

--- a/manifests/07-observability/redis/namespace.yaml
+++ b/manifests/07-observability/redis/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redis-limitador

--- a/manifests/07-observability/redis/redis-secret.yaml
+++ b/manifests/07-observability/redis/redis-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-config
+  namespace: kuadrant-system
+type: Opaque
+stringData:
+  URL: "redis://redis-service.redis-limitador.svc:6379"

--- a/manifests/07-observability/redis/redis.yaml
+++ b/manifests/07-observability/redis/redis.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: redis-limitador
+  labels:
+    app: redis
+    app.kubernetes.io/part-of: maas-limitador-persistence
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: registry.redhat.io/rhel9/redis-7
+        args:
+        - /usr/bin/run-redis
+        - --save ""
+        - --appendonly no
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+  namespace: redis-limitador
+  labels:
+    app: redis
+    app.kubernetes.io/part-of: maas-limitador-persistence
+spec:
+  selector:
+    app: redis
+  ports:
+  - protocol: TCP
+    port: 6379
+    targetPort: 6379

--- a/scripts/cleanup-maas.sh
+++ b/scripts/cleanup-maas.sh
@@ -247,6 +247,20 @@ if should_run 2; then
         log_info "  Tempo operator not found, skipping"
     fi
 
+    # Redis for Limitador persistence
+    if oc get namespace redis-limitador >/dev/null 2>&1; then
+        log_info "  Removing Redis for Limitador..."
+        # Revert Limitador to in-memory storage
+        if oc get limitador limitador -n kuadrant-system >/dev/null 2>&1; then
+            run_cmd oc patch limitador limitador -n kuadrant-system --type=json \
+                -p '[{"op":"remove","path":"/spec/storage"}]' 2>/dev/null || true
+        fi
+        run_cmd oc delete -k "$MANIFESTS_DIR/07-observability/redis/" --ignore-not-found 2>/dev/null || true
+        delete_namespace "redis-limitador"
+    else
+        log_info "  Redis for Limitador not found, skipping"
+    fi
+
     log_info "Observability cleanup complete"
 fi
 

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -57,6 +57,7 @@ FROM_PHASE=0
 SKIP_MODELS=false
 SKIP_VERIFY=false
 WITH_OBSERVABILITY=false
+WITH_REDIS=false
 WITH_EXTERNAL_MODELS=false
 MAAS_HOSTNAME="${MAAS_HOSTNAME:-}"
 EXTERNAL_MODEL_PROVIDER="${EXTERNAL_MODEL_PROVIDER:-openai}"
@@ -72,6 +73,7 @@ while [[ $# -gt 0 ]]; do
         --skip-models) SKIP_MODELS=true; shift ;;
         --skip-verify) SKIP_VERIFY=true; shift ;;
         --with-observability) WITH_OBSERVABILITY=true; shift ;;
+        --with-redis) WITH_REDIS=true; shift ;;
         --with-external-models) WITH_EXTERNAL_MODELS=true; shift ;;
         --maas-hostname) MAAS_HOSTNAME="$2"; shift 2 ;;
         --external-model-provider) EXTERNAL_MODEL_PROVIDER="$2"; shift 2 ;;
@@ -96,6 +98,7 @@ Options:
   --skip-verify        Skip Phase 6 (verification)
   --disconnected       Disconnected/air-gapped mode (oci:// URIs, skip Phase 8)
   --with-observability Also run Phase 7 (Tempo + OpenTelemetry + COO + telemetry + Loki usage dashboards)
+  --with-redis           Deploy dev Redis for Limitador counter persistence (runs in Phase 7, can combine with --with-observability)
   --with-external-models Also run Phase 8 (ExternalModel deployment + test)
   --external-model-provider <p>   Provider: openai (default), gemini, bedrock (or set EXTERNAL_MODEL_PROVIDER)
   --external-model-api-key <key>  API key for external provider (or set EXTERNAL_MODEL_API_KEY)
@@ -110,7 +113,7 @@ Phases:
   4  RHOAI config       DSC with MaaS: Managed, Dashboard flags
   5  Deploy model       Auto-detect GPU, apply model Kustomize manifests
   6  Verify             6-phase E2E verification (API, auth, rate limits)
-  7  Observability      Tempo + OpenTelemetry + COO + telemetry + Loki usage dashboards (only with --with-observability)
+  7  Observability      Tempo + OpenTelemetry + COO + telemetry + Loki usage dashboards + Redis (only with --with-observability/--with-redis)
   8  External models    ExternalModel + governance (only with --with-external-models, skipped in --disconnected)
 
 Auto-detection (--model auto):
@@ -1091,9 +1094,10 @@ fi
 # =============================================================================
 # Phase 7: Observability (Optional)
 # =============================================================================
-if should_run 7 && [ "$WITH_OBSERVABILITY" = true ]; then
+if should_run 7 && { [ "$WITH_OBSERVABILITY" = true ] || [ "$WITH_REDIS" = true ]; }; then
     log_phase 7 "Observability"
 
+    if [ "$WITH_OBSERVABILITY" = true ]; then
     # Tempo Operator
     log_step "Installing Tempo Operator..."
     run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/tempo/"
@@ -1243,6 +1247,38 @@ if should_run 7 && [ "$WITH_OBSERVABILITY" = true ]; then
         run_cmd oc patch configs.maas.opendatahub.io default --type=merge \
             -p '{"spec":{"usageLogging":true}}'
         log_info "Usage logging enabled - operator will create EnvoyFilter, OTEL Collector, and Perses dashboards"
+    fi
+    fi # end WITH_OBSERVABILITY
+
+    # Redis for Limitador persistence (optional, any RHOAI version)
+    if [ "$WITH_REDIS" = true ]; then
+        log_step "Deploying Redis for Limitador persistence..."
+        run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/redis/"
+        if [ "$DRY_RUN" = false ]; then
+            log_info "Waiting for Redis deployment..."
+            oc wait --for=condition=available deployment/redis -n redis-limitador --timeout=120s 2>/dev/null || \
+                log_warn "Redis deployment not ready within 120s"
+        fi
+
+        log_step "Patching Limitador CR for Redis storage..."
+        run_cmd oc patch limitador limitador -n kuadrant-system --type=merge -p '{
+          "spec": {
+            "storage": {
+              "redis": {
+                "configSecretRef": {
+                  "name": "redis-config"
+                }
+              }
+            }
+          }
+        }'
+
+        if [ "$DRY_RUN" = false ]; then
+            log_info "Waiting for Limitador to reconnect with Redis..."
+            oc wait --for=condition=ready pod -n kuadrant-system -l app=limitador --timeout=60s 2>/dev/null || true
+            log_info "Limitador pod restarted with Redis storage configured"
+        fi
+        log_info "Redis for Limitador configured"
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Add Step 7 to the observability page covering Limitador persistence with Redis
- By default Limitador stores rate-limit counters in memory - they reset on pod restart. Redis keeps them alive across restarts
- New kustomize manifests in `manifests/07-observability/redis/` for a dev Redis instance (registry.redhat.io/rhel9/redis-7)
- New `--with-redis` flag for `setup-maas.sh` - can be used alone or combined with `--with-observability`
- Cleanup support in `cleanup-maas.sh` (reverts Limitador to in-memory, deletes Redis resources)
- Links to RHCL Redis production docs, upstream limitador-persistence docs, Red Hat Developer usage dashboard article, and Limitador server configuration

Customer asked about Redis for Limitador in MaaS. Engineering confirmed it's optional but recommended for production. The guide had zero mentions of Redis until now.

## Test plan

- [x] Tested on sandbox30 (AWS multi-node, OCP 4.21.31, RHOAI 3.5.0, RHCL 1.4.3) - manual step-by-step
- [x] Tested on cluster-hsk4p (SNO, platform=None, OCP 4.21.31) - full `setup-maas.sh --model simulator --with-redis`
- [x] Redis deployed, Limitador patched, counters stored in Redis (verified with redis-cli DBSIZE)
- [x] Counter persistence confirmed across Limitador pod restart on both clusters
- [x] 15/15 verify.sh on sandbox30, 14/14 on cluster-hsk4p - nothing broke
- [x] Scripts pass bash -n syntax check
- [x] Kustomize manifests build clean (`oc kustomize`)

Closes #141