### PR TITLE
Replace manual telemetry apply with operator auto-creation

### DIFF
--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -159,7 +159,7 @@ oc get telemetry.telemetry.istio.io -n openshift-ingress
 --
 ====
 
-NOTE: The manifests in `manifests/07-observability/telemetry/` are kept as reference for what the operator creates. You do not need to apply them manually.
+NOTE: The manifests in `manifests/07-observability/telemetry/` are kept as a reference. The operator-created resources may differ slightly in label expressions and dimensions. You do not need to apply them manually.
 
 == Step 6: Usage Dashboards with Loki (RHOAI 3.5+ Only)
 

--- a/content/modules/ROOT/pages/07-observability.adoc
+++ b/content/modules/ROOT/pages/07-observability.adoc
@@ -10,7 +10,7 @@ This phase adds *optional* observability enhancements on top of UWM:
 
 . *Cluster Observability Operator (COO)* - required for the Observability Dashboard tab in the {rhoai} UI. COO provides the Perses CRDs (`Perses`, `PersesDatasource`, `PersesDashboard`) that the RHOAI operator uses to deploy the dashboard backend.
 
-. *Gateway Telemetry* - per-model, per-user, per-subscription usage metrics on the MaaS gateway. Adds fine-grained labels (`model`, `user`, `subscription`, `organization_id`, `cost_center`) to gateway metrics for usage attribution and billing.
+. *Gateway Telemetry* (auto-created) - the RHOAI operator auto-creates a TelemetryPolicy and Istio Telemetry CR when telemetry is enabled on the MaasTenantConfig (3.5) or Tenant (3.4). These add per-model, per-subscription, and per-organization labels to gateway metrics for usage attribution.
 
 . *Loki Operator + Usage Dashboards* (RHOAI 3.5+ only) - log-based per-request usage tracking. The gateway emits structured OTLP access logs with token counts, user identity, and subscription info. Logs are shipped to a LokiStack via an OpenTelemetry Collector. The RHOAI console shows admin and user-scoped usage dashboards under *Observe & monitor*.
 
@@ -104,14 +104,62 @@ Wait for the DSCI to reconcile:
 oc wait --for=jsonpath='{.status.phase}'=Ready dsci/default-dsci --timeout=300s
 ----
 
-== Step 5: Apply Gateway Telemetry
+== Step 5: Enable Gateway Telemetry
 
-Once COO is installed and the MaaS gateway is running:
+The RHOAI operator auto-creates a TelemetryPolicy and an Istio Telemetry CR when telemetry is enabled on the MaaS tenant configuration. These add per-model, per-subscription, and per-organization labels to gateway Prometheus metrics. No manual YAML application is needed.
+
+[tabs]
+====
+RHOAI 3.5+ (MaasTenantConfig)::
++
+--
+Patch the `MaasTenantConfig` to enable telemetry:
 
 [source,bash]
 ----
-oc apply -k manifests/07-observability/telemetry/
+oc patch maastenantconfig default-tenant -n models-as-a-service \
+  --type=merge -p '{"spec":{"telemetry":{"enabled":true}}}'
 ----
+
+The operator creates a TelemetryPolicy with `model`, `subscription`, `organization_id`, and `cost_center` labels, plus an Istio Telemetry CR for `REQUEST_DURATION` per subscription. Verify they exist:
+
+[source,bash]
+----
+oc get telemetrypolicies.extensions.kuadrant.io -n openshift-ingress
+oc get telemetry.telemetry.istio.io -n openshift-ingress
+----
+
+Optional - enable per-user metrics (disabled by default for GDPR compliance):
+
+[source,bash]
+----
+oc patch maastenantconfig default-tenant -n models-as-a-service \
+  --type=merge -p '{"spec":{"telemetry":{"metrics":{"captureUser":true}}}}'
+----
+--
+
+RHOAI 3.4 (Tenant)::
++
+--
+Patch the `Tenant` CR to enable telemetry:
+
+[source,bash]
+----
+oc patch tenant default-tenant -n models-as-a-service \
+  --type=merge -p '{"spec":{"telemetry":{"enabled":true}}}'
+----
+
+Verify the auto-created resources:
+
+[source,bash]
+----
+oc get telemetrypolicies.extensions.kuadrant.io -n openshift-ingress
+oc get telemetry.telemetry.istio.io -n openshift-ingress
+----
+--
+====
+
+NOTE: The manifests in `manifests/07-observability/telemetry/` are kept as reference for what the operator creates. You do not need to apply them manually.
 
 == Step 6: Usage Dashboards with Loki (RHOAI 3.5+ Only)
 
