### PR TITLE
fix: switch curl examples to body-based routing

### DIFF
--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -239,21 +239,21 @@ API_KEY=$(curl -sk -X POST "https://${MAAS_URL}/maas-api/v1/api-keys" \
 curl -sk "https://${MAAS_URL}/v1/models" \
   -H "Authorization: Bearer ${API_KEY}"
 
-# Get the model endpoint URL from the listing
-MODEL_URL=$(curl -sk "https://${MAAS_URL}/v1/models" \
-  -H "Authorization: Bearer ${API_KEY}" | jq -r '.data[0].url')
+# Get the model ID from the listing
+MODEL_ID=$(curl -sk "https://${MAAS_URL}/v1/models" \
+  -H "Authorization: Bearer ${API_KEY}" | jq -r '.data[0].id')
 
-# Send a chat completion request (uses the model-specific URL path)
-curl -sk "${MODEL_URL}/v1/chat/completions" \
+# Send a chat completion request (body-based routing)
+curl -sk "https://${MAAS_URL}/v1/chat/completions" \
   -H "Authorization: Bearer ${API_KEY}" \
   -H "Content-Type: application/json" \
-  -d '{
-    "model": "facebook/opt-125m",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
+  -d "{
+    \"model\": \"${MODEL_ID}\",
+    \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]
+  }"
 ----
 
-For GPU models, replace the model name with `granite-4-tiny` or `gpt-oss-20b` as appropriate.
+IMPORTANT: The `model` field in the request body must match the `id` returned by `/v1/models`. For local models (LLMInferenceService), this is the canonical form `publishers/{namespace}/models/{model-name}` (e.g., `publishers/llm/models/facebook/opt-125m`). For external models (ExternalModel), it is just the model name (e.g., `gpt-4o-mini`). Using a short name like `facebook/opt-125m` for local models will return 404.
 
 == Removing a Model
 

--- a/content/modules/ROOT/pages/06-verification.adoc
+++ b/content/modules/ROOT/pages/06-verification.adoc
@@ -135,7 +135,7 @@ oc get pods -n llm
 DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 HOST="https://maas.${DOMAIN}"
 
-# Create API key (save the key and model URL for subsequent phases)
+# Create API key (save the key and model ID for subsequent phases)
 API_KEY=$(curl -sk -X POST \
   -H "Authorization: Bearer $(oc whoami -t)" \
   -H "Content-Type: application/json" \
@@ -146,10 +146,10 @@ echo "API_KEY=${API_KEY}"
 # List models
 curl -sk -H "Authorization: Bearer ${API_KEY}" "${HOST}/v1/models"
 
-# Get the model endpoint URL
-MODEL_URL=$(curl -sk -H "Authorization: Bearer ${API_KEY}" \
-  "${HOST}/v1/models" | jq -r '.data[0].url')
-echo "MODEL_URL=${MODEL_URL}"
+# Get the model ID (canonical form for body-based routing)
+MODEL_ID=$(curl -sk -H "Authorization: Bearer ${API_KEY}" \
+  "${HOST}/v1/models" | jq -r '.data[0].id')
+echo "MODEL_ID=${MODEL_ID}"
 ----
 
 === Phase 4: Auth enforcement
@@ -159,8 +159,8 @@ echo "MODEL_URL=${MODEL_URL}"
 # Should return 401 or 403
 curl -sk -o /dev/null -w '%{http_code}' \
   -H "Content-Type: application/json" \
-  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Hello"}]}' \
-  "${MODEL_URL}/v1/chat/completions"
+  -d "{\"model\":\"${MODEL_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}" \
+  "${HOST}/v1/chat/completions"
 ----
 
 === Phase 5: Rate limiting
@@ -172,8 +172,8 @@ for i in $(seq 1 16); do
   curl -sk -o /dev/null -w '%{http_code}\n' \
     -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
-    -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Hello, write a long essay"}],"max_tokens":50}' \
-    "${MODEL_URL}/v1/chat/completions"
+    -d "{\"model\":\"${MODEL_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello, write a long essay\"}],\"max_tokens\":50}" \
+    "${HOST}/v1/chat/completions"
 done
 ----
 

--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -216,14 +216,16 @@ API_KEY=$(curl -sk -X POST "${MAAS_GW}/maas-api/v1/api-keys" \
     -d '{"name": "openai-test", "subscription": "openai-free", "expiresIn": "1h"}' \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])")
 
