### PR TITLE
chore: rename release notes to guide changelog

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -36,8 +36,8 @@
 .Cleanup
 * xref:09-cleanup.adoc[Cleanup & Teardown]
 
-.Release Notes
-* xref:release-notes.adoc[Release Notes]
+.Guide Changelog
+* xref:changelog.adoc[Guide Changelog]
 
 .Tools
 * xref:claude-code.adoc[AI-Assisted Installation]

--- a/content/modules/ROOT/pages/changelog.adoc
+++ b/content/modules/ROOT/pages/changelog.adoc
@@ -1,6 +1,6 @@
-= Release Notes
+= Guide Changelog
 
-Changelog for the {rhoai} {maas} companion guide. Covers new guide phases, automation improvements, bug fixes, and community contributions since the project started in June 2026.
+Changes to the {rhoai} {maas} companion guide since the project started in June 2026. Covers new guide phases, automation improvements, bug fixes, and community contributions.
 
 Each entry links to its pull request for full details.
 


### PR DESCRIPTION
## Summary

- Renamed `release-notes.adoc` to `changelog.adoc`
- Page title changed from "Release Notes" to "Guide Changelog"
- Nav section updated to match

Just a naming change, "Guide Changelog" fits better than "Release Notes" for this type of page.

## Test plan

- [ ] Page renders correctly on GitHub Pages
- [ ] Nav sidebar shows "Guide Changelog"