@@ -306,19 +354,21 @@ oc get crd perses.perses.dev
 oc get crd lokistacks.loki.grafana.com
 ----
 
-Check the TelemetryPolicy exists:
+Check the TelemetryPolicy exists (auto-created by the operator):
 
 [source,bash]
 ----
-oc get telemetrypolicies.extensions.kuadrant.io maas-telemetry -n openshift-ingress
+oc get telemetrypolicies.extensions.kuadrant.io -n openshift-ingress
 ----
 
-Check the Istio Telemetry exists:
+Check the Istio Telemetry exists (auto-created by the operator):
 
 [source,bash]
 ----
-oc get telemetry.telemetry.istio.io latency-per-subscription -n openshift-ingress
+oc get telemetry.telemetry.istio.io -n openshift-ingress
 ----
+
+NOTE: If these resources are missing, verify that `spec.telemetry.enabled: true` is set on the MaasTenantConfig (3.5) or Tenant (3.4) CR.
 
 Check Redis is running (if deployed):
 
@@ -365,8 +415,8 @@ manifests/07-observability/
     operatorgroup.yaml               # Loki OperatorGroup
     subscription.yaml                # Loki Subscription
   telemetry/
-    gateway-telemetry-policy.yaml    # Kuadrant TelemetryPolicy
-    istio-gateway-telemetry.yaml     # Istio Telemetry CR
+    gateway-telemetry-policy.yaml    # Kuadrant TelemetryPolicy (reference - auto-created by operator)
+    istio-gateway-telemetry.yaml     # Istio Telemetry CR (reference - auto-created by operator)
     kustomization.yaml
   usage-logging/
     kustomization.yaml               # MinIO + LokiStack