-# Test inference
-curl -sk "${MAAS_GW}/external-models/gpt-4o-mini/v1/chat/completions" \
+# Test inference (body-based routing)
+curl -sk "${MAAS_GW}/v1/chat/completions" \
     -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
     -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Say hello in 3 words."}], "max_tokens": 20}'
 ----
 
 A successful response contains a `choices` array with the model's reply.
+
+NOTE: External models use the plain model name (e.g., `gpt-4o-mini`) as the `model` field, unlike local models which require the canonical `publishers/{namespace}/models/{model-name}` format. You can always check the correct model ID with the `/v1/models` endpoint.
 
 == Automated Setup
 
@@ -430,10 +432,10 @@ API_KEY=$(curl -sk -X POST "${MAAS_GW}/maas-api/v1/api-keys" \
     -d '{"name": "bedrock-test", "subscription": "bedrock-free", "expiresIn": "1h"}' \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])")
 
-curl -sk "${MAAS_GW}/external-models/aws-gpt-oss-20b/v1/chat/completions" \
+curl -sk "${MAAS_GW}/v1/chat/completions" \
     -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
-    -d '{"model": "openai.gpt-oss-20b", "messages": [{"role": "user", "content": "Say hello in 3 words."}], "max_tokens": 20}'
+    -d '{"model": "aws-gpt-oss-20b", "messages": [{"role": "user", "content": "Say hello in 3 words."}], "max_tokens": 20}'
 ----
 
 ==== Automated Deployment

--- a/content/modules/ROOT/pages/09-external-oidc.adoc
+++ b/content/modules/ROOT/pages/09-external-oidc.adoc
@@ -342,12 +342,18 @@ IMPORTANT: API keys capture the user's group memberships at the time of creation
 
 ==== Run inference with the API key
 
+Get the model ID from `/v1/models` and send a chat completion:
+
 [source,bash]
 ----
+MODEL_ID=$(curl -sSk \
+    -H "Authorization: Bearer ${API_KEY}" \
+    "https://maas.${CLUSTER_DOMAIN}/v1/models" | jq -r '.data[0].id')
+
 curl -sSk -X POST \
     -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
-    -d '{"model": "simulator", "messages": [{"role": "user", "content": "Hello from OIDC!"}], "max_tokens": 20}' \
+    -d "{\"model\": \"${MODEL_ID}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello from OIDC!\"}], \"max_tokens\": 20}" \
     "https://maas.${CLUSTER_DOMAIN}/v1/chat/completions" | jq .
 ----
 

--- a/content/modules/ROOT/pages/11-model-swap.adoc
+++ b/content/modules/ROOT/pages/11-model-swap.adoc
@@ -125,11 +125,11 @@ Governance means at least one `MaaSSubscription` AND one `MaaSAuthPolicy` both r
 
 | Model ID in requests
 | *No*
-| Both `qwen-36` and `qwen-38` serve the same `spec.model.name` (`Qwen/Qwen3-Coder`), so the model ID in `/v1/chat/completions` stays the same.
+| Both `qwen-36` and `qwen-38` serve the same `spec.model.name` (`Qwen/Qwen3-Coder`), so the canonical model ID (`publishers/llm/models/Qwen/Qwen3-Coder`) stays the same.
 
 | BBR endpoint (`/v1/chat/completions`)
 | *No*
-| Body-based routing uses the model ID in the request body (`Qwen/Qwen3-Coder`), which is derived from `spec.model.name` (unchanged). Customers using this endpoint need no changes.
+| Body-based routing uses the canonical model ID in the request body (`publishers/llm/models/Qwen/Qwen3-Coder`), derived from the namespace and `spec.model.name` (both unchanged). Customers using this endpoint need no changes.
 
 | Per-model URL path (`/llm/<name>/...`)
 | *Yes*

