### PR TITLE
docs: add ServiceAccount-scoped subscriptions section

### DIFF
--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -287,6 +287,79 @@ oc get maasmodelref -n llm -o wide
 If you update only the `MaaSSubscription` without updating the `MaaSAuthPolicy`, the new model will stay in `Pending` phase. The `MaaSModelRef` condition will show `No active subscription and auth policy pairing found`. This applies to both CLI and UI edits. See <<governance-pairing>> for details.
 ====
 
+== ServiceAccount-Scoped Subscriptions
+
+By default, the guide's subscriptions use `system:authenticated` in `spec.owner.groups`, which means any authenticated user can create API keys bound to them. For programmatic workloads (CI/CD pipelines, batch jobs, automated testing), you can create a dedicated subscription scoped to a specific ServiceAccount with its own rate limits.
+
+Create a ServiceAccount and generate a token:
+
+[source,bash]
+----
+oc create sa my-pipeline-sa -n default
+SA_TOKEN=$(oc create token my-pipeline-sa -n default --duration=24h)
+----
+
+Create a `MaaSSubscription` that only this ServiceAccount can use:
+
+[source,bash]
+----
+cat <<EOF | oc apply -f -
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: simulator-pipeline
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Simulator Pipeline Tier"
+    openshift.io/description: "Dedicated rate limit for CI/CD pipeline"
+spec:
+  owner:
+    groups: []
+    users:
+      - system:serviceaccount:default:my-pipeline-sa
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 5000
+          window: 1m
+  priority: 15
+EOF
+----
+
+NOTE: The ServiceAccount name in `spec.owner.users` must use the full format: `system:serviceaccount:{namespace}:{sa-name}`. Setting `groups: []` ensures only this SA (and no other users) can create API keys bound to this subscription.
+
+The existing `MaaSAuthPolicy` with `system:authenticated` already covers ServiceAccounts, so you do not need a separate auth policy. The governance pairing is satisfied by the existing policy.
+
+Test it:
+
+[source,bash]
+----
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+MAAS_URL="maas.${CLUSTER_DOMAIN}"
+
+# Create API key using the SA token
+API_KEY=$(curl -sk -X POST "https://${MAAS_URL}/maas-api/v1/api-keys" \
+  -H "Authorization: Bearer ${SA_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "pipeline-key", "subscription": "simulator-pipeline", "expiresIn": "1h"}' \
+  | jq -r '.key')
+
+# Run inference
+MODEL_ID=$(curl -sk "https://${MAAS_URL}/v1/models" \
+  -H "Authorization: Bearer ${API_KEY}" | jq -r '.data[0].id')
+
+curl -sk "https://${MAAS_URL}/v1/chat/completions" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"${MODEL_ID}\",
+    \"messages\": [{\"role\": \"user\", \"content\": \"Hello from pipeline!\"}]
+  }"
+----
+
+If a regular user tries to create an API key with `"subscription": "simulator-pipeline"`, the API returns `invalid_subscription` because they are not in the subscription's `spec.owner.users` list.
+
 == Appendix
 
 === Directory Structure

--- a/content/modules/ROOT/pages/changelog.adoc
+++ b/content/modules/ROOT/pages/changelog.adoc
@@ -32,6 +32,8 @@ Each entry links to its pull request for full details.
 
 * *Governance Pairing Documentation* - Both MaaSAuthPolicy AND MaaSSubscription must reference the same model for Ready state. Day 2 patch commands included. (link:{repo-url}/pull/117[#117])
 
+* *ServiceAccount-Scoped Subscriptions* - New section in Phase 5 showing how to scope a MaaSSubscription to a specific ServiceAccount via `spec.owner.users`. Useful for CI/CD pipelines and batch jobs that need their own rate limits. (link:{repo-url}/pull/150[#150])
+
 === Fixes
 
 * *Phase 4 CRD Race Condition* - DSC triggers async CRD registration. Script was applying HardwareProfile before CRD existed. Added wait_for_crd() helper. (link:{repo-url}/pull/108[#108])


### PR DESCRIPTION
## Summary

- Added a new section to Phase 5 (05-maas-models) documenting how to scope a `MaaSSubscription` to a specific ServiceAccount using `spec.owner.users`
- Covers SA creation, token generation, subscription YAML with `groups: []` + `users: [system:serviceaccount:...]`, and full inference test
- Explains that existing `MaaSAuthPolicy` with `system:authenticated` already covers SAs - no separate auth policy needed
- Includes negative test: regular users get `invalid_subscription` when trying to use a SA-scoped subscription

Closes #148

## Test plan

- [x] Created SA `my-pipeline-sa` and generated token on cluster-z67vp
- [x] Applied SA-scoped MaaSSubscription - went Active
- [x] Created API key with SA token - success
- [x] Ran inference with SA API key - HTTP 200
- [x] Negative test: admin user tries SA subscription - got `invalid_subscription`
- [x] Cleaned up test resources