--- a/content/modules/ROOT/pages/release-notes.adoc
+++ b/content/modules/ROOT/pages/release-notes.adoc
@@ -28,6 +28,8 @@ Each entry links to its pull request for full details.
 
 * *Gateway Proxy Workaround* - On OCP < 4.22 behind corporate proxy, gateway pod does not get cluster-wide proxy settings. Added Step 5f with ConfigMap template for HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars. (link:{repo-url}/pull/137[#137])
 
+* *Gateway Telemetry Auto-Creation* - Replaced manual `oc apply -k` telemetry step with MaasTenantConfig/Tenant CR patch. The RHOAI operator (`maas-controller`) auto-creates TelemetryPolicy and Istio Telemetry when `spec.telemetry.enabled: true` is set. Added 3.4/3.5 tabs and optional per-user metrics toggle. (link:{repo-url}/pull/146[#146])
+
 * *Governance Pairing Documentation* - Both MaaSAuthPolicy AND MaaSSubscription must reference the same model for Ready state. Day 2 patch commands included. (link:{repo-url}/pull/117[#117])
 
 === Fixes

--- a/manifests/07-observability/telemetry/README.md
+++ b/manifests/07-observability/telemetry/README.md
@@ -1,0 +1,35 @@
+# Gateway Telemetry (Reference Only)
+
+These manifests are **reference only**. The RHOAI operator (`maas-controller`) auto-creates both resources when `spec.telemetry.enabled: true` is set on the MaasTenantConfig (3.5) or Tenant (3.4) CR.
+
+You do not need to run `oc apply -k` on this directory.
+
+## How to enable
+
+```bash
+# RHOAI 3.5+
+oc patch maastenantconfig default-tenant -n models-as-a-service \
+  --type=merge -p '{"spec":{"telemetry":{"enabled":true}}}'
+
+# RHOAI 3.4
+oc patch tenant default-tenant -n models-as-a-service \
+  --type=merge -p '{"spec":{"telemetry":{"enabled":true}}}'
+```
+
+## What the operator creates
+
+- **TelemetryPolicy** `maas-telemetry` - adds `model`, `subscription`, `organization_id`, and `cost_center` labels to gateway Prometheus metrics
+- **Istio Telemetry** `latency-per-subscription` - adds `subscription` tag to `REQUEST_DURATION` metric
+
+## Optional metric dimensions
+
+The MaasTenantConfig/Tenant CRD supports additional metric toggles:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `captureModelUsage` | `true` | Model name in metrics |
+| `captureOrganization` | `true` | Organization ID and cost center |
+| `captureUser` | `false` | User ID (opt-in, GDPR implications) |
+| `captureGroup` | `false` | Group membership |
+
+See [Phase 7: Observability](../../content/modules/ROOT/pages/07-observability.adoc) for the full guide.

--- a/manifests/07-observability/telemetry/gateway-telemetry-policy.yaml
+++ b/manifests/07-observability/telemetry/gateway-telemetry-policy.yaml
@@ -1,6 +1,6 @@
 # REFERENCE ONLY - the RHOAI operator (maas-controller) auto-creates this resource
 # when spec.telemetry.enabled: true is set on MaasTenantConfig (3.5) or Tenant (3.4).
-# You do not need to apply this manually. Kept here to show what the operator creates.
+# You do not need to apply this manually. Kept here as a reference.
 apiVersion: extensions.kuadrant.io/v1alpha1
 kind: TelemetryPolicy
 metadata:

--- a/manifests/07-observability/telemetry/gateway-telemetry-policy.yaml
+++ b/manifests/07-observability/telemetry/gateway-telemetry-policy.yaml
@@ -1,3 +1,6 @@
+# REFERENCE ONLY - the RHOAI operator (maas-controller) auto-creates this resource
+# when spec.telemetry.enabled: true is set on MaasTenantConfig (3.5) or Tenant (3.4).
+# You do not need to apply this manually. Kept here to show what the operator creates.
 apiVersion: extensions.kuadrant.io/v1alpha1
 kind: TelemetryPolicy
 metadata:

--- a/manifests/07-observability/telemetry/istio-gateway-telemetry.yaml
+++ b/manifests/07-observability/telemetry/istio-gateway-telemetry.yaml
@@ -1,3 +1,6 @@
+# REFERENCE ONLY - the RHOAI operator (maas-controller) auto-creates this resource
+# when spec.telemetry.enabled: true is set on MaasTenantConfig (3.5) or Tenant (3.4).
+# You do not need to apply this manually. Kept here to show what the operator creates.
 ---
 apiVersion: telemetry.istio.io/v1
 kind: Telemetry

--- a/manifests/07-observability/telemetry/istio-gateway-telemetry.yaml
+++ b/manifests/07-observability/telemetry/istio-gateway-telemetry.yaml
@@ -1,6 +1,6 @@
 # REFERENCE ONLY - the RHOAI operator (maas-controller) auto-creates this resource
 # when spec.telemetry.enabled: true is set on MaasTenantConfig (3.5) or Tenant (3.4).
-# You do not need to apply this manually. Kept here to show what the operator creates.
+# You do not need to apply this manually. Kept here as a reference.
 ---
 apiVersion: telemetry.istio.io/v1
 kind: Telemetry

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -1192,10 +1192,35 @@ if should_run 7 && { [ "$WITH_OBSERVABILITY" = true ] || [ "$WITH_REDIS" = true 
     fi
     log_info "DSCI monitoring configured"
 
-    # Telemetry
-    log_step "Applying Gateway telemetry..."
-    run_cmd oc apply -k "$MANIFESTS_DIR/07-observability/telemetry/"
-    log_info "Gateway telemetry applied"
+    # Telemetry (auto-created by operator when enabled on MaasTenantConfig/Tenant)
+    log_step "Enabling Gateway telemetry..."
+    if [ "$IS_35_PLUS" = true ]; then
+        run_cmd oc patch maastenantconfig default-tenant -n models-as-a-service \
+            --type=merge -p '{"spec":{"telemetry":{"enabled":true}}}'
+    else
+        run_cmd oc patch tenant default-tenant -n models-as-a-service \
+            --type=merge -p '{"spec":{"telemetry":{"enabled":true}}}'
+    fi
+    if [ "$DRY_RUN" = false ]; then
+        TIMEOUT=120
+        ELAPSED=0
+        while [ $ELAPSED -lt $TIMEOUT ]; do
+            TP_COUNT=$(oc get telemetrypolicies.extensions.kuadrant.io -n openshift-ingress --no-headers 2>/dev/null | wc -l | tr -d ' ')
+            IT_COUNT=$(oc get telemetry.telemetry.istio.io -n openshift-ingress --no-headers 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$TP_COUNT" -gt 0 ] && [ "$IT_COUNT" -gt 0 ]; then
+                break
+            fi
+            sleep 10
+            ELAPSED=$((ELAPSED + 10))
+        done
+        if [ "$TP_COUNT" -gt 0 ] && [ "$IT_COUNT" -gt 0 ]; then
+            log_info "Gateway telemetry auto-created (TelemetryPolicy: $TP_COUNT, Istio Telemetry: $IT_COUNT)"
+        else
+            log_warn "Gateway telemetry not found after ${TIMEOUT}s - applying manually as fallback"
+            oc apply -k "$MANIFESTS_DIR/07-observability/telemetry/"
+            log_info "Gateway telemetry applied (manual fallback)"
+        fi
+    fi
 
     # Usage Dashboards with Loki (3.5+ only)
     if [ "$IS_35_PLUS" = true ]; then

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -1220,6 +1220,8 @@ if should_run 7 && { [ "$WITH_OBSERVABILITY" = true ] || [ "$WITH_REDIS" = true 
             oc apply -k "$MANIFESTS_DIR/07-observability/telemetry/"
             log_info "Gateway telemetry applied (manual fallback)"
         fi
+    else
+        log_info "Would verify auto-created TelemetryPolicy and Istio Telemetry in openshift-ingress"
     fi
 
     # Usage Dashboards with Loki (3.5+ only)


### PR DESCRIPTION
Closes #145

## Summary

- The RHOAI operator (`maas-controller`) auto-creates TelemetryPolicy and Istio Telemetry CRs when `spec.telemetry.enabled: true` is set on MaasTenantConfig (3.5) or Tenant (3.4)
- Step 5 in Phase 7 now patches the tenant CR instead of running `oc apply -k` on the manual manifests
- Added tabs block for 3.5 vs 3.4 with the correct CR name and patch command
- The auto-created TelemetryPolicy includes `model`, `subscription`, `organization_id`, and `cost_center` labels. Per-user tracking (`captureUser`) is opt-in for GDPR reasons - added the optional patch command
- setup-maas.sh patches the tenant CR and waits for the operator to create the resources, with manual `oc apply -k` as fallback if they don't appear within 120s
- Telemetry manifests kept in the repo as reference, marked as such in the Appendix

## Test plan

- [x] Tested on cluster-b6bk7 (RHOAI 3.5.0, OCP 4.21.31 SNO)
- [x] Confirmed operator does NOT auto-create when spec is empty (`spec: {}`) - CRD default alone is not enough
- [x] Confirmed operator DOES auto-create within seconds when `spec.telemetry.enabled: true` is explicitly set
- [x] Verified `managedFields[0].manager` is `maas-controller` (not kubectl)
- [x] Deleted both CRs, patched MaasTenantConfig, confirmed recreation
- [x] Compared auto-created TelemetryPolicy spec with manual manifest - auto version has more labels (org, cost_center), no user by default