--- a/content/modules/ROOT/pages/release-notes.adoc
+++ b/content/modules/ROOT/pages/release-notes.adoc
@@ -44,6 +44,8 @@ Each entry links to its pull request for full details.
 
 * *HTTPRoute Rule Name Collision* - RHOAI 3.5 hardcoded HTTPRoute rule names. Multiple models on the same gateway cause Istio to merge duplicate rules, sending all traffic to one EPP. Documented as known issue. (link:{repo-url}/pull/139[#139])
 
+* *Body-Based Routing Curl Examples* - All inference curl examples across 5 guide pages, verify.sh, and setup-maas.sh now use body-based routing at `/v1/chat/completions` with the correct model ID from `/v1/models`. Local models require the canonical `publishers/{namespace}/models/{model-name}` format - short names return 404. Also added `qwen3-06b` to VALID_MODELS. (link:{repo-url}/pull/147[#147])
+
 * *13 Documentation Fixes from Full Guide Review* - Broken xref anchor, wrong Roo Code URL, missing namespace in oc patch, stale llamastackoperator ref, missing externalModels flag, wrong OCP version, and more across 10 files. (link:{repo-url}/pull/124[#124])
 
 * *Gateway-access Namespace Labeling for RHOAI 3.5* - Phase 2 tried to label `redhat-ai-gateway-infra` before it exists. Moved labeling to Phase 4 with safety-net re-label. (link:{repo-url}/pull/101[#101])

--- a/manifests/06-verification/verify.sh
+++ b/manifests/06-verification/verify.sh
@@ -599,26 +599,24 @@ if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ]; then
 
     if [ "$MODEL_COUNT" -gt 0 ] 2>/dev/null; then
         FIRST_MODEL_ID=$(echo "$MODELS_RESPONSE" | jq -r '.data[0].id // empty' 2>/dev/null || echo "")
-        MODEL_URL=$(echo "$MODELS_RESPONSE" | jq -r '.data[0].url // empty' 2>/dev/null || echo "")
         log_pass "Models available ($MODEL_COUNT total, first: $FIRST_MODEL_ID)"
         INFERENCE_MODEL="$FIRST_MODEL_ID"
     else
         log_warn "No models found in listing (may be timing or API version difference)"
         log_warn "Response: ${MODELS_RESPONSE:0:200}"
-        INFERENCE_MODEL="facebook/opt-125m"
-        MODEL_URL="${HOST}/llm/${MODEL_NAME}"
+        INFERENCE_MODEL="publishers/llm/models/facebook/opt-125m"
     fi
 fi
 
 # Test inference
-if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ] && [ -n "${MODEL_URL:-}" ]; then
+if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ] && [ -n "${INFERENCE_MODEL:-}" ]; then
     log_info "Testing inference..."
     INFERENCE_RESPONSE=$(maas_curl \
         -H "Authorization: Bearer ${API_KEY}" \
         -H "Content-Type: application/json" \
         -w "\n%{http_code}" \
-        -d "{\"model\": \"${INFERENCE_MODEL:-$MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 50}" \
-        "${MODEL_URL}/v1/chat/completions" 2>/dev/null || echo -e "\n000")
+        -d "{\"model\": \"${INFERENCE_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 50}" \
+        "${HOST}/v1/chat/completions" 2>/dev/null || echo -e "\n000")
 
     INFERENCE_CODE=$(echo "$INFERENCE_RESPONSE" | tail -1)
     INFERENCE_BODY=$(echo "$INFERENCE_RESPONSE" | sed '$d')
@@ -640,13 +638,13 @@ fi
 # =============================================================================
 log_step "Phase 4: Auth enforcement"
 
-if [ -n "${MODEL_URL:-}" ]; then
+if [ -n "${INFERENCE_MODEL:-}" ]; then
     # No token
     NO_AUTH_CODE=$(maas_curl \
         -o /dev/null -w '%{http_code}' \
         -H "Content-Type: application/json" \
-        -d "{\"model\": \"${INFERENCE_MODEL:-$MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 10}" \
-        "${MODEL_URL}/v1/chat/completions" 2>/dev/null || echo "000")
+        -d "{\"model\": \"${INFERENCE_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 10}" \
+        "${HOST}/v1/chat/completions" 2>/dev/null || echo "000")
 
     if [ "$NO_AUTH_CODE" = "401" ] || [ "$NO_AUTH_CODE" = "403" ]; then
         log_pass "Unauthenticated request rejected (HTTP $NO_AUTH_CODE)"
@@ -659,8 +657,8 @@ if [ -n "${MODEL_URL:-}" ]; then
         -o /dev/null -w '%{http_code}' \
         -H "Authorization: Bearer invalid-token-12345" \
         -H "Content-Type: application/json" \
-        -d "{\"model\": \"${INFERENCE_MODEL:-$MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 10}" \
-        "${MODEL_URL}/v1/chat/completions" 2>/dev/null || echo "000")
+        -d "{\"model\": \"${INFERENCE_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 10}" \
+        "${HOST}/v1/chat/completions" 2>/dev/null || echo "000")
 
     if [ "$INVALID_CODE" = "401" ] || [ "$INVALID_CODE" = "403" ]; then
         log_pass "Invalid token rejected (HTTP $INVALID_CODE)"
@@ -668,7 +666,7 @@ if [ -n "${MODEL_URL:-}" ]; then
         log_fail "Invalid token returned HTTP $INVALID_CODE (expected 401/403)"
     fi
 else
-    log_fail "Skipping auth tests (no model URL)"
+    log_fail "Skipping auth tests (no model ID)"
 fi
 
 # =============================================================================
@@ -676,7 +674,7 @@ fi
 # =============================================================================
 log_step "Phase 5: Rate limiting"
 
-if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ] && [ -n "${MODEL_URL:-}" ]; then
+if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ] && [ -n "${INFERENCE_MODEL:-}" ]; then
     log_info "Sending 16 rapid requests to trigger rate limit..."
     RATE_LIMITED=0
     SUCCESSES=0
@@ -685,8 +683,8 @@ if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ] && [ -n "${MODEL_URL:-}" ]; the
             -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${API_KEY}" \
             -H "Content-Type: application/json" \
-            -d "{\"model\": \"${INFERENCE_MODEL:-$MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello, write me a very long essay about the history of computing\"}], \"max_tokens\": 50}" \
-            "${MODEL_URL}/v1/chat/completions" 2>/dev/null || echo "000")
+            -d "{\"model\": \"${INFERENCE_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello, write me a very long essay about the history of computing\"}], \"max_tokens\": 50}" \
+            "${HOST}/v1/chat/completions" 2>/dev/null || echo "000")
         if [ "$CODE" = "429" ]; then
             RATE_LIMITED=$((RATE_LIMITED + 1))
         elif [ "$CODE" = "200" ]; then

--- a/scripts/setup-maas.sh
+++ b/scripts/setup-maas.sh
@@ -995,7 +995,7 @@ if should_run 5 && [ "$SKIP_MODELS" = false ]; then
             fi
         fi
 
-        VALID_MODELS="simulator simulator-disconnected granite-tiny-gpu gpt-oss-20b gemma"
+        VALID_MODELS="simulator simulator-disconnected granite-tiny-gpu gpt-oss-20b gemma qwen3-06b"
         if ! echo "$VALID_MODELS" | grep -qw "$MODEL"; then
             log_error "Unknown model: $MODEL (valid: $VALID_MODELS)"
             exit 1
@@ -1436,10 +1436,10 @@ if should_run 8 && [ "$WITH_EXTERNAL_MODELS" = true ]; then
                             log_info "Ephemeral API key created"
 
                             INFERENCE_RESPONSE=$(curl -sk -X POST \
-                                "${MAAS_GW}/external-models/${EXTMODEL_NAME}/v1/chat/completions" \
+                                "${MAAS_GW}/v1/chat/completions" \
                                 -H "Authorization: Bearer ${TEST_API_KEY}" \
                                 -H "Content-Type: application/json" \
-                                -d "{\"model\": \"${EXTMODEL_TARGET_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say hello in exactly 3 words.\"}], \"max_tokens\": 20}" \
+                                -d "{\"model\": \"${EXTMODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say hello in exactly 3 words.\"}], \"max_tokens\": 20}" \
                                 --max-time 30 2>/dev/null || echo "")
 
                             if echo "$INFERENCE_RESPONSE" | grep -q '"choices"'; then
@@ -1447,10 +1447,10 @@ if should_run 8 && [ "$WITH_EXTERNAL_MODELS" = true ]; then
                                 log_info "${EXTERNAL_MODEL_PROVIDER} inference SUCCESS: ${REPLY_TEXT}"
                             else
                                 HTTP_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST \
-                                    "${MAAS_GW}/external-models/${EXTMODEL_NAME}/v1/chat/completions" \
+                                    "${MAAS_GW}/v1/chat/completions" \
                                     -H "Authorization: Bearer ${TEST_API_KEY}" \
                                     -H "Content-Type: application/json" \
-                                    -d "{\"model\": \"${EXTMODEL_TARGET_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hi\"}], \"max_tokens\": 5}" \
+                                    -d "{\"model\": \"${EXTMODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hi\"}], \"max_tokens\": 5}" \
                                     --max-time 15 2>/dev/null || echo "000")
                                 log_warn "${EXTERNAL_MODEL_PROVIDER} inference returned HTTP ${HTTP_CODE} - model is registered and governed but inference routing may need BBR ext-proc propagation"
                             fi

--- a/scripts/test-inference.sh
+++ b/scripts/test-inference.sh
@@ -4,13 +4,13 @@
 #
 # Usage:
 #   ./scripts/test-inference.sh --base-url <url> --api-key <key>
-#   ./scripts/test-inference.sh --base-url https://maas.apps.cluster.example.com/llm/model-name --api-key <key>
-#   ./scripts/test-inference.sh --base-url <url> --api-key <key> --model facebook/opt-125m --prompt "What is AI?"
+#   ./scripts/test-inference.sh --base-url https://maas.apps.cluster.example.com --api-key <key>
+#   ./scripts/test-inference.sh --base-url <url> --api-key <key> --model publishers/llm/models/facebook/opt-125m --prompt "What is AI?"
 #
 
 set -euo pipefail
 
-MODEL="facebook/opt-125m"
+MODEL="publishers/llm/models/facebook/opt-125m"
 PROMPT="Hello, how are you?"
 MAX_TOKENS=50
 ENDPOINT="chat/completions"
@@ -21,9 +21,9 @@ usage() {
     sed -n '3,9p' "$0" | sed 's/^# \{0,1\}//'
     echo ""
     echo "Options:"
-    echo "  --base-url URL      (required) MaaS base URL (e.g. https://maas.apps.cluster.example.com/llm/model-name)"
+    echo "  --base-url URL      (required) MaaS gateway URL (e.g. https://maas.apps.cluster.example.com)"
     echo "  --api-key KEY       (required) MaaS API key"
-    echo "  --model MODEL       vLLM model ID (default: $MODEL)"
+    echo "  --model MODEL       MaaS model ID (default: $MODEL)"
     echo "  --prompt TEXT       Prompt text (default: \"$PROMPT\")"
     echo "  --max-tokens N      Max tokens to generate (default: $MAX_TOKENS)"
     echo "  --endpoint TYPE     completions | chat/completions (default: $ENDPOINT)"


### PR DESCRIPTION
## Summary

- All curl examples in the guide now use body-based routing at `/v1/chat/completions` instead of path-based URLs like `/llm/{model}/v1/chat/completions` or `/external-models/{model}/v1/chat/completions`
- For local models (LLMInferenceService), the model ID in the request body must use the canonical `publishers/{namespace}/models/{model-name}` format from `/v1/models`. Using the short name like `facebook/opt-125m` returns 404
- For external models (ExternalModel), the model ID is just the plain name like `gpt-4o-mini`
- Added `qwen3-06b` to `VALID_MODELS` in setup-maas.sh (was missing, `--model qwen3-06b` would fail)
- Fixed verify.sh to use `${HOST}/v1/chat/completions` with `${INFERENCE_MODEL}` instead of the old `${MODEL_URL}/v1/chat/completions` path-based pattern
- Updated test-inference.sh help text and default model to use the canonical form

### Files changed

| File | What |
|------|------|
| `05-maas-models.adoc` | MODEL_URL to MODEL_ID, body-based curl, added IMPORTANT note about model ID format |
| `06-verification.adoc` | Same MODEL_URL to MODEL_ID change for phases 4-5 |
| `08-external-models.adoc` | OpenAI and Bedrock tests now use `/v1/chat/completions` with plain model name |
| `09-external-oidc.adoc` | Replaced hardcoded `"model": "simulator"` with MODEL_ID from /v1/models |
| `11-model-swap.adoc` | Fixed table to use canonical model ID (was contradicting the curl example below it) |
| `verify.sh` | Replaced all MODEL_URL path-based routing with HOST body-based routing |
| `setup-maas.sh` | External model test uses body-based routing + qwen3-06b in VALID_MODELS |
| `test-inference.sh` | Default model canonical form, help text updated |

## Test plan

Tested E2E on cluster-z67vp (RHOAI 3.5.0):

- [x] `setup-maas.sh --model simulator` - 14/14 passed
- [x] `verify.sh --no-cleanup` with body-based routing - 15/15 passed
- [x] Body-based with canonical `publishers/llm/models/facebook/opt-125m` - HTTP 200
- [x] Body-based with short name `facebook/opt-125m` - HTTP 404 (confirms IMPORTANT note)
- [x] No auth header at body-based endpoint - HTTP 401
- [x] Qwen3-0.6B deployed manually, body-based inference - HTTP 200
- [x] OpenAI gpt-4o-mini body-based with plain name - HTTP 200
- [x] `test-inference.sh` with gateway root URL - HTTP 200