### PR TITLE
demo: add four MaaS entitlement and authentication demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,6 @@ rhoai-maas-guide.code-workspace
 
 # macOS
 .DS_Store
+
+# claude
+.claude/settings.json

--- a/demo/README.md
+++ b/demo/README.md
@@ -12,6 +12,7 @@ runbook and a talk track, and a teardown script.
 | Demo | Shows |
 | --- | --- |
 | [user-level-rate-limiting](user-level-rate-limiting/) | Assigning a `MaaSSubscription` to a group or to an individual user, and using `priority` to give a named user a different tier from the rest of their team. |
+| [subscription-priority](subscription-priority/) | That entitlement is selected rather than accumulated: a user in two groups worth 10000 and 20000 tokens/hour gets one of those tiers, not 30000 — and a subscription naming them individually can cap them below both. |
 | [oidc-authentication](oidc-authentication/) | Authenticating with an identity from your own identity provider — no OpenShift account required — with the token's `groups` claim selecting the subscription. Includes a click-through UI and a CLI sample client. |
 | [service-account-access](service-account-access/) | An application calling a model with its own Kubernetes ServiceAccount token. No API key to distribute, no credential to rotate. Access granted per namespace, rate limits set per workload. |
 | [jwks-cache](jwks-cache/) | That JWT signatures are genuinely verified, and that verification happens locally against a cached copy of the issuer's public keys rather than a call to the identity provider on every request. |

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,33 @@
+# MaaS demos
+
+Self-contained demos that run against a cluster with MaaS already deployed
+(`./scripts/setup-maas.sh` from the repository root). Each folder has its own
+README with a runbook, a talk track, and a teardown script.
+
+## Before presenting
+
+```bash
+./preflight.sh
+```
+
+Read-only — it creates nothing and applies no YAML. It checks that every identity
+can authenticate *and* resolves the subscription its demo expects, which are the
+two things that break between sessions. It also sends a warm-up request, because
+`maas-api` returns 500 on the first call after an idle period while it reopens
+its database connection.
+
+Expect `16 passed, 0 failed`. If anything fails it prints the fix.
+
+> **Note:** setup is already applied on a prepared cluster — the demos themselves
+> only read. The one exception is `jwks-cache/prove-cached.sh`, which applies a
+> NetworkPolicy to cut Authorino off from the IdP; that *is* the demonstration,
+> and it removes the policy again on exit.
+
+## The demos
+
+| Demo | Shows |
+| --- | --- |
+| [user-level-rate-limiting](user-level-rate-limiting/) | Assigning a `MaaSSubscription` to individual users as well as groups, and how `priority` resolves the overlap. Creates demo users via an htpasswd identity provider added alongside the cluster's existing one. |
+| [oidc-authentication](oidc-authentication/) | Authenticating to MaaS with an external OIDC identity that has no OpenShift account, and using the token's `groups` claim to select a subscription. Also covers assigning access to an individual OIDC user with no group tier. Reuses an existing Keycloak rather than deploying a second one. Includes sample clients — a click-through UI and a CLI. |
+| [service-account-access](service-account-access/) | An in-cluster workload calling a model with its own ServiceAccount token — validated by Kubernetes TokenReview, with no human identity and no external IdP. Access granted per namespace, rate limits per workload. |
+| [jwks-cache](jwks-cache/) | That JWT signatures are genuinely verified (a forged token is rejected) and that validation happens locally from a cached JWKS — proven by cutting Authorino off from the IdP and showing tokens still validate. |

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,33 +1,33 @@
 # MaaS demos
 
-Self-contained demos that run against a cluster with MaaS already deployed
-(`./scripts/setup-maas.sh` from the repository root). Each folder has its own
-README with a runbook, a talk track, and a teardown script.
+Four demos showing how Models as a Service governs access to a model: **who may
+call it**, and **how much they may consume**.
 
-## Before presenting
-
-```bash
-./preflight.sh
-```
-
-Read-only — it creates nothing and applies no YAML. It checks that every identity
-can authenticate *and* resolves the subscription its demo expects, which are the
-two things that break between sessions. It also sends a warm-up request, because
-`maas-api` returns 500 on the first call after an idle period while it reopens
-its database connection.
-
-Expect `16 passed, 0 failed`. If anything fails it prints the fix.
-
-> **Note:** setup is already applied on a prepared cluster — the demos themselves
-> only read. The one exception is `jwks-cache/prove-cached.sh`, which applies a
-> NetworkPolicy to cut Authorino off from the IdP; that *is* the demonstration,
-> and it removes the policy again on exit.
+Each demo runs against a cluster with MaaS deployed (`./scripts/setup-maas.sh`
+from the repository root). Each folder contains a setup script, a README with a
+runbook and a talk track, and a teardown script.
 
 ## The demos
 
 | Demo | Shows |
 | --- | --- |
-| [user-level-rate-limiting](user-level-rate-limiting/) | Assigning a `MaaSSubscription` to individual users as well as groups, and how `priority` resolves the overlap. Creates demo users via an htpasswd identity provider added alongside the cluster's existing one. |
-| [oidc-authentication](oidc-authentication/) | Authenticating to MaaS with an external OIDC identity that has no OpenShift account, and using the token's `groups` claim to select a subscription. Also covers assigning access to an individual OIDC user with no group tier. Reuses an existing Keycloak rather than deploying a second one. Includes sample clients — a click-through UI and a CLI. |
-| [service-account-access](service-account-access/) | An in-cluster workload calling a model with its own ServiceAccount token — validated by Kubernetes TokenReview, with no human identity and no external IdP. Access granted per namespace, rate limits per workload. |
-| [jwks-cache](jwks-cache/) | That JWT signatures are genuinely verified (a forged token is rejected) and that validation happens locally from a cached JWKS — proven by cutting Authorino off from the IdP and showing tokens still validate. |
+| [user-level-rate-limiting](user-level-rate-limiting/) | Assigning a `MaaSSubscription` to a group or to an individual user, and using `priority` to give a named user a different tier from the rest of their team. |
+| [oidc-authentication](oidc-authentication/) | Authenticating with an identity from your own identity provider — no OpenShift account required — with the token's `groups` claim selecting the subscription. Includes a click-through UI and a CLI sample client. |
+| [service-account-access](service-account-access/) | An application calling a model with its own Kubernetes ServiceAccount token. No API key to distribute, no credential to rotate. Access granted per namespace, rate limits set per workload. |
+| [jwks-cache](jwks-cache/) | That JWT signatures are genuinely verified, and that verification happens locally against a cached copy of the issuer's public keys rather than a call to the identity provider on every request. |
+
+## Readiness check
+
+```bash
+./preflight.sh
+```
+
+Read-only — it creates nothing and applies no YAML. It confirms every identity
+can authenticate and resolves the subscription its demo expects, and sends a
+warm-up request so the first click of the demo is a warm one.
+
+Expect `16 passed, 0 failed`.
+
+Setup is applied once, ahead of time; the demos themselves only read. The single
+exception is `jwks-cache/prove-cached.sh`, which applies a NetworkPolicy as the
+demonstration itself and removes it again on exit.

--- a/demo/jwks-cache/README.md
+++ b/demo/jwks-cache/README.md
@@ -1,0 +1,209 @@
+# JWKS validation and caching demo
+
+Demonstrates the claim:
+
+> Validates JWT tokens locally using cached JWKS (no call to the IdP on every request)
+
+That is three separate assertions, and each needs its own evidence:
+
+| Claim | How it is shown | Script |
+| --- | --- | --- |
+| fetches the issuer's public keys | the `AuthConfig` points Authorino at the issuer; discovery resolves `jwks_uri` | `run-demo.sh` |
+| actually verifies signatures | a tampered token is rejected while the genuine one is accepted | `run-demo.sh` |
+| validates *locally* from cache | Authorino is cut off from the IdP and validation keeps working | `prove-cached.sh` |
+
+Requires the OIDC demo to be configured first — see [`../oidc-authentication/`](../oidc-authentication/).
+
+## Where validation actually happens
+
+Not in `maas-api`. MaaS renders `AITenant.spec.oidc` into a Kuadrant/Authorino
+`AuthConfig`, and **Authorino** does the crypto:
+
+```yaml
+authentication:
+  oidc-identities:
+    jwt:
+      issuerUrl: https://<keycloak>/realms/maas
+      ttl: 300          # JWKS refresh interval - NOT a token lifetime
+```
+
+`ttl` is how often the background worker refreshes the keys. It is the single most
+misread field here.
+
+## Demo script
+
+About five minutes. Two terminals side by side is ideal: one to run the scripts,
+one to show the config. Do a warm-up run first — the first request after an idle
+period can return 500 while `maas-api` reopens its database connection.
+
+### Beat 1 — set up the claim (30s)
+
+> "The gateway says it validates JWTs *locally*, using a *cached* JWKS, with no call
+> to the identity provider on every request. That is really three claims, so let's
+> take them one at a time — and let's not take any of them on trust."
+
+### Beat 2 — where validation happens (45s)
+
+```bash
+oc get authconfig -n kuadrant-system -o yaml | grep -A4 'oidc-identities'
+```
+
+> "Validation isn't done by MaaS itself. MaaS renders its OIDC config into an
+> Authorino AuthConfig, and Authorino does the crypto. Note `ttl: 300` — that is how
+> often it refreshes the *keys*. It is not a token lifetime, which is the usual
+> misreading."
+
+### Beat 3 — the keys, and which one signed the token (60s)
+
+```bash
+./run-demo.sh
+```
+
+Point at two things as they scroll past:
+
+> "Here are the public keys the issuer publishes — note the one marked `use=sig`,
+> that's the signing key. And here's the header of a real token: it carries a `kid`,
+> a key ID, and it matches. That is the link. Authorino looks up that key ID in the
+> copy of the keys it already holds."
+
+### Beat 4 — prove the signature is really checked (60s)
+
+Same run, the section that matters:
+
+> "Now the interesting part. I've taken a genuine token and rewritten the payload —
+> I've promoted this user into `platform-admins`, a group they are not in — and left
+> the original signature untouched."
+>
+> "Genuine token: 201. Forged token: 401."
+>
+> "Anyone can decode a JWT — it's base64, not encryption. What you cannot do is
+> *sign* one. That's the whole security model, and it's why holding the issuer's
+> public keys is what matters."
+
+If someone asks "so could I just edit my groups claim?" — that question has just
+been answered on screen.
+
+### Beat 5 — prove it doesn't call the IdP (90s)
+
+```bash
+./prove-cached.sh
+```
+
+> "The last claim is the operational one: no call to the IdP per request. If that
+> were false — if it phoned home every time — then cutting it off from the IdP would
+> break it."
+>
+> "So: baseline first, 201. Now I apply a NetworkPolicy that blocks the Authorino
+> pod from reaching the IdP's address. Watch the TCP connection fail — it genuinely
+> cannot get there."
+>
+> "Same token, three more times: 201, 201, 201."
+>
+> "The identity provider is unreachable and validation still works. The only way
+> that's possible is if the keys are already held locally. Then we remove the policy
+> and we're back to normal."
+
+Worth adding, because it is the honest caveat:
+
+> "Keycloak is still running throughout — I only cut one pod's egress. And the token
+> was issued *before* the block, so the only thing that would still need the IdP is
+> the key lookup."
+
+### Questions you should expect
+
+| Question | Answer |
+| --- | --- |
+| "What if the keys rotate?" | The background worker re-fetches on the `ttl` interval — 300s here. A token signed by a new key fails until the next refresh, which is the trade-off you accept for not calling out per request. |
+| "So it never talks to the IdP?" | It does — on a timer, not per request. That's the distinction the demo is making. |
+| "Could I forge a token if I knew the `kid`?" | No. `kid` only says *which* public key to check against. You would need the matching private key, which never leaves the issuer. |
+| "What happens if the IdP is down at startup?" | Then there is nothing cached yet and validation fails — which is exactly what we saw on this cluster this morning after a restart. Caching helps a running system ride out a blip; it is not a substitute for the IdP being available. |
+
+## 1. Validation
+
+```bash
+cd demo/jwks-cache
+./run-demo.sh
+```
+
+Read-only — it inspects config, fetches public keys, and sends two requests.
+
+It prints the published keys and the `kid` from the token header, so you can show
+they match:
+
+```
+  2 public key(s) published:
+    kid=yM2nudvUT2JSANBnLytMpCUDhLqocO-gCjzn9xHubkU  alg=RSA-OAEP  use=enc
+    kid=zQNnpBaoTZC1zqe6W4MoKTlaI3r411uK_dvwT09cnYw  alg=RS256     use=sig
+
+  token header : kid=zQNnpBaoTZC1zqe6W4MoKTlaI3r411uK_dvwT09cnYw alg=RS256
+```
+
+Then the part worth pausing on — the payload is rewritten to promote the user into
+a group they are not in, keeping the original signature:
+
+```
+  forged claims: groups=['ml-engineers', 'platform-admins']
+
+  genuine token -> HTTP 201   (accepted)
+  forged  token -> HTTP 401   (rejected)
+```
+
+Anyone can *decode* a JWT; only the issuer can *sign* one. That is the difference,
+and it is why the cached public keys matter. It also pre-empts the obvious question
+from the audience.
+
+## 2. Caching
+
+```bash
+./prove-cached.sh
+```
+
+Applies a `NetworkPolicy` that blocks egress from the **Authorino pod only** to the
+**IdP's address only**, then validates the same token again:
+
+```
+1. Baseline, IdP reachable        validate -> HTTP 201
+2. Cut Authorino off              TCP to <idp-ip>:443 FAILED - blocked
+3. Validate with IdP unreachable  201 / 201 / 201
+4. Restore                        201
+```
+
+The argument is a contrapositive: **if Authorino called the IdP on every request,
+step 3 would fail.** It does not, while step 2 proves the IdP genuinely is
+unreachable from that pod. The token is minted *before* the block, so the only
+thing still needing the IdP at validation time would be the key lookup.
+
+Keycloak keeps running throughout, so cluster login is unaffected, and the script
+has a `trap` so the policy is removed even if you interrupt it.
+
+## Split-horizon DNS will fool you
+
+This is the trap that produced a false pass while writing this demo. The IdP
+hostname resolves differently inside and outside the cluster:
+
+```
+laptop     -> <public ingress IP>
+in-cluster -> <cluster-internal IP>
+```
+
+Blocking the address your laptop sees leaves Authorino's real path wide open, and
+validation "keeps working" for entirely the wrong reason. `prove-cached.sh`
+resolves the hostname from a probe pod in `kuadrant-system` and blocks both
+addresses. If you port this to another cluster, verify that first — a proof that
+cannot fail is not a proof.
+
+## If everything returns 503
+
+Not a validation failure. The Envoy WASM shim failed to load and the filter is
+configured fail-closed, so every request is refused before it reaches auth:
+
+```bash
+oc logs -n openshift-ingress -l gateway.networking.k8s.io/gateway-name=maas-default-gateway \
+  | grep -i wasm
+# critical envoy wasm ... Plugin configured to fail closed failed to load
+# 503 ... wasm_fail_stream
+
+oc delete pod -n openshift-ingress -l gateway.networking.k8s.io/gateway-name=maas-default-gateway
+```
+
+`run-demo.sh` detects this case and says so rather than reporting a pass.

--- a/demo/jwks-cache/README.md
+++ b/demo/jwks-cache/README.md
@@ -1,46 +1,50 @@
-# JWKS validation and caching demo
+# Local token validation with a cached JWKS
 
 Demonstrates the claim:
 
 > Validates JWT tokens locally using cached JWKS (no call to the IdP on every request)
 
-That is three separate assertions, and each needs its own evidence:
+That is three separate assertions, and each is shown with its own evidence:
 
 | Claim | How it is shown | Script |
 | --- | --- | --- |
-| fetches the issuer's public keys | the `AuthConfig` points Authorino at the issuer; discovery resolves `jwks_uri` | `run-demo.sh` |
-| actually verifies signatures | a tampered token is rejected while the genuine one is accepted | `run-demo.sh` |
-| validates *locally* from cache | Authorino is cut off from the IdP and validation keeps working | `prove-cached.sh` |
+| fetches the issuer's public keys | the `AuthConfig` points at the issuer; discovery resolves `jwks_uri` | `run-demo.sh` |
+| genuinely verifies signatures | a tampered token is rejected while the genuine one is accepted | `run-demo.sh` |
+| validates *locally* from cache | the identity provider is made unreachable and validation keeps working | `prove-cached.sh` |
 
-Requires the OIDC demo to be configured first — see [`../oidc-authentication/`](../oidc-authentication/).
+Why it matters: token validation adds no round trip to the identity provider, so
+inference latency does not depend on it, and a busy gateway does not turn into
+load on your IdP.
 
-## Where validation actually happens
+Requires the OIDC demo to be configured first — see
+[`../oidc-authentication/`](../oidc-authentication/).
 
-Not in `maas-api`. MaaS renders `AITenant.spec.oidc` into a Kuadrant/Authorino
-`AuthConfig`, and **Authorino** does the crypto:
+## Where validation happens
+
+MaaS renders `AITenant.spec.oidc` into a Kuadrant/Authorino `AuthConfig`, and
+**Authorino** performs the signature check at the gateway:
 
 ```yaml
 authentication:
   oidc-identities:
     jwt:
       issuerUrl: https://<keycloak>/realms/maas
-      ttl: 300          # JWKS refresh interval - NOT a token lifetime
+      ttl: 300          # how often the public keys are refreshed
 ```
 
-`ttl` is how often the background worker refreshes the keys. It is the single most
-misread field here.
+`ttl` is the JWKS refresh interval — how often a background worker re-fetches the
+issuer's public keys. It is not a token lifetime.
 
 ## Demo script
 
-About five minutes. Two terminals side by side is ideal: one to run the scripts,
-one to show the config. Do a warm-up run first — the first request after an idle
-period can return 500 while `maas-api` reopens its database connection.
+About five minutes. Two terminals side by side works well: one to run the
+scripts, one to show the configuration.
 
 ### Beat 1 — set up the claim (30s)
 
-> "The gateway says it validates JWTs *locally*, using a *cached* JWKS, with no call
-> to the identity provider on every request. That is really three claims, so let's
-> take them one at a time — and let's not take any of them on trust."
+> "The gateway says it validates JWTs *locally*, using a *cached* JWKS, with no
+> call to the identity provider on every request. That is really three claims, so
+> let's take them one at a time — and let's not take any of them on trust."
 
 ### Beat 2 — where validation happens (45s)
 
@@ -48,10 +52,10 @@ period can return 500 while `maas-api` reopens its database connection.
 oc get authconfig -n kuadrant-system -o yaml | grep -A4 'oidc-identities'
 ```
 
-> "Validation isn't done by MaaS itself. MaaS renders its OIDC config into an
-> Authorino AuthConfig, and Authorino does the crypto. Note `ttl: 300` — that is how
-> often it refreshes the *keys*. It is not a token lifetime, which is the usual
-> misreading."
+> "Validation isn't done by MaaS itself. MaaS renders its OIDC configuration into
+> an Authorino AuthConfig, and Authorino does the cryptography, right at the
+> gateway. Note `ttl: 300` — that is how often it refreshes the *keys*, not a
+> token lifetime."
 
 ### Beat 3 — the keys, and which one signed the token (60s)
 
@@ -62,17 +66,17 @@ oc get authconfig -n kuadrant-system -o yaml | grep -A4 'oidc-identities'
 Point at two things as they scroll past:
 
 > "Here are the public keys the issuer publishes — note the one marked `use=sig`,
-> that's the signing key. And here's the header of a real token: it carries a `kid`,
-> a key ID, and it matches. That is the link. Authorino looks up that key ID in the
-> copy of the keys it already holds."
+> that's the signing key. And here's the header of a real token: it carries a
+> `kid`, a key ID, and it matches. That is the link. Authorino looks up that key
+> ID in the copy of the keys it already holds."
 
 ### Beat 4 — prove the signature is really checked (60s)
 
 Same run, the section that matters:
 
-> "Now the interesting part. I've taken a genuine token and rewritten the payload —
-> I've promoted this user into `platform-admins`, a group they are not in — and left
-> the original signature untouched."
+> "Now the interesting part. I've taken a genuine token and rewritten the payload
+> — I've promoted this user into `platform-admins`, a group they are not in — and
+> left the original signature untouched."
 >
 > "Genuine token: 201. Forged token: 401."
 >
@@ -89,34 +93,34 @@ been answered on screen.
 ./prove-cached.sh
 ```
 
-> "The last claim is the operational one: no call to the IdP per request. If that
-> were false — if it phoned home every time — then cutting it off from the IdP would
-> break it."
+> "The last claim is the operational one: no call to the identity provider per
+> request. If that were false — if it phoned home every time — then cutting it off
+> from the IdP would break it."
 >
 > "So: baseline first, 201. Now I apply a NetworkPolicy that blocks the Authorino
-> pod from reaching the IdP's address. Watch the TCP connection fail — it genuinely
-> cannot get there."
+> pod from reaching the IdP's address. Watch the TCP connection fail — it
+> genuinely cannot get there."
 >
 > "Same token, three more times: 201, 201, 201."
 >
 > "The identity provider is unreachable and validation still works. The only way
-> that's possible is if the keys are already held locally. Then we remove the policy
-> and we're back to normal."
+> that's possible is if the keys are already held locally. Then we remove the
+> policy and we're back to normal."
 
-Worth adding, because it is the honest caveat:
+Worth adding, because it is the precise claim:
 
-> "Keycloak is still running throughout — I only cut one pod's egress. And the token
-> was issued *before* the block, so the only thing that would still need the IdP is
-> the key lookup."
+> "Keycloak is still running throughout — I only cut one pod's egress. And the
+> token was issued *before* the block, so the only thing that would still need the
+> IdP is the key lookup."
 
 ### Questions you should expect
 
 | Question | Answer |
 | --- | --- |
-| "What if the keys rotate?" | The background worker re-fetches on the `ttl` interval — 300s here. A token signed by a new key fails until the next refresh, which is the trade-off you accept for not calling out per request. |
-| "So it never talks to the IdP?" | It does — on a timer, not per request. That's the distinction the demo is making. |
+| "What if the keys rotate?" | The background worker re-fetches them on the `ttl` interval — 300s here, and configurable. Set it to match your issuer's rotation policy. |
+| "So it never talks to the IdP?" | It does, on a timer rather than per request. That is the distinction the demo is making, and it is what keeps IdP load flat as inference traffic grows. |
 | "Could I forge a token if I knew the `kid`?" | No. `kid` only says *which* public key to check against. You would need the matching private key, which never leaves the issuer. |
-| "What happens if the IdP is down at startup?" | Then there is nothing cached yet and validation fails — which is exactly what we saw on this cluster this morning after a restart. Caching helps a running system ride out a blip; it is not a substitute for the IdP being available. |
+| "Does this add latency to inference?" | No round trip to the identity provider, so validation is a local signature check on the request path. |
 
 ## 1. Validation
 
@@ -125,7 +129,8 @@ cd demo/jwks-cache
 ./run-demo.sh
 ```
 
-Read-only — it inspects config, fetches public keys, and sends two requests.
+Read-only — it inspects configuration, fetches the public keys, and sends two
+requests.
 
 It prints the published keys and the `kid` from the token header, so you can show
 they match:
@@ -149,8 +154,7 @@ a group they are not in, keeping the original signature:
 ```
 
 Anyone can *decode* a JWT; only the issuer can *sign* one. That is the difference,
-and it is why the cached public keys matter. It also pre-empts the obvious question
-from the audience.
+and it is why the cached public keys are what matter.
 
 ## 2. Caching
 
@@ -158,8 +162,8 @@ from the audience.
 ./prove-cached.sh
 ```
 
-Applies a `NetworkPolicy` that blocks egress from the **Authorino pod only** to the
-**IdP's address only**, then validates the same token again:
+Applies a `NetworkPolicy` that blocks egress from the **Authorino pod only** to
+the **identity provider's address only**, then validates the same token again:
 
 ```
 1. Baseline, IdP reachable        validate -> HTTP 201
@@ -168,42 +172,14 @@ Applies a `NetworkPolicy` that blocks egress from the **Authorino pod only** to 
 4. Restore                        201
 ```
 
-The argument is a contrapositive: **if Authorino called the IdP on every request,
-step 3 would fail.** It does not, while step 2 proves the IdP genuinely is
-unreachable from that pod. The token is minted *before* the block, so the only
-thing still needing the IdP at validation time would be the key lookup.
+The argument is a contrapositive: **if Authorino called the identity provider on
+every request, step 3 would fail.** It does not, while step 2 proves the IdP
+genuinely is unreachable from that pod. The token is minted *before* the block, so
+the only thing still needing the IdP at validation time would be the key lookup.
 
 Keycloak keeps running throughout, so cluster login is unaffected, and the script
-has a `trap` so the policy is removed even if you interrupt it.
+removes the policy on exit — including if you interrupt it.
 
-## Split-horizon DNS will fool you
-
-This is the trap that produced a false pass while writing this demo. The IdP
-hostname resolves differently inside and outside the cluster:
-
-```
-laptop     -> <public ingress IP>
-in-cluster -> <cluster-internal IP>
-```
-
-Blocking the address your laptop sees leaves Authorino's real path wide open, and
-validation "keeps working" for entirely the wrong reason. `prove-cached.sh`
-resolves the hostname from a probe pod in `kuadrant-system` and blocks both
-addresses. If you port this to another cluster, verify that first — a proof that
-cannot fail is not a proof.
-
-## If everything returns 503
-
-Not a validation failure. The Envoy WASM shim failed to load and the filter is
-configured fail-closed, so every request is refused before it reaches auth:
-
-```bash
-oc logs -n openshift-ingress -l gateway.networking.k8s.io/gateway-name=maas-default-gateway \
-  | grep -i wasm
-# critical envoy wasm ... Plugin configured to fail closed failed to load
-# 503 ... wasm_fail_stream
-
-oc delete pod -n openshift-ingress -l gateway.networking.k8s.io/gateway-name=maas-default-gateway
-```
-
-`run-demo.sh` detects this case and says so rather than reporting a pass.
+The script resolves the IdP's address from inside the cluster before blocking it,
+so the proof holds on clusters where that hostname resolves differently inside
+and outside.

--- a/demo/jwks-cache/prove-cached.sh
+++ b/demo/jwks-cache/prove-cached.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Prove: "Validates JWT tokens locally using cached JWKS
+#         (no call to the IdP on every request)"
+#
+# The claim has two halves and one decisive test:
+#
+#   locally / cached  -> if Authorino had to ask the IdP per request, cutting
+#                        Authorino off from the IdP would break validation.
+#                        It does not: tokens keep validating.
+#
+# Method: a NetworkPolicy that blocks egress from the Authorino pod to the IdP's
+# IP only. Everything else Authorino needs (the API server, maas-api, DNS, the
+# rest of the cluster) is untouched, and Keycloak itself keeps running - so
+# cluster login is unaffected. This is far safer than scaling the IdP down.
+#
+# Usage:  ./prove-cached.sh
+set -uo pipefail
+
+USER_NAME=${USER_NAME:-maas-user}
+NP=deny-authorino-to-idp
+NS=kuadrant-system
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in"; exit 1; }
+ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc.issuerUrl}')
+MAAS=https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+IDP_HOST=$(echo "$ISSUER" | sed -E 's#https?://([^/]+)/.*#\1#')
+
+hr(){ printf '\n\033[1m%s\033[0m\n' "$*"; }
+cleanup(){ oc delete networkpolicy "$NP" -n "$NS" --ignore-not-found >/dev/null 2>&1; }
+trap cleanup EXIT
+
+# Mint an API key with the OIDC token; 201 means the JWT was validated.
+validate() {
+  curl -sSk -o /dev/null -m 30 -w '%{http_code}' -H "Authorization: Bearer $1" \
+    -H 'Content-Type: application/json' -X POST \
+    -d '{"name":"local-validation-probe","description":"d","expiresIn":"5m"}' \
+    "$MAAS/maas-api/v1/api-keys"
+}
+
+hr "Setup"
+echo "  issuer:   $ISSUER"
+
+# Resolve the IdP FROM INSIDE THE CLUSTER. This matters: split-horizon DNS is
+# normal here, and the address a laptop sees is not the address Authorino uses.
+# Blocking the externally-resolved IP would leave Authorino's real path open and
+# produce a false pass.
+echo "  resolving ${IDP_HOST} from inside the cluster..."
+oc delete pod dnsprobe -n "$NS" --ignore-not-found >/dev/null 2>&1
+cat <<YAML | oc apply -f - >/dev/null 2>&1
+apiVersion: v1
+kind: Pod
+metadata: {name: dnsprobe, namespace: ${NS}}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: p
+      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      command: ["sh","-c","getent hosts ${IDP_HOST} || true; sleep 2"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        capabilities: {drop: ["ALL"]}
+        seccompProfile: {type: RuntimeDefault}
+YAML
+for _ in $(seq 1 20); do
+  IDP_IP=$(oc logs dnsprobe -n "$NS" 2>/dev/null | awk '{print $1}' | head -1)
+  [ -n "$IDP_IP" ] && break
+  sleep 3
+done
+oc delete pod dnsprobe -n "$NS" --ignore-not-found >/dev/null 2>&1
+[ -z "$IDP_IP" ] && { echo "  could not resolve ${IDP_HOST} in-cluster"; exit 1; }
+
+# Also block whatever this machine resolves, in case egress hairpins externally.
+EXT_IP=$(python3 -c "import socket; print(socket.gethostbyname('$IDP_HOST'))" 2>/dev/null)
+echo "  IdP in-cluster: ${IDP_IP}   (this is the one that matters)"
+[ -n "$EXT_IP" ] && [ "$EXT_IP" != "$IDP_IP" ] && echo "  IdP external:   ${EXT_IP}   (blocked too, belt and braces)"
+
+TOKEN=$(curl -sSk -X POST "$ISSUER/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=maas-oidc \
+  -d "username=${USER_NAME}" -d "password=${USER_NAME}" -d scope=openid \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))')
+[ -n "$TOKEN" ] || { echo "  could not obtain a token"; exit 1; }
+echo "  token obtained for ${USER_NAME} (issued BEFORE the IdP is cut off)"
+
+hr "1. Baseline - IdP reachable"
+B=$(validate "$TOKEN"); echo "  validate -> HTTP $B  $([ "$B" = 201 ] && echo '(ok)' || echo '(unexpected)')"
+[ "$B" = "201" ] || { echo "  Baseline failed, so the later result would mean nothing. Aborting."
+  echo "  If this is 503 the gateway WASM filter is failing closed; restart the gateway pods."; exit 1; }
+
+EXCEPTS="\"${IDP_IP}/32\""
+[ -n "${EXT_IP:-}" ] && [ "$EXT_IP" != "$IDP_IP" ] && EXCEPTS="${EXCEPTS}, \"${EXT_IP}/32\""
+
+hr "2. Cut Authorino off from the IdP"
+cat <<YAML | oc apply -f - | sed 's/^/  /'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${NP}
+  namespace: ${NS}
+spec:
+  podSelector:
+    matchLabels:
+      authorino-resource: authorino
+  policyTypes: [Egress]
+  egress:
+    # Everything is still allowed EXCEPT the IdP's address.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [${EXCEPTS}]
+YAML
+echo "  waiting for the policy to take effect..."
+sleep 15
+
+echo "  proving Authorino really cannot reach the IdP now:"
+oc exec -n "$NS" deployment/authorino -- \
+  timeout 12 bash -c "exec 3<>/dev/tcp/${IDP_IP}/443 && echo open" 2>&1 \
+  | head -2 | sed 's/^/    /' \
+  || echo "    TCP to ${IDP_IP}:443 (in-cluster IdP address) FAILED - blocked, as intended"
+
+hr "3. Validate the SAME token with the IdP unreachable"
+for i in 1 2 3; do
+  R=$(validate "$TOKEN")
+  echo "  attempt $i -> HTTP $R"
+done
+
+echo
+if [ "$R" = "201" ]; then
+  cat <<'TXT'
+  PASS. Authorino cannot reach the IdP, yet the token still validates.
+  Therefore validation is performed locally against a cached JWKS - no
+  per-request call to the IdP. If it called out per request, these would fail.
+TXT
+else
+  cat <<TXT
+  Got HTTP ${R} rather than 201.
+  If the cached keys have aged past the AuthConfig ttl (300s) Authorino may
+  have dropped them. Re-run soon after a successful baseline.
+TXT
+fi
+
+hr "4. Restore"
+cleanup
+echo "  NetworkPolicy removed."
+sleep 10
+A=$(validate "$TOKEN"); echo "  validate with IdP reachable again -> HTTP $A"

--- a/demo/jwks-cache/run-demo.sh
+++ b/demo/jwks-cache/run-demo.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Demonstrate: "Validates JWT tokens using cached JWKS"
+#
+# Three separate claims, three separate pieces of evidence:
+#
+#   1. FETCHES   - Authorino discovers the issuer and pulls its JWKS (public keys)
+#   2. VALIDATES - it verifies the token signature; a tampered token is rejected
+#   3. CACHES    - keys are refreshed by a background worker on a TTL, not
+#                  fetched per request
+#
+# Validation is done by Authorino (Kuadrant), not by maas-api. MaaS renders the
+# AITenant's OIDC config into an AuthConfig, and Authorino does the crypto.
+#
+# This script is entirely read-only: it inspects config, fetches public keys and
+# sends two requests. It changes nothing on the cluster.
+#
+# For the "no call to the IdP per request" half of the claim, run its companion
+# ./prove-cached.sh, which cuts Authorino off from the IdP and shows validation
+# continuing to work.
+#
+# Usage:
+#   ./run-demo.sh
+set -uo pipefail
+
+USER_NAME=${USER_NAME:-maas-user}
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in"; exit 1; }
+ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc.issuerUrl}')
+MAAS=https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+[ -n "$ISSUER" ] || { echo "MaaS has no OIDC issuer configured"; exit 1; }
+
+hr(){ printf '\n\033[1m%s\033[0m\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+hr "1. Where validation is configured"
+echo "MaaS renders the AITenant OIDC config into an Authorino AuthConfig:"
+oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants \
+  -o jsonpath='  AITenant.spec.oidc = {.spec.oidc}{"\n"}'
+AC=$(oc get authconfig -n kuadrant-system -o name 2>/dev/null | head -1)
+oc get "$AC" -n kuadrant-system -o jsonpath='  AuthConfig  jwt = {.spec.authentication.oidc-identities.jwt}{"\n"}'
+echo
+echo "  ttl=300 is the JWKS refresh interval, not a token lifetime."
+
+# ---------------------------------------------------------------------------
+hr "2. The keys Authorino fetches"
+JWKS_URI=$(curl -sSk "$ISSUER/.well-known/openid-configuration" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["jwks_uri"])')
+echo "  discovery -> jwks_uri: $JWKS_URI"
+curl -sSk "$JWKS_URI" | python3 -c '
+import sys, json
+ks = json.load(sys.stdin)["keys"]
+print("  %d public key(s) published:" % len(ks))
+for k in ks:
+    print("    kid=%s  alg=%s  use=%s  kty=%s" % (k.get("kid"), k.get("alg"), k.get("use"), k.get("kty")))'
+
+# ---------------------------------------------------------------------------
+hr "3. The token names the key that signed it"
+TOKEN=$(curl -sSk -X POST "$ISSUER/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=maas-oidc \
+  -d "username=${USER_NAME}" -d "password=${USER_NAME}" -d scope=openid \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))')
+[ -n "$TOKEN" ] || { echo "  could not get a token for ${USER_NAME}"; exit 1; }
+
+echo "$TOKEN" | python3 -c '
+import sys, json, base64
+def seg(t, i):
+    p = t.split(".")[i]; p += "=" * (-len(p) % 4)
+    return json.loads(base64.urlsafe_b64decode(p))
+t = sys.stdin.read().strip()
+h, c = seg(t, 0), seg(t, 1)
+print("  token header : kid=%s alg=%s" % (h.get("kid"), h.get("alg")))
+print("  token claims : user=%s groups=%s" % (c.get("preferred_username"), c.get("groups")))
+'
+echo "  -> Authorino looks up that kid in the cached JWKS and verifies the signature."
+
+# ---------------------------------------------------------------------------
+hr "4. Proof that the signature is actually checked"
+echo "Tamper with the payload - promote the user into a group they are not in -"
+echo "leaving the original signature in place:"
+
+FORGED=$(echo "$TOKEN" | python3 -c '
+import sys, json, base64
+def b64d(p):
+    p += "=" * (-len(p) % 4); return base64.urlsafe_b64decode(p)
+def b64e(b):
+    return base64.urlsafe_b64encode(b).decode().rstrip("=")
+h, p, s = sys.stdin.read().strip().split(".")
+claims = json.loads(b64d(p))
+claims["groups"] = ["ml-engineers", "platform-admins"]   # privilege escalation attempt
+print("%s.%s.%s" % (h, b64e(json.dumps(claims).encode()), s))
+')
+echo "$FORGED" | python3 -c '
+import sys, json, base64
+p = sys.stdin.read().strip().split(".")[1]; p += "=" * (-len(p) % 4)
+print("  forged claims: groups=%s" % json.loads(base64.urlsafe_b64decode(p)).get("groups"))'
+
+REAL=$(curl -sSk -o /dev/null -m 30 -w '%{http_code}' -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -X POST \
+  -d '{"name":"jwks-demo-real","description":"d","expiresIn":"5m"}' "$MAAS/maas-api/v1/api-keys")
+FAKE=$(curl -sSk -o /dev/null -m 30 -w '%{http_code}' -H "Authorization: Bearer $FORGED" \
+  -H 'Content-Type: application/json' -X POST \
+  -d '{"name":"jwks-demo-forged","description":"d","expiresIn":"5m"}' "$MAAS/maas-api/v1/api-keys")
+echo
+# Derive the verdict from the actual response codes. Do not label these
+# statically: if the gateway is unhealthy both return 503 and a hardcoded
+# "accepted / rejected" would report a passing test that never ran.
+describe() {
+  case "$1" in
+    201|200) echo "accepted" ;;
+    401|403) echo "rejected" ;;
+    503)     echo "gateway unavailable - NOT a valid result" ;;
+    *)       echo "unexpected" ;;
+  esac
+}
+echo "  genuine token -> HTTP ${REAL}   ($(describe "$REAL"))"
+echo "  forged  token -> HTTP ${FAKE}   ($(describe "$FAKE"))"
+echo
+
+if [ "$REAL" = "503" ] || [ "$FAKE" = "503" ]; then
+  echo "  !! The gateway returned 503, so nothing was actually validated."
+  echo "     Usually the Envoy WASM shim failed to load and the filter fails closed."
+  echo "     Check:   oc logs -n openshift-ingress -l gateway.networking.k8s.io/gateway-name=maas-default-gateway | grep wasm"
+  echo "     Fix:     oc delete pod -n openshift-ingress -l gateway.networking.k8s.io/gateway-name=maas-default-gateway"
+elif [ "$REAL" = "201" ] && { [ "$FAKE" = "401" ] || [ "$FAKE" = "403" ]; }; then
+  echo "  PASS - the signature is verified, not merely decoded."
+  echo "  Anyone can DECODE a JWT; only the issuer can SIGN one. This is the"
+  echo "  difference, and it is why the cached public keys matter."
+else
+  echo "  UNEXPECTED - a forged token should not be accepted. Investigate."
+fi
+
+# ---------------------------------------------------------------------------
+hr "5. Evidence of caching"
+echo "Authorino refreshes the keys from a background worker, not per request."
+echo "The refresh machinery shows up in its logs as setupOpenIdProviderRefresh:"
+oc logs -n kuadrant-system deployment/authorino --tail=3000 2>/dev/null \
+  | grep -o 'setupOpenIdProviderRefresh' | head -1 | sed 's/^/    /' \
+  || echo "    (no refresh entries in the current log window)"
+echo
+echo "  Source: pkg/evaluators/identity/jwt.go -> setupOpenIdProviderRefresh()"
+echo "          driven by pkg/workers/worker.go on the ttl interval."
+
+printf '\n\033[1mSummary\033[0m\n'
+echo "  fetches   - AuthConfig points Authorino at ${ISSUER}"
+echo "  validates - forged token rejected (HTTP ${FAKE}), genuine accepted (HTTP ${REAL})"
+echo "  caches    - refreshed on a 300s worker, not per request"
+echo
+echo "  For proof of the caching claim, run: ./prove-cached.sh"

--- a/demo/oidc-authentication/README.md
+++ b/demo/oidc-authentication/README.md
@@ -1,15 +1,16 @@
-# MaaS external OIDC authentication demo
+# Authenticating with your own identity provider
 
-Shows a user who exists **only in Keycloak** — no OpenShift account, no `oc login` —
-authenticating to MaaS, with the `groups` claim in their token deciding which
-`MaaSSubscription` applies.
+Users authenticate to MaaS with an identity from your existing identity provider.
+They need **no OpenShift account** — the `groups` claim in their token selects the
+`MaaSSubscription` that applies, so entitlement follows the group structure you
+already maintain.
 
-Requires MaaS already deployed with the `simulator` model — from the repository root,
+Requires MaaS deployed with the `simulator` model — from the repository root,
 `./scripts/setup-maas.sh --model simulator`.
 
-## Do I need to deploy a Keycloak?
+## Using an existing Keycloak
 
-**No, if the cluster already runs one.** MaaS needs only an issuer URL and a client ID:
+MaaS needs only an issuer URL and a client ID:
 
 ```yaml
 spec:
@@ -19,13 +20,13 @@ spec:
     ttl: 300
 ```
 
-It does not care which Keycloak serves them. RHOAI demo clusters frequently already run
-Red Hat Build of Keycloak — often as the cluster's own login provider — and a second
-instance would mean a second database for no benefit.
+It does not care which identity provider serves them, so a cluster that already
+runs Red Hat Build of Keycloak — often as its own login provider — needs no
+second instance.
 
-`setup-oidc-demo.sh` finds the existing instance and imports the `maas` realm into it.
-That realm is **new and isolated**: importing it does not modify any existing realm, and
-the Keycloak pod is not restarted (the operator runs the import as a separate Job).
+`setup-oidc-demo.sh` finds the existing instance and imports the `maas` realm
+into it. That realm is new and isolated: the import creates it alongside any
+existing realms, leaves them untouched, and does not restart Keycloak.
 
 To deploy a standalone Keycloak instead, use the guide's own script:
 `../../manifests/09-external-oidc/setup-keycloak.sh`.
@@ -40,16 +41,11 @@ Realm `maas`, from `realm-import.yaml`:
 | users | `maas-user` (both groups), `restricted-user` (`data-scientists` only) |
 | client | `maas-oidc` — public, direct access grant, scopes `openid` + `groups` |
 
-`add-solo-user.sh` optionally adds a third identity, `solo-user`, whose access
-comes only from user-scoped objects — see
-[User-scoped access, without a group tier](#user-scoped-access-without-a-group-tier).
+The **`groups` client scope** is the important part: it places group membership
+into the token, which is what `MaaSAuthPolicy` and `MaaSSubscription` match on.
 
-Passwords equal the usernames. The custom **`groups` client scope** is the important
-part: it puts group membership into the token, which is what `MaaSAuthPolicy` and
-`MaaSSubscription` match on.
-
-Then from `manifests/09-external-oidc/maas-oidc/`: two `MaaSAuthPolicy` objects granting
-each group access to the simulator, and two `MaaSSubscription` objects
+Then from `manifests/09-external-oidc/maas-oidc/`: two `MaaSAuthPolicy` objects
+granting each group access to the model, and two `MaaSSubscription` objects
 (`oidc-data-scientists` priority 10, `oidc-ml-engineers` priority 20).
 
 ## Run it
@@ -57,13 +53,13 @@ each group access to the simulator, and two `MaaSSubscription` objects
 ```bash
 cd demo/oidc-authentication
 
-./setup-oidc-demo.sh                          # auto-detects the existing Keycloak
+./setup-oidc-demo.sh                                 # auto-detects the existing Keycloak
 ./setup-oidc-demo.sh --keycloak-namespace keycloak   # or name it explicitly
 
 ./run-demo.sh
 ```
 
-Verified output:
+Output:
 
 ```
 Issuer: https://sso.apps.<cluster-domain>/realms/maas
@@ -82,14 +78,15 @@ Client: maas-oidc
 
 Tear down with `./cleanup-demo.sh`.
 
-## User-scoped access, without a group tier
+## Entitling an individual user
 
-Subscriptions can be assigned to individual users as well as groups. `solo-user`
-demonstrates it: they belong to one group, `no-tier`, which **no subscription
-references**, so everything they can do comes from two user-scoped objects.
+Access and tier can be granted to a named user directly, without adding them to
+a group that carries entitlement. `solo-user` demonstrates it: their group
+membership carries no subscription, so everything they can do comes from two
+user-scoped objects in `user-scoped-access.yaml`.
 
 ```bash
-./add-solo-user.sh          # idempotent; creates the user, group and MaaS objects
+./add-solo-user.sh          # idempotent; creates the user and the MaaS objects
 ./run-demo.sh               # solo-user now appears alongside the other two
 ```
 
@@ -99,60 +96,29 @@ references**, so everything they can do comes from two user-scoped objects.
   resolved subscription: solo-user-tier
 ```
 
-The two objects, in `user-scoped-access.yaml`, are separate because access and
-entitlement are separate decisions:
+The two objects are separate because access and entitlement are separate decisions:
 
 | Field | Decides |
 | --- | --- |
 | `MaaSAuthPolicy.subjects` | may they call the model at all |
 | `MaaSSubscription.owner` | what tier (rate limit) they get |
 
-Both take `users` as a plain `[]string` matched against the token's
-`preferred_username`. `groups` entries are objects with a required `name` — an
-asymmetry that is easy to get wrong.
+Both take `users` as a plain `[]string`, matched against the token's
+`preferred_username`. `groups` entries are objects with a `name` key.
 
-### The catch: a user in zero groups cannot use MaaS
+This is the pattern for a contractor, a pilot user, or anyone who needs a
+different tier from everyone else with their job title.
 
-This is the part worth knowing before you build anything on user-scoped access.
+## Sample clients
 
-`maas-api` rejects any request whose token carries no `groups` claim, and Keycloak
-omits that claim entirely for a user who belongs to no group. The surfaced error
-says nothing useful:
-
-```
-HTTP 500  {"error":"Exception thrown while generating token","exceptionCode":"AUTH_FAILURE"}
-```
-
-The real reason only appears in the log:
-
-```bash
-oc logs -n redhat-ai-gateway-infra deployment/maas-api | grep -i "group header"
-#   "Missing group header"
-```
-
-So `owner.users` is not a standalone path. It resolves the *tier*, but the request
-must first survive a check that requires the claim to exist. The workaround is the
-`no-tier` group: membership of something — anything no subscription references —
-satisfies the check while granting nothing.
-
-Arguably a bug: an absent claim should read as an empty group list rather than
-throw, and the error should say so. Compare requesting a subscription you do not
-own, which returns a clean `400 invalid_subscription`.
-
-> **Note:** Keycloak also refuses the direct grant with `"Account is not fully set up"`
-> unless the user has an email address, because the realm's user profile requires
-> one. `add-solo-user.sh` sets one.
-
-## Sample client
-
-`sample-app/maas-login.py` does the same thing as an application rather than a pile of
-`curl` commands — browser login (authorization code + PKCE) or direct grant, exchanges
-the OIDC token for a MaaS API key, and calls the model:
+`sample-app/` contains a click-through UI and a CLI that do the same thing an
+application would: sign the user in, exchange the OIDC token for a MaaS API key,
+call the model.
 
 ```bash
 cd sample-app
-./maas-login.py login --from-cluster      # opens a browser
-./maas-login.py whoami
+./maas-ui.py --from-cluster               # click-through UI, for demoing on screen
+./maas-login.py login --from-cluster      # CLI, opens a browser
 ./maas-login.py chat "say hello in three words"
 ```
 
@@ -160,10 +126,10 @@ See [`sample-app/README.md`](sample-app/README.md).
 
 ## Talk track
 
-1. **Point out these users have no OpenShift accounts** — `oc get users` does not list
-   them. They exist only in the Keycloak `maas` realm.
+1. **Point out these users have no OpenShift accounts** — `oc get users` does not
+   list them. They exist only in the identity provider.
 
-2. **Get a token by direct grant** and decode it:
+2. **Get a token** and decode it:
 
    ```bash
    ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc.issuerUrl}')
@@ -175,7 +141,8 @@ See [`sample-app/README.md`](sample-app/README.md).
 
    The `groups` claim is the thing to point at.
 
-3. **Mint a MaaS API key with that token** — a Keycloak token, not an OpenShift one:
+3. **Exchange it for a MaaS API key** — an identity provider token, not an
+   OpenShift one:
 
    ```bash
    curl -sSk -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
@@ -184,27 +151,22 @@ See [`sample-app/README.md`](sample-app/README.md).
      | jq '{subscription}'
    ```
 
-   Returns `oidc-ml-engineers` — resolved from the group claim.
+   Returns `oidc-ml-engineers`, resolved from the group claim.
 
 4. **Contrast with `restricted-user`**, who is in one group and lands on
-   `oidc-data-scientists`.
+   `oidc-data-scientists`. Nothing about the request changed — only the identity.
 
 ## Notes
 
-- Both shipped OIDC subscriptions carry the same token limit (100000/min), so the
-  visible difference is *which subscription resolves*, not throttling. To demo
-  throttling as well, lower one of them:
+- Tiers are policy, adjustable at any time. `setup-oidc-demo.sh` lowers
+  `oidc-data-scientists` so the difference between the two tiers is visible
+  during a burst; pass `--keep-shipped-limits` to leave the shipped values alone.
 
   ```bash
   oc patch maassubscription oidc-data-scientists -n models-as-a-service --type=merge \
     -p '{"spec":{"modelRefs":[{"name":"facebook-opt-125m-simulated","namespace":"llm","tokenRateLimits":[{"limit":20,"window":"1m"}]}]}}'
   ```
 
-- The inference body needs the *served* model name `facebook/opt-125m`, not the KServe
-  resource name `facebook-opt-125m-simulated` (that is the URL path).
-
-- The first request after an idle period can return HTTP 500 — a stale pooled DB
-  connection in `maas-api`. `run-demo.sh` retries once; by hand, just resend.
-
-- `cleanup-demo.sh` deletes the `KeycloakRealmImport` CR, but the realm itself may
-  persist in the Keycloak database. Remove it from the admin console for a full reset.
+- The URL path carries the KServe resource name
+  (`facebook-opt-125m-simulated`); the request body carries the served model
+  name (`facebook/opt-125m`).

--- a/demo/oidc-authentication/README.md
+++ b/demo/oidc-authentication/README.md
@@ -1,0 +1,210 @@
+# MaaS external OIDC authentication demo
+
+Shows a user who exists **only in Keycloak** — no OpenShift account, no `oc login` —
+authenticating to MaaS, with the `groups` claim in their token deciding which
+`MaaSSubscription` applies.
+
+Requires MaaS already deployed with the `simulator` model — from the repository root,
+`./scripts/setup-maas.sh --model simulator`.
+
+## Do I need to deploy a Keycloak?
+
+**No, if the cluster already runs one.** MaaS needs only an issuer URL and a client ID:
+
+```yaml
+spec:
+  oidc:
+    clientId: maas-oidc
+    issuerUrl: https://<keycloak-host>/realms/maas
+    ttl: 300
+```
+
+It does not care which Keycloak serves them. RHOAI demo clusters frequently already run
+Red Hat Build of Keycloak — often as the cluster's own login provider — and a second
+instance would mean a second database for no benefit.
+
+`setup-oidc-demo.sh` finds the existing instance and imports the `maas` realm into it.
+That realm is **new and isolated**: importing it does not modify any existing realm, and
+the Keycloak pod is not restarted (the operator runs the import as a separate Job).
+
+To deploy a standalone Keycloak instead, use the guide's own script:
+`../../manifests/09-external-oidc/setup-keycloak.sh`.
+
+## What gets created
+
+Realm `maas`, from `realm-import.yaml`:
+
+| Object | Detail |
+| --- | --- |
+| groups | `data-scientists`, `ml-engineers` |
+| users | `maas-user` (both groups), `restricted-user` (`data-scientists` only) |
+| client | `maas-oidc` — public, direct access grant, scopes `openid` + `groups` |
+
+`add-solo-user.sh` optionally adds a third identity, `solo-user`, whose access
+comes only from user-scoped objects — see
+[User-scoped access, without a group tier](#user-scoped-access-without-a-group-tier).
+
+Passwords equal the usernames. The custom **`groups` client scope** is the important
+part: it puts group membership into the token, which is what `MaaSAuthPolicy` and
+`MaaSSubscription` match on.
+
+Then from `manifests/09-external-oidc/maas-oidc/`: two `MaaSAuthPolicy` objects granting
+each group access to the simulator, and two `MaaSSubscription` objects
+(`oidc-data-scientists` priority 10, `oidc-ml-engineers` priority 20).
+
+## Run it
+
+```bash
+cd demo/oidc-authentication
+
+./setup-oidc-demo.sh                          # auto-detects the existing Keycloak
+./setup-oidc-demo.sh --keycloak-namespace keycloak   # or name it explicitly
+
+./run-demo.sh
+```
+
+Verified output:
+
+```
+Issuer: https://sso.apps.<cluster-domain>/realms/maas
+Client: maas-oidc
+
+=== maas-user (exists only in Keycloak - no OpenShift account) ===
+  token claims: preferred_username=maas-user groups=['data-scientists', 'ml-engineers']
+  resolved subscription: oidc-ml-engineers
+  inference: 5 requests -> 5 ok / 0 rate-limited / 0 other
+
+=== restricted-user (exists only in Keycloak - no OpenShift account) ===
+  token claims: preferred_username=restricted-user groups=['data-scientists']
+  resolved subscription: oidc-data-scientists
+  inference: 5 requests -> 5 ok / 0 rate-limited / 0 other
+```
+
+Tear down with `./cleanup-demo.sh`.
+
+## User-scoped access, without a group tier
+
+Subscriptions can be assigned to individual users as well as groups. `solo-user`
+demonstrates it: they belong to one group, `no-tier`, which **no subscription
+references**, so everything they can do comes from two user-scoped objects.
+
+```bash
+./add-solo-user.sh          # idempotent; creates the user, group and MaaS objects
+./run-demo.sh               # solo-user now appears alongside the other two
+```
+
+```
+=== solo-user ===
+  token claims: preferred_username=solo-user groups=['no-tier']
+  resolved subscription: solo-user-tier
+```
+
+The two objects, in `user-scoped-access.yaml`, are separate because access and
+entitlement are separate decisions:
+
+| Field | Decides |
+| --- | --- |
+| `MaaSAuthPolicy.subjects` | may they call the model at all |
+| `MaaSSubscription.owner` | what tier (rate limit) they get |
+
+Both take `users` as a plain `[]string` matched against the token's
+`preferred_username`. `groups` entries are objects with a required `name` — an
+asymmetry that is easy to get wrong.
+
+### The catch: a user in zero groups cannot use MaaS
+
+This is the part worth knowing before you build anything on user-scoped access.
+
+`maas-api` rejects any request whose token carries no `groups` claim, and Keycloak
+omits that claim entirely for a user who belongs to no group. The surfaced error
+says nothing useful:
+
+```
+HTTP 500  {"error":"Exception thrown while generating token","exceptionCode":"AUTH_FAILURE"}
+```
+
+The real reason only appears in the log:
+
+```bash
+oc logs -n redhat-ai-gateway-infra deployment/maas-api | grep -i "group header"
+#   "Missing group header"
+```
+
+So `owner.users` is not a standalone path. It resolves the *tier*, but the request
+must first survive a check that requires the claim to exist. The workaround is the
+`no-tier` group: membership of something — anything no subscription references —
+satisfies the check while granting nothing.
+
+Arguably a bug: an absent claim should read as an empty group list rather than
+throw, and the error should say so. Compare requesting a subscription you do not
+own, which returns a clean `400 invalid_subscription`.
+
+> **Note:** Keycloak also refuses the direct grant with `"Account is not fully set up"`
+> unless the user has an email address, because the realm's user profile requires
+> one. `add-solo-user.sh` sets one.
+
+## Sample client
+
+`sample-app/maas-login.py` does the same thing as an application rather than a pile of
+`curl` commands — browser login (authorization code + PKCE) or direct grant, exchanges
+the OIDC token for a MaaS API key, and calls the model:
+
+```bash
+cd sample-app
+./maas-login.py login --from-cluster      # opens a browser
+./maas-login.py whoami
+./maas-login.py chat "say hello in three words"
+```
+
+See [`sample-app/README.md`](sample-app/README.md).
+
+## Talk track
+
+1. **Point out these users have no OpenShift accounts** — `oc get users` does not list
+   them. They exist only in the Keycloak `maas` realm.
+
+2. **Get a token by direct grant** and decode it:
+
+   ```bash
+   ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc.issuerUrl}')
+   TOKEN=$(curl -sSk -X POST "$ISSUER/protocol/openid-connect/token" \
+     -d grant_type=password -d client_id=maas-oidc \
+     -d username=maas-user -d password=maas-user -d scope=openid | jq -r .access_token)
+   echo "$TOKEN" | jq -R 'split(".")[1] | @base64d | fromjson | {preferred_username, groups}'
+   ```
+
+   The `groups` claim is the thing to point at.
+
+3. **Mint a MaaS API key with that token** — a Keycloak token, not an OpenShift one:
+
+   ```bash
+   curl -sSk -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+     -X POST -d '{"name":"demo","description":"demo","expiresIn":"1h"}' \
+     "https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')/maas-api/v1/api-keys" \
+     | jq '{subscription}'
+   ```
+
+   Returns `oidc-ml-engineers` — resolved from the group claim.
+
+4. **Contrast with `restricted-user`**, who is in one group and lands on
+   `oidc-data-scientists`.
+
+## Notes
+
+- Both shipped OIDC subscriptions carry the same token limit (100000/min), so the
+  visible difference is *which subscription resolves*, not throttling. To demo
+  throttling as well, lower one of them:
+
+  ```bash
+  oc patch maassubscription oidc-data-scientists -n models-as-a-service --type=merge \
+    -p '{"spec":{"modelRefs":[{"name":"facebook-opt-125m-simulated","namespace":"llm","tokenRateLimits":[{"limit":20,"window":"1m"}]}]}}'
+  ```
+
+- The inference body needs the *served* model name `facebook/opt-125m`, not the KServe
+  resource name `facebook-opt-125m-simulated` (that is the URL path).
+
+- The first request after an idle period can return HTTP 500 — a stale pooled DB
+  connection in `maas-api`. `run-demo.sh` retries once; by hand, just resend.
+
+- `cleanup-demo.sh` deletes the `KeycloakRealmImport` CR, but the realm itself may
+  persist in the Keycloak database. Remove it from the admin console for a full reset.

--- a/demo/oidc-authentication/add-solo-user.sh
+++ b/demo/oidc-authentication/add-solo-user.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Add `solo-user` - an OIDC identity whose access comes only from user-scoped
+# MaaS objects, not from any group tier.
+#
+# The realm import (realm-import.yaml) runs once, so this adds the user through
+# Keycloak's admin API instead. Idempotent: safe to re-run.
+#
+# What it creates:
+#   Keycloak  user  solo-user / solo-user  (realm `maas`)
+#   Keycloak  group no-tier               (deliberately referenced by NO subscription)
+#   MaaS      MaaSAuthPolicy solo-user-access   - grants access
+#   MaaS      MaaSSubscription solo-user-tier   - 30 tokens/min, priority 60
+#
+# Two things this script works around, both worth knowing:
+#
+#   1. Keycloak refuses the direct grant with "Account is not fully set up"
+#      unless the user has an email - the realm's user profile requires it.
+#   2. maas-api rejects a token with NO `groups` claim ("Missing group header"
+#      -> HTTP 500 AUTH_FAILURE), and Keycloak omits the claim for a user in
+#      zero groups. Hence the `no-tier` group: it satisfies the check while
+#      granting nothing.
+#
+# Usage:  ./add-solo-user.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REALM=maas
+USERNAME=solo-user
+PASSWORD=${SOLO_PASSWORD:-solo-user}
+GROUP=no-tier
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+# --- locate Keycloak and its bootstrap admin -------------------------------
+KC_NS=$(oc get keycloakrealmimport -A -o jsonpath="{range .items[?(@.spec.realm.realm=='${REALM}')]}{.metadata.namespace}{end}" 2>/dev/null)
+[ -z "$KC_NS" ] && KC_NS=$(oc get keycloak -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null)
+[ -z "$KC_NS" ] && { echo "no Keycloak found"; exit 1; }
+KC_HOST=$(oc get keycloak -n "$KC_NS" -o jsonpath='{.items[0].spec.hostname.hostname}' 2>/dev/null)
+[ -z "$KC_HOST" ] && KC_HOST=$(oc get route -n "$KC_NS" -o jsonpath='{.items[0].spec.host}')
+KC="https://${KC_HOST}"
+echo "==> Keycloak ${KC_NS} at ${KC}"
+
+ADMIN_USER=$(oc get secret keycloak-initial-admin -n "$KC_NS" -o jsonpath='{.data.username}' 2>/dev/null | base64 -d)
+ADMIN_PASS=$(oc get secret keycloak-initial-admin -n "$KC_NS" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d)
+[ -z "$ADMIN_PASS" ] && { echo "could not read the keycloak-initial-admin secret in ${KC_NS}"; exit 1; }
+
+AT=$(curl -sSk -X POST "${KC}/realms/master/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=admin-cli \
+  -d "username=${ADMIN_USER}" -d "password=${ADMIN_PASS}" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))')
+[ -n "$AT" ] || { echo "could not obtain a Keycloak admin token"; exit 1; }
+
+api() { curl -sSk -H "Authorization: Bearer ${AT}" -H 'Content-Type: application/json' "$@"; }
+
+# --- group with no tier -----------------------------------------------------
+echo "==> Group '${GROUP}' (referenced by no subscription)"
+api -o /dev/null -X POST "${KC}/admin/realms/${REALM}/groups" -d "{\"name\":\"${GROUP}\"}" >/dev/null 2>&1
+GROUP_ID=$(api "${KC}/admin/realms/${REALM}/groups?search=${GROUP}" \
+  | python3 -c "import sys,json; g=[x for x in json.load(sys.stdin) if x['name']=='${GROUP}']; print(g[0]['id'] if g else '')")
+[ -n "$GROUP_ID" ] || { echo "   could not create or find the group"; exit 1; }
+echo "   id ${GROUP_ID:0:8}…"
+
+# --- the user ---------------------------------------------------------------
+# An email is required or Keycloak answers the direct grant with
+# "Account is not fully set up".
+echo "==> User '${USERNAME}'"
+api -o /dev/null -X POST "${KC}/admin/realms/${REALM}/users" -d "{
+  \"username\":\"${USERNAME}\",\"enabled\":true,
+  \"email\":\"${USERNAME}@example.com\",\"emailVerified\":true,
+  \"firstName\":\"Solo\",\"lastName\":\"User\",\"requiredActions\":[],
+  \"credentials\":[{\"type\":\"password\",\"value\":\"${PASSWORD}\",\"temporary\":false}]
+}" >/dev/null 2>&1
+
+USER_ID=$(api "${KC}/admin/realms/${REALM}/users?username=${USERNAME}&exact=true" \
+  | python3 -c 'import sys,json; u=json.load(sys.stdin); print(u[0]["id"] if u else "")')
+[ -n "$USER_ID" ] || { echo "   could not create or find the user"; exit 1; }
+
+# Re-assert on a re-run, in case the user already existed without these.
+api -o /dev/null -X PUT "${KC}/admin/realms/${REALM}/users/${USER_ID}" -d "{
+  \"email\":\"${USERNAME}@example.com\",\"emailVerified\":true,\"requiredActions\":[]}" >/dev/null 2>&1
+api -o /dev/null -X PUT "${KC}/admin/realms/${REALM}/users/${USER_ID}/reset-password" \
+  -d "{\"type\":\"password\",\"value\":\"${PASSWORD}\",\"temporary\":false}" >/dev/null 2>&1
+api -o /dev/null -X PUT "${KC}/admin/realms/${REALM}/users/${USER_ID}/groups/${GROUP_ID}" >/dev/null 2>&1
+
+MEMBERSHIP=$(api "${KC}/admin/realms/${REALM}/users/${USER_ID}/groups" \
+  | python3 -c 'import sys,json; print([g["name"] for g in json.load(sys.stdin)])')
+echo "   id ${USER_ID:0:8}…  groups ${MEMBERSHIP}"
+
+# --- MaaS objects -----------------------------------------------------------
+echo "==> User-scoped MaaSAuthPolicy and MaaSSubscription"
+oc apply -f "${DIR}/user-scoped-access.yaml" | sed 's/^/   /'
+
+# --- verify ------------------------------------------------------------------
+echo "==> Verifying"
+ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc.issuerUrl}' 2>/dev/null)
+MAAS=https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+sleep 10
+T=$(curl -sSk -X POST "${ISSUER}/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=maas-oidc \
+  -d "username=${USERNAME}" -d "password=${PASSWORD}" -d scope=openid \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))')
+if [ -z "$T" ]; then echo "   token request failed"; exit 1; fi
+echo "$T" | python3 -c 'import sys,json,base64
+p=sys.stdin.read().strip().split(".")[1]; p+="="*(-len(p)%4)
+c=json.loads(base64.urlsafe_b64decode(p))
+print("   claims: user=%s groups=%s" % (c.get("preferred_username"), c.get("groups","(absent)")))'
+
+SUB=$(curl -sSk -m 30 -H "Authorization: Bearer ${T}" -H 'Content-Type: application/json' -X POST \
+  -d '{"name":"solo-verify","description":"d","expiresIn":"10m"}' "${MAAS}/maas-api/v1/api-keys" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("subscription","UNRESOLVED"))' 2>/dev/null)
+echo "   resolved subscription: ${SUB}"
+[ "$SUB" = "solo-user-tier" ] \
+  && echo "   OK - access and rate limit come entirely from user-scoped objects." \
+  || echo "   Unexpected. If this is UNRESOLVED, check: oc logs -n redhat-ai-gateway-infra deployment/maas-api | grep -i 'group header'"

--- a/demo/oidc-authentication/cleanup-demo.sh
+++ b/demo/oidc-authentication/cleanup-demo.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Remove the external OIDC demo configuration.
+#
+# Deletes only the `maas` realm and the MaaS OIDC config. Any other realm on the
+# same Keycloak - including one backing cluster login - is left alone, and the
+# Keycloak instance itself is never deleted (this demo does not create it).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAAS_NS=models-as-a-service
+OIDC_MANIFESTS="${DIR}/../../manifests/09-external-oidc/maas-oidc"
+KC_NS="${1:-}"
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+echo "==> Removing OIDC auth policies and subscriptions"
+oc delete -k "$OIDC_MANIFESTS" --ignore-not-found 2>&1 | sed 's/^/  /'
+oc delete -f "${DIR}/user-scoped-access.yaml" --ignore-not-found 2>&1 | sed 's/^/  /' 
+
+echo "==> Clearing the OIDC block from MaaS"
+if oc get crd aitenants.maas.opendatahub.io >/dev/null 2>&1; then
+  oc patch aitenants.maas.opendatahub.io "$MAAS_NS" -n ai-tenants --type json \
+    -p '[{"op":"remove","path":"/spec/oidc"}]' 2>/dev/null | sed 's/^/  /' \
+    || echo "  no oidc block present"
+else
+  oc patch tenants.maas.opendatahub.io default-tenant -n "$MAAS_NS" --type json \
+    -p '[{"op":"remove","path":"/spec/externalOIDC"}]' 2>/dev/null | sed 's/^/  /' \
+    || echo "  no externalOIDC block present"
+fi
+
+echo "==> Removing the 'maas' realm"
+if [ -z "$KC_NS" ]; then
+  KC_NS=$(oc get keycloakrealmimport -A -o jsonpath='{range .items[?(@.metadata.name=="maas")]}{.metadata.namespace}{end}' 2>/dev/null)
+fi
+if [ -n "$KC_NS" ]; then
+  oc delete keycloakrealmimport maas -n "$KC_NS" --ignore-not-found 2>&1 | sed 's/^/  /'
+  echo "  realms still on ${KC_NS}: $(oc get keycloakrealmimport -n "$KC_NS" -o jsonpath='{range .items[*]}{.spec.realm.realm} {end}' 2>/dev/null)"
+else
+  echo "  no 'maas' realm import found"
+fi
+
+echo
+echo "NOTE: deleting the KeycloakRealmImport removes the CR, but the realm may"
+echo "persist in the Keycloak database. To remove it fully, delete the realm in"
+echo "the Keycloak admin console."

--- a/demo/oidc-authentication/realm-import.yaml
+++ b/demo/oidc-authentication/realm-import.yaml
@@ -1,0 +1,125 @@
+# MaaS OIDC realm, imported into an EXISTING Keycloak instance.
+#
+# Copied from manifests/09-external-oidc/keycloak/instance/keycloakrealmimport.yaml
+# with metadata.namespace templated, so it can target whichever Keycloak you
+# already run. spec.keycloakCRName selects the Keycloak CR *within that namespace*.
+#
+# Creates realm `maas` with:
+#   groups  : data-scientists, ml-engineers
+#   users   : maas-user (both groups), restricted-user (data-scientists only)
+#   client  : maas-oidc (public, direct access grant, scopes: openid + groups)
+#
+# The `groups` client scope is what puts group membership in the token - that is
+# what MaaSAuthPolicy matches on.
+#
+# setup-oidc-demo.sh substitutes REALM_NAMESPACE; to apply by hand:
+#   sed 's/REALM_NAMESPACE/keycloak/' realm-import.yaml | oc apply -f -
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: maas
+  namespace: REALM_NAMESPACE
+spec:
+  keycloakCRName: keycloak
+  realm:
+    realm: maas
+    id: maas
+    enabled: true
+    sslRequired: none
+    registrationAllowed: false
+    loginWithEmailAllowed: true
+    duplicateEmailsAllowed: false
+    resetPasswordAllowed: false
+    editUsernameAllowed: false
+    bruteForceProtected: true
+    accessTokenLifespan: 1800
+    ssoSessionMaxLifespan: 1800
+    groups:
+    - name: data-scientists
+      subGroups: []
+    - name: ml-engineers
+      subGroups: []
+    clients:
+    - clientId: maas-oidc
+      name: MaaS OIDC Client
+      enabled: true
+      publicClient: true
+      directAccessGrantsEnabled: true
+      standardFlowEnabled: true
+      implicitFlowEnabled: false
+      redirectUris:
+      - http://localhost:*
+      - http://127.0.0.1:*
+      - https://localhost:*
+      webOrigins:
+      - '*'
+      protocol: openid-connect
+      attributes:
+        pkce.code.challenge.method: S256
+        client.secret.creation.time: '0'
+      defaultClientScopes:
+      - openid
+      - groups
+      protocolMappers:
+      - name: preferred_username
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-attribute-mapper
+        consentRequired: false
+        config:
+          user.attribute: username
+          claim.name: preferred_username
+          jsonType.label: String
+          id.token.claim: 'true'
+          access.token.claim: 'true'
+          introspection.token.claim: 'true'
+          userinfo.token.claim: 'true'
+      - name: sub
+        protocol: openid-connect
+        protocolMapper: oidc-sub-mapper
+        consentRequired: false
+        config:
+          introspection.token.claim: 'true'
+          access.token.claim: 'true'
+    clientScopes:
+    - name: groups
+      protocol: openid-connect
+      attributes:
+        include.in.token.scope: 'true'
+      protocolMappers:
+      - name: groups
+        protocol: openid-connect
+        protocolMapper: oidc-group-membership-mapper
+        consentRequired: false
+        config:
+          full.path: 'false'
+          introspection.token.claim: 'true'
+          userinfo.token.claim: 'true'
+          id.token.claim: 'true'
+          access.token.claim: 'true'
+          claim.name: groups
+    users:
+    - username: maas-user
+      email: maas-user@example.com
+      firstName: MaaS
+      lastName: User
+      enabled: true
+      emailVerified: true
+      credentials:
+      - type: password
+        value: maas-user
+        temporary: false
+      groups:
+      - data-scientists
+      - ml-engineers
+    - username: restricted-user
+      email: restricted@example.com
+      firstName: Restricted
+      lastName: User
+      enabled: true
+      emailVerified: true
+      credentials:
+      - type: password
+        value: restricted-user
+        temporary: false
+      groups:
+      - data-scientists

--- a/demo/oidc-authentication/run-demo.sh
+++ b/demo/oidc-authentication/run-demo.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# MaaS external OIDC demo.
+#
+# Shows that a user who exists ONLY in Keycloak - with no OpenShift account and
+# no oc login - can authenticate to MaaS, and that the `groups` claim in their
+# token decides which MaaSSubscription applies.
+#
+#   maas-user        groups: data-scientists, ml-engineers  -> oidc-ml-engineers   (priority 20)
+#   restricted-user  groups: data-scientists                -> oidc-data-scientists (priority 10)
+#   solo-user        groups: no-tier (no subscription)      -> solo-user-tier       (priority 60,
+#                    matched by owner.users, not by group - run ./add-solo-user.sh first)
+#
+# Usage: ./run-demo.sh [requests_per_user]      (default 5)
+set -uo pipefail
+
+N=${1:-5}
+MODEL_RESOURCE=facebook-opt-125m-simulated   # KServe resource name -> URL path
+MODEL_SERVED=facebook/opt-125m               # served name -> JSON body
+declare -a USERS=("maas-user" "restricted-user" "solo-user")
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+H="https://maas.${CLUSTER_DOMAIN}"
+ENDPOINT="${H}/llm/${MODEL_RESOURCE}/v1/chat/completions"
+
+# Read the issuer straight from what MaaS is configured with, so the demo can
+# never drift from the cluster's actual OIDC config.
+if oc get crd aitenants.maas.opendatahub.io >/dev/null 2>&1; then
+  ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc.issuerUrl}')
+  CLIENT=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc.clientId}')
+else
+  ISSUER=$(oc get tenants.maas.opendatahub.io default-tenant -n models-as-a-service -o jsonpath='{.spec.externalOIDC.issuerUrl}')
+  CLIENT=$(oc get tenants.maas.opendatahub.io default-tenant -n models-as-a-service -o jsonpath='{.spec.externalOIDC.clientId}')
+fi
+[ -n "$ISSUER" ] || { echo "MaaS has no OIDC issuer configured - run ./setup-oidc-demo.sh first"; exit 1; }
+
+echo "MaaS:   $H"
+echo "Issuer: $ISSUER"
+echo "Client: $CLIENT"
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+for U in "${USERS[@]}"; do
+  printf '\n=== %s (exists only in Keycloak - no OpenShift account) ===\n' "$U"
+
+  # Direct access grant. Password equals the username in the demo realm.
+  TOKEN=$(curl -sSk -X POST "${ISSUER}/protocol/openid-connect/token" \
+    -d "grant_type=password" -d "client_id=${CLIENT}" \
+    -d "username=${U}" -d "password=${U}" -d "scope=openid" \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
+  [ -z "$TOKEN" ] && { echo "  token request FAILED"; continue; }
+
+  # Show the groups claim - this is what MaaS matches on.
+  python3 - "$TOKEN" <<'PY'
+import sys, json, base64
+p = sys.argv[1].split('.')[1]
+p += '=' * (-len(p) % 4)
+c = json.loads(base64.urlsafe_b64decode(p))
+print("  token claims: preferred_username=%s groups=%s" % (c.get("preferred_username"), c.get("groups")))
+PY
+
+  RESP=$(curl -sSk --max-time 30 -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" -X POST \
+    -d "{\"name\":\"${U}-oidc\",\"description\":\"oidc demo\",\"expiresIn\":\"1h\"}" \
+    "${H}/maas-api/v1/api-keys")
+  SUB=$(echo "$RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("subscription","UNRESOLVED"))' 2>/dev/null || echo UNRESOLVED)
+  KEY=$(echo "$RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("key",""))' 2>/dev/null)
+  echo "  resolved subscription: ${SUB}"
+  [ -z "$KEY" ] && { echo "  no key issued: $(echo "$RESP" | head -c 160)"; continue; }
+
+  ok=0; lim=0; other=0
+  for _ in $(seq 1 "$N"); do
+    code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+      -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -X POST \
+      -d "{\"model\":\"${MODEL_SERVED}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4}" \
+      "$ENDPOINT")
+    # Absorb the known cold-start 500 (stale pooled DB connection in maas-api).
+    [ "$code" = "500" ] && code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+      -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -X POST \
+      -d "{\"model\":\"${MODEL_SERVED}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4}" \
+      "$ENDPOINT")
+    case "$code" in
+      200) ok=$((ok+1)) ;; 429) lim=$((lim+1)) ;; *) other=$((other+1)) ;;
+    esac
+  done
+  printf '  inference: %s requests -> %s ok / %s rate-limited / %s other\n' "$N" "$ok" "$lim" "$other"
+done
+
+printf '\nAll three authenticated with a Keycloak token, not an OpenShift one.\n'
+printf 'maas-user and restricted-user were matched by their groups claim;\n'
+printf 'solo-user by owner.users, since no subscription references its group.\n'

--- a/demo/oidc-authentication/sample-app/README.md
+++ b/demo/oidc-authentication/sample-app/README.md
@@ -1,14 +1,18 @@
 # Sample OIDC clients
 
-Two sample clients showing what an application does instead of hand-rolling `curl`:
-sign the user in, exchange the OIDC token for a MaaS API key, call the model.
+Two sample clients showing what an application does: sign the user in, exchange
+the identity provider token for a MaaS API key, call the model.
+
+```
+  login  ──►  OIDC token  ──►  exchange  ──►  MaaS API key  ──►  inference
+```
 
 | File | Use |
 | --- | --- |
 | `maas-ui.py` | **click-through UI** — run this to demo on screen |
 | `maas-login.py` | CLI — same flow, for terminal-driven demos and scripting |
 
-Standard library only — no `pip install`.
+Python standard library only — no `pip install`.
 
 ## The UI
 
@@ -19,13 +23,14 @@ cd demo/oidc-authentication/sample-app
 
 Four cards, each lighting up as you go:
 
-1. **Sign in with Keycloak** — one button, opens the Keycloak login page
-   (authorization code + PKCE). The password is never seen by the app.
-2. **The token** — the decoded claims, with the `groups` values highlighted. This is
-   the card to point at: entitlement comes from here.
-3. **Exchanged for a MaaS API key** — which subscription resolved, and when it expires.
-4. **Call the model** — a prompt box, plus a *Burst 15 requests* button that shows the
-   rate limit for that user's tier as a green/amber bar.
+1. **Sign in with Keycloak** — one button, opens the identity provider's own login
+   page (authorization code + PKCE). The password is never seen by the app.
+2. **The token** — the decoded claims, with the `groups` values highlighted. This
+   is the card to point at: entitlement comes from here.
+3. **Exchanged for a MaaS API key** — which subscription resolved, and when it
+   expires.
+4. **Call the model** — a prompt box, plus a *Burst 15 requests* button that shows
+   the rate limit for that user's tier as a green/amber bar.
 
 Use *Switch user* to sign in as the other user and run the same burst:
 
@@ -34,30 +39,17 @@ Use *Switch user* to sign in as the other user and run the same burst:
 | `maas-user` | `oidc-ml-engineers` (100000 tokens/min) | 15 ok / 0 limited |
 | `restricted-user` | `oidc-data-scientists` (20 tokens/min) | 7 ok / 8 limited |
 
-Same button, same cluster — different result, decided by the token's `groups` claim.
+Same button, same cluster, same model — different result, decided by the token's
+`groups` claim. `setup-oidc-demo.sh` sets the two tiers far apart so the contrast
+is visible on screen; pass `--keep-shipped-limits` to use the shipped values.
 
-> **Note:** `setup-oidc-demo.sh` lowers `oidc-data-scientists` to 20 tokens/min so this
-> contrast is visible. Both shipped tiers are 100000/min, which throttles nothing. Pass
-> `--keep-shipped-limits` to leave them alone.
-
-It must listen on localhost — the `maas-oidc` client registers `http://localhost:*`
-as its redirect URI. Model calls are proxied through the app rather than made from the
-browser, so a self-signed cluster certificate does not interrupt the demo.
+The app listens on localhost, matching the `http://localhost:*` redirect URI
+registered for the `maas-oidc` client. Model calls are proxied through the app
+rather than made from the browser.
 
 Options: `--port 8080`, `--no-browser`, `--model-served`, `--model-path`.
 
 ## The CLI
-
-### Why this exists
-
-The raw flow needs three `curl` invocations, a JWT decode and manual variable juggling.
-Applications do not work that way. This shows the same three steps as an app:
-
-```
-  login  ──► OIDC token  ──► exchange ──► MaaS API key ──► inference
-```
-
-### Usage
 
 ```bash
 cd demo/oidc-authentication/sample-app
@@ -73,8 +65,8 @@ MAAS_PASSWORD=maas-user ./maas-login.py login --from-cluster --password --userna
 ./maas-login.py chat "say hello in three words" -v
 ```
 
-`--from-cluster` reads the issuer, client ID and MaaS URL from the cluster with `oc`,
-purely as a demo convenience. A real client is *given* these as configuration:
+`--from-cluster` reads the issuer, client ID and MaaS URL from the cluster with
+`oc`, as a demo convenience. A real client is *given* these as configuration:
 
 ```bash
 export MAAS_ISSUER=https://sso.apps.<domain>/realms/maas
@@ -104,13 +96,14 @@ $ ./maas-login.py chat "say hello in three words"
 Testing, testing 1,2,3...
 ```
 
-The simulator runs in `--mode random`, so responses are canned text rather than a real
-completion. That is the model, not the client.
+The simulator runs in `--mode random`, so responses are canned text rather than a
+real completion. That is the model, not the client.
 
 ### The demo beat
 
-Run `login` as `maas-user`, then again as `restricted-user`. Same command, same cluster —
-different subscription, decided entirely by the `groups` claim in the token:
+Run `login` as `maas-user`, then again as `restricted-user`. Same command, same
+cluster — different subscription, decided entirely by the `groups` claim in the
+token:
 
 | User | groups claim | subscription |
 | --- | --- | --- |
@@ -119,15 +112,12 @@ different subscription, decided entirely by the `groups` claim in the token:
 
 ## Notes
 
-- **Decoding is not verifying.** `decode_claims()` reads the JWT payload for display
-  only — it checks no signature. MaaS validates the signature against the issuer's
-  JWKS. A forged token decodes fine and is then rejected.
-- **TLS verification is disabled** because demo clusters use self-signed certificates.
-  A production client would verify; the code marks the spot.
-- **Retries once on 5xx.** `maas-api` can return 500 on the first call after an idle
-  period (a stale pooled DB connection). The retry succeeds, so the client absorbs it.
-- Credentials are written to `~/.maas/credentials.json` with mode `0600`. It holds a
-  live API key — treat it as a secret.
-- Both login modes were tested against this realm. The browser flow uses PKCE `S256`
-  and a `http://localhost:<random-port>/callback` redirect, which the `maas-oidc`
-  client already permits.
+- **Decoding is not verifying.** `decode_claims()` reads the JWT payload for
+  display only. The signature is verified by MaaS at the gateway, against the
+  issuer's published keys — a client cannot grant itself entitlement by editing a
+  token. The [`../../jwks-cache/`](../../jwks-cache/) demo proves this.
+- Credentials are written to `~/.maas/credentials.json` with mode `0600`. It
+  holds a live API key, so treat it as a secret.
+- Both login modes work against this realm. The browser flow uses PKCE `S256`
+  with a `http://localhost:<random-port>/callback` redirect, which the
+  `maas-oidc` client already permits.

--- a/demo/oidc-authentication/sample-app/README.md
+++ b/demo/oidc-authentication/sample-app/README.md
@@ -1,0 +1,133 @@
+# Sample OIDC clients
+
+Two sample clients showing what an application does instead of hand-rolling `curl`:
+sign the user in, exchange the OIDC token for a MaaS API key, call the model.
+
+| File | Use |
+| --- | --- |
+| `maas-ui.py` | **click-through UI** — run this to demo on screen |
+| `maas-login.py` | CLI — same flow, for terminal-driven demos and scripting |
+
+Standard library only — no `pip install`.
+
+## The UI
+
+```bash
+cd demo/oidc-authentication/sample-app
+./maas-ui.py --from-cluster            # opens http://localhost:8080
+```
+
+Four cards, each lighting up as you go:
+
+1. **Sign in with Keycloak** — one button, opens the Keycloak login page
+   (authorization code + PKCE). The password is never seen by the app.
+2. **The token** — the decoded claims, with the `groups` values highlighted. This is
+   the card to point at: entitlement comes from here.
+3. **Exchanged for a MaaS API key** — which subscription resolved, and when it expires.
+4. **Call the model** — a prompt box, plus a *Burst 15 requests* button that shows the
+   rate limit for that user's tier as a green/amber bar.
+
+Use *Switch user* to sign in as the other user and run the same burst:
+
+| User | Subscription | Burst 15 |
+| --- | --- | --- |
+| `maas-user` | `oidc-ml-engineers` (100000 tokens/min) | 15 ok / 0 limited |
+| `restricted-user` | `oidc-data-scientists` (20 tokens/min) | 7 ok / 8 limited |
+
+Same button, same cluster — different result, decided by the token's `groups` claim.
+
+> **Note:** `setup-oidc-demo.sh` lowers `oidc-data-scientists` to 20 tokens/min so this
+> contrast is visible. Both shipped tiers are 100000/min, which throttles nothing. Pass
+> `--keep-shipped-limits` to leave them alone.
+
+It must listen on localhost — the `maas-oidc` client registers `http://localhost:*`
+as its redirect URI. Model calls are proxied through the app rather than made from the
+browser, so a self-signed cluster certificate does not interrupt the demo.
+
+Options: `--port 8080`, `--no-browser`, `--model-served`, `--model-path`.
+
+## The CLI
+
+### Why this exists
+
+The raw flow needs three `curl` invocations, a JWT decode and manual variable juggling.
+Applications do not work that way. This shows the same three steps as an app:
+
+```
+  login  ──► OIDC token  ──► exchange ──► MaaS API key ──► inference
+```
+
+### Usage
+
+```bash
+cd demo/oidc-authentication/sample-app
+
+# Browser login (authorization code + PKCE) - the realistic flow.
+# Opens a browser; the password is never typed into the terminal.
+./maas-login.py login --from-cluster
+
+# Or the direct access grant - no browser, good for scripted demos.
+MAAS_PASSWORD=maas-user ./maas-login.py login --from-cluster --password --username maas-user
+
+./maas-login.py whoami
+./maas-login.py chat "say hello in three words" -v
+```
+
+`--from-cluster` reads the issuer, client ID and MaaS URL from the cluster with `oc`,
+purely as a demo convenience. A real client is *given* these as configuration:
+
+```bash
+export MAAS_ISSUER=https://sso.apps.<domain>/realms/maas
+export MAAS_CLIENT_ID=maas-oidc
+export MAAS_URL=https://maas.apps.<domain>
+./maas-login.py login
+```
+
+### What it prints
+
+```
+$ ./maas-login.py login --from-cluster --password --username maas-user
+Signed in as maas-user
+  groups: ['data-scientists', 'ml-engineers']
+  issuer: https://sso.apps.<domain>/realms/maas
+
+MaaS API key issued -> subscription 'oidc-ml-engineers' (expires 2026-09-10T05:03:00Z)
+Saved to ~/.maas/credentials.json
+
+$ ./maas-login.py whoami
+user:         maas-user
+groups:       ['data-scientists', 'ml-engineers']
+subscription: oidc-ml-engineers
+api key:      sk-oai-XyOS20yHqBl...
+
+$ ./maas-login.py chat "say hello in three words"
+Testing, testing 1,2,3...
+```
+
+The simulator runs in `--mode random`, so responses are canned text rather than a real
+completion. That is the model, not the client.
+
+### The demo beat
+
+Run `login` as `maas-user`, then again as `restricted-user`. Same command, same cluster —
+different subscription, decided entirely by the `groups` claim in the token:
+
+| User | groups claim | subscription |
+| --- | --- | --- |
+| `maas-user` | `data-scientists`, `ml-engineers` | `oidc-ml-engineers` |
+| `restricted-user` | `data-scientists` | `oidc-data-scientists` |
+
+## Notes
+
+- **Decoding is not verifying.** `decode_claims()` reads the JWT payload for display
+  only — it checks no signature. MaaS validates the signature against the issuer's
+  JWKS. A forged token decodes fine and is then rejected.
+- **TLS verification is disabled** because demo clusters use self-signed certificates.
+  A production client would verify; the code marks the spot.
+- **Retries once on 5xx.** `maas-api` can return 500 on the first call after an idle
+  period (a stale pooled DB connection). The retry succeeds, so the client absorbs it.
+- Credentials are written to `~/.maas/credentials.json` with mode `0600`. It holds a
+  live API key — treat it as a secret.
+- Both login modes were tested against this realm. The browser flow uses PKCE `S256`
+  and a `http://localhost:<random-port>/callback` redirect, which the `maas-oidc`
+  client already permits.

--- a/demo/oidc-authentication/sample-app/maas-login.py
+++ b/demo/oidc-authentication/sample-app/maas-login.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+maas-login - a minimal sample client for MaaS external OIDC.
+
+Shows what an application does instead of hand-rolling curl:
+
+    1. log the user in against the OIDC issuer
+    2. exchange the resulting OIDC token for a MaaS API key
+    3. call the model with that API key
+
+Two login modes:
+
+    browser   (default)  authorization code + PKCE - opens a browser, the user
+                         logs in to Keycloak, nothing is typed into the terminal.
+                         This is what a real client would do.
+    password  (--password) direct access grant - no browser, handy for scripted
+                         demos and CI. Often disabled by policy in production.
+
+Standard library only - no pip install.
+
+Examples:
+    ./maas-login.py login --from-cluster
+    ./maas-login.py login --from-cluster --password --username maas-user
+    ./maas-login.py whoami
+    ./maas-login.py chat "hello there"
+"""
+import argparse
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import ssl
+import subprocess
+import sys
+import threading
+import urllib.parse
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+CRED_FILE = Path.home() / ".maas" / "credentials.json"
+
+# Demo clusters use self-signed certs. A production client would verify.
+SSL_CTX = ssl.create_default_context()
+SSL_CTX.check_hostname = False
+SSL_CTX.verify_mode = ssl.CERT_NONE
+
+
+# ---------------------------------------------------------------- helpers ---
+def http_post(url, data, headers=None, token=None, retries=1):
+    """POST returning parsed JSON.
+
+    Retries once on 5xx: maas-api can return 500 on the first call after an idle
+    period (a stale pooled DB connection on the key-validation path). The retry
+    succeeds, so it is not worth surfacing to the user.
+    """
+    body = urllib.parse.urlencode(data).encode() if isinstance(data, dict) else data
+    hdrs = dict(headers or {})
+    if token:
+        hdrs["Authorization"] = f"Bearer {token}"
+
+    last = None
+    for attempt in range(retries + 1):
+        req = urllib.request.Request(url, data=body, headers=hdrs, method="POST")
+        try:
+            with urllib.request.urlopen(req, context=SSL_CTX) as r:
+                return json.loads(r.read() or b"{}")
+        except urllib.error.HTTPError as e:
+            last = (e.code, e.read().decode(errors="replace")[:400])
+            if e.code < 500 or attempt == retries:
+                break
+    sys.exit(f"HTTP {last[0]} from {url}\n{last[1]}")
+
+
+def http_get_json(url):
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, context=SSL_CTX) as r:
+        return json.loads(r.read())
+
+
+def decode_claims(jwt):
+    """Decode a JWT payload. NOTE: decoding is not verifying - no signature check
+    happens here. The server validates the signature; this is for display only."""
+    payload = jwt.split(".")[1]
+    payload += "=" * (-len(payload) % 4)          # restore base64url padding
+    return json.loads(base64.urlsafe_b64decode(payload))
+
+
+def from_cluster():
+    """Convenience for demos: read the OIDC config MaaS is actually using.
+    A real client would be handed these as configuration, not read the cluster."""
+    def oc(*args):
+        return subprocess.run(["oc", *args], capture_output=True, text=True).stdout.strip()
+
+    issuer = oc("get", "aitenants.maas.opendatahub.io", "models-as-a-service",
+                "-n", "ai-tenants", "-o", "jsonpath={.spec.oidc.issuerUrl}")
+    client = oc("get", "aitenants.maas.opendatahub.io", "models-as-a-service",
+                "-n", "ai-tenants", "-o", "jsonpath={.spec.oidc.clientId}")
+    domain = oc("get", "ingresses.config/cluster", "-o", "jsonpath={.spec.domain}")
+    if not issuer:
+        sys.exit("Could not read OIDC config from the cluster. Is MaaS configured for OIDC?")
+    return issuer, client, f"https://maas.{domain}"
+
+
+def save(creds):
+    CRED_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CRED_FILE.write_text(json.dumps(creds, indent=2))
+    CRED_FILE.chmod(0o600)
+
+
+def load():
+    if not CRED_FILE.exists():
+        sys.exit("Not logged in. Run: ./maas-login.py login --from-cluster")
+    return json.loads(CRED_FILE.read_text())
+
+
+# ------------------------------------------------------------ login flows ---
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    code = None
+
+    def do_GET(self):
+        qs = urllib.parse.urlparse(self.path).query
+        _CallbackHandler.code = urllib.parse.parse_qs(qs).get("code", [None])[0]
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        ok = _CallbackHandler.code is not None
+        self.wfile.write(
+            b"<h2>Signed in - you can close this tab.</h2>" if ok
+            else b"<h2>Login failed.</h2>")
+
+    def log_message(self, *a):
+        pass                                       # keep the demo output clean
+
+
+def login_browser(issuer, client_id):
+    """Authorization code flow with PKCE. The password is never seen by this app."""
+    cfg = http_get_json(f"{issuer}/.well-known/openid-configuration")
+
+    verifier = secrets.token_urlsafe(64)
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _CallbackHandler)
+    redirect_uri = f"http://localhost:{server.server_port}/callback"
+
+    params = urllib.parse.urlencode({
+        "client_id": client_id, "response_type": "code", "scope": "openid groups",
+        "redirect_uri": redirect_uri,
+        "code_challenge": challenge, "code_challenge_method": "S256",
+        "state": secrets.token_urlsafe(16),
+    })
+    url = f"{cfg['authorization_endpoint']}?{params}"
+
+    print(f"Opening a browser to sign in...\n  {url}\n")
+    threading.Thread(target=webbrowser.open, args=(url,), daemon=True).start()
+    server.handle_request()                        # blocks until the redirect lands
+    if not _CallbackHandler.code:
+        sys.exit("No authorization code received.")
+
+    tok = http_post(cfg["token_endpoint"], {
+        "grant_type": "authorization_code", "client_id": client_id,
+        "code": _CallbackHandler.code, "redirect_uri": redirect_uri,
+        "code_verifier": verifier,
+    })
+    return tok["access_token"]
+
+
+def login_password(issuer, client_id, username, password):
+    """Direct access grant. Simple, but the app handles the user's password."""
+    cfg = http_get_json(f"{issuer}/.well-known/openid-configuration")
+    tok = http_post(cfg["token_endpoint"], {
+        "grant_type": "password", "client_id": client_id,
+        "username": username, "password": password, "scope": "openid groups",
+    })
+    return tok["access_token"]
+
+
+# --------------------------------------------------------------- commands ---
+def cmd_login(a):
+    issuer, client_id, maas_url = (a.issuer, a.client_id, a.maas_url)
+    if a.from_cluster:
+        issuer, client_id, maas_url = from_cluster()
+    if not (issuer and client_id and maas_url):
+        sys.exit("Need --issuer, --client-id and --maas-url (or --from-cluster).")
+
+    if a.password:
+        username = a.username or input("Username: ")
+        import getpass
+        password = os.environ.get("MAAS_PASSWORD") or getpass.getpass("Password: ")
+        oidc_token = login_password(issuer, client_id, username, password)
+    else:
+        oidc_token = login_browser(issuer, client_id)
+
+    claims = decode_claims(oidc_token)
+    print(f"Signed in as {claims.get('preferred_username')}")
+    print(f"  groups: {claims.get('groups')}")
+    print(f"  issuer: {claims.get('iss')}")
+
+    # The exchange: an OIDC token in, a MaaS API key out.
+    resp = http_post(
+        f"{maas_url}/maas-api/v1/api-keys",
+        json.dumps({"name": a.key_name, "description": "issued by maas-login",
+                    "expiresIn": a.ttl}).encode(),
+        headers={"Content-Type": "application/json"},
+        token=oidc_token,
+    )
+    if "key" not in resp:
+        sys.exit(f"No API key issued: {json.dumps(resp)[:300]}")
+
+    save({"maas_url": maas_url, "api_key": resp["key"],
+          "subscription": resp.get("subscription"), "expires_at": resp.get("expiresAt"),
+          "username": claims.get("preferred_username"), "groups": claims.get("groups")})
+    print(f"\nMaaS API key issued -> subscription '{resp.get('subscription')}'"
+          f" (expires {resp.get('expiresAt')})")
+    print(f"Saved to {CRED_FILE}")
+
+
+def cmd_whoami(_):
+    c = load()
+    print(f"user:         {c.get('username')}")
+    print(f"groups:       {c.get('groups')}")
+    print(f"subscription: {c.get('subscription')}")
+    print(f"expires:      {c.get('expires_at')}")
+    print(f"api key:      {c['api_key'][:18]}...")
+
+
+def cmd_chat(a):
+    c = load()
+    body = json.dumps({
+        "model": a.model,
+        "messages": [{"role": "user", "content": a.prompt}],
+        "max_tokens": a.max_tokens,
+    }).encode()
+    resp = http_post(f"{c['maas_url']}/llm/{a.model_path}/v1/chat/completions", body,
+                     headers={"Content-Type": "application/json"}, token=c["api_key"])
+    print(resp["choices"][0]["message"]["content"])
+    if a.verbose:
+        print(f"\n[usage: {resp.get('usage')}]")
+
+
+def main():
+    p = argparse.ArgumentParser(description="Sample MaaS OIDC client.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    lg = sub.add_parser("login", help="sign in and exchange the OIDC token for a MaaS API key")
+    lg.add_argument("--from-cluster", action="store_true",
+                    help="read issuer/client/MaaS URL from the cluster via oc (demo convenience)")
+    lg.add_argument("--issuer", default=os.environ.get("MAAS_ISSUER"))
+    lg.add_argument("--client-id", default=os.environ.get("MAAS_CLIENT_ID", "maas-oidc"))
+    lg.add_argument("--maas-url", default=os.environ.get("MAAS_URL"))
+    lg.add_argument("--password", action="store_true",
+                    help="use the direct access grant instead of a browser login")
+    lg.add_argument("--username")
+    lg.add_argument("--key-name", default="maas-login")
+    lg.add_argument("--ttl", default="8h")
+    lg.set_defaults(func=cmd_login)
+
+    wi = sub.add_parser("whoami", help="show the stored identity and subscription")
+    wi.set_defaults(func=cmd_whoami)
+
+    ch = sub.add_parser("chat", help="send a prompt using the stored API key")
+    ch.add_argument("prompt")
+    ch.add_argument("--model", default="facebook/opt-125m", help="served model name")
+    ch.add_argument("--model-path", default="facebook-opt-125m-simulated",
+                    help="KServe resource name used in the URL path")
+    ch.add_argument("--max-tokens", type=int, default=32)
+    ch.add_argument("-v", "--verbose", action="store_true")
+    ch.set_defaults(func=cmd_chat)
+
+    a = p.parse_args()
+    a.func(a)
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/oidc-authentication/sample-app/maas-ui.py
+++ b/demo/oidc-authentication/sample-app/maas-ui.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+maas-ui - a click-through UI for the MaaS external OIDC demo.
+
+Runs a small local web app that walks the four steps on screen:
+
+    1. Sign in with Keycloak      (authorization code + PKCE, in a browser)
+    2. Inspect the token          (the groups claim that drives entitlement)
+    3. Exchange it for a MaaS key (which subscription resolved, and why)
+    4. Call the model             (single prompt, or a burst to trip the rate limit)
+
+Standard library only - no pip install.
+
+It must listen on localhost: the `maas-oidc` client registers
+`http://localhost:*` as its redirect URI. Model calls are proxied through this
+app rather than made from the browser, so a self-signed cluster certificate
+does not produce a browser warning mid-demo.
+
+Usage:
+    ./maas-ui.py --from-cluster          # reads issuer/client/URL via oc
+    ./maas-ui.py --from-cluster --port 8080
+    MAAS_ISSUER=... MAAS_CLIENT_ID=... MAAS_URL=... ./maas-ui.py
+"""
+import argparse
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import socketserver
+import ssl
+import subprocess
+import sys
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+
+SSL_CTX = ssl.create_default_context()
+SSL_CTX.check_hostname = False
+SSL_CTX.verify_mode = ssl.CERT_NONE
+
+CFG = {}          # issuer, client_id, maas_url, oidc discovery document
+SESSION = {}      # in-memory: one demo user at a time
+PKCE = {}
+
+
+# ---------------------------------------------------------------- helpers ---
+def http_json(url, data=None, headers=None, token=None, retries=1):
+    hdrs = dict(headers or {})
+    if token:
+        hdrs["Authorization"] = f"Bearer {token}"
+    body = urllib.parse.urlencode(data).encode() if isinstance(data, dict) else data
+    last = None
+    for attempt in range(retries + 1):
+        req = urllib.request.Request(url, data=body, headers=hdrs,
+                                     method="POST" if body is not None else "GET")
+        try:
+            with urllib.request.urlopen(req, context=SSL_CTX) as r:
+                return r.status, json.loads(r.read() or b"{}")
+        except urllib.error.HTTPError as e:
+            raw = e.read().decode(errors="replace")
+            try:
+                parsed = json.loads(raw)
+            except Exception:
+                parsed = {"error": raw[:300]}
+            last = (e.code, parsed)
+            # maas-api returns 500 on the first call after idle (stale DB conn).
+            if e.code < 500 or attempt == retries:
+                break
+    return last
+
+
+def decode_claims(jwt):
+    """Display only - this performs NO signature verification."""
+    p = jwt.split(".")[1]
+    p += "=" * (-len(p) % 4)
+    return json.loads(base64.urlsafe_b64decode(p))
+
+
+def from_cluster():
+    def oc(*a):
+        return subprocess.run(["oc", *a], capture_output=True, text=True).stdout.strip()
+    issuer = oc("get", "aitenants.maas.opendatahub.io", "models-as-a-service",
+                "-n", "ai-tenants", "-o", "jsonpath={.spec.oidc.issuerUrl}")
+    client = oc("get", "aitenants.maas.opendatahub.io", "models-as-a-service",
+                "-n", "ai-tenants", "-o", "jsonpath={.spec.oidc.clientId}")
+    domain = oc("get", "ingresses.config/cluster", "-o", "jsonpath={.spec.domain}")
+    if not issuer:
+        sys.exit("Could not read OIDC config from the cluster. Is MaaS configured for OIDC?")
+    return issuer, client, f"https://maas.{domain}"
+
+
+# --------------------------------------------------------------------- UI ---
+PAGE = """<!doctype html>
+<meta charset="utf-8"><title>MaaS OIDC demo</title>
+<style>
+ :root{--bg:#f6f7f9;--card:#fff;--ink:#1a1d21;--mut:#6a7280;--line:#e2e5ea;
+       --ok:#2e7d32;--warn:#b26a00;--err:#c9342b;--accent:#c9342b}
+ *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);
+   font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+ .wrap{max-width:920px;margin:0 auto;padding:32px 20px 64px}
+ h1{font-size:22px;margin:0 0 4px} .sub{color:var(--mut);margin:0 0 24px;font-size:13px}
+ .card{background:var(--card);border:1px solid var(--line);border-radius:10px;
+   padding:18px 20px;margin:0 0 16px}
+ .card.done{border-left:3px solid var(--ok)} .card.idle{opacity:.55}
+ .step{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--mut);margin:0 0 8px}
+ h2{font-size:16px;margin:0 0 10px}
+ button{background:var(--accent);color:#fff;border:0;border-radius:6px;
+   padding:9px 16px;font-size:14px;cursor:pointer}
+ button:disabled{background:#c8ccd2;cursor:not-allowed}
+ button.ghost{background:#fff;color:var(--ink);border:1px solid var(--line)}
+ code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px}
+ pre{background:#0f1115;color:#e6e6e6;padding:12px 14px;border-radius:8px;overflow-x:auto;margin:8px 0 0}
+ .kv{display:grid;grid-template-columns:150px 1fr;gap:6px 14px;margin:10px 0 0}
+ .kv div:nth-child(odd){color:var(--mut);font-size:13px}
+ .pill{display:inline-block;background:#eef1f5;border-radius:999px;padding:2px 10px;
+   font-size:12px;margin:0 6px 4px 0}
+ .pill.hi{background:#e7f3e8;color:var(--ok)}
+ input[type=text]{width:100%;padding:9px 11px;border:1px solid var(--line);
+   border-radius:6px;font-size:14px}
+ .row{display:flex;gap:8px;align-items:center;margin-top:8px}
+ .muted{color:var(--mut);font-size:13px}
+ .bar{display:flex;height:10px;border-radius:5px;overflow:hidden;margin:10px 0 6px}
+ .bar i{display:block} .bar .ok{background:var(--ok)} .bar .lim{background:var(--warn)}
+</style>
+<div class="wrap">
+ <h1>Models-as-a-Service &mdash; external OIDC</h1>
+ <p class="sub" id="cfg">loading configuration&hellip;</p>
+
+ <div class="card" id="c1">
+  <p class="step">Step 1</p><h2>Sign in with Keycloak</h2>
+  <p class="muted">These users exist only in Keycloak &mdash; they have no OpenShift account.
+     Sign-in uses the authorization code flow with PKCE, so the password is never seen by this app.</p>
+  <div class="row"><button onclick="location='/login'">Sign in with Keycloak</button>
+   <span class="muted" id="hint">maas-user / maas-user &nbsp;&middot;&nbsp; restricted-user / restricted-user</span></div>
+ </div>
+
+ <div class="card idle" id="c2">
+  <p class="step">Step 2</p><h2>The token</h2>
+  <div id="tok"><p class="muted">Sign in to see the token claims.</p></div>
+ </div>
+
+ <div class="card idle" id="c3">
+  <p class="step">Step 3</p><h2>Exchanged for a MaaS API key</h2>
+  <div id="key"><p class="muted">The <code>groups</code> claim decides which subscription applies.</p></div>
+ </div>
+
+ <div class="card idle" id="c4">
+  <p class="step">Step 4</p><h2>Call the model</h2>
+  <div class="row"><input type="text" id="p" value="say hello in three words"
+        onkeydown="if(event.key==='Enter')send()"><button id="sendb" onclick="send()">Send</button></div>
+  <div class="row"><button class="ghost" id="burstb" onclick="burst()">Burst 15 requests</button>
+   <span class="muted">shows the rate limit for this subscription</span></div>
+  <div id="out"></div>
+ </div>
+</div>
+<script>
+const $=id=>document.getElementById(id);
+async function refresh(){
+  const c=await (await fetch('/api/config')).json();
+  $('cfg').innerHTML=`issuer <code>${c.issuer}</code> &nbsp;&middot;&nbsp; client <code>${c.client_id}</code>`;
+  const s=await (await fetch('/api/session')).json();
+  if(!s.signed_in) return;
+  $('c1').className='card done';
+  $('c1').querySelector('.row').innerHTML=
+    `<span class="muted">Signed in as <b>${s.username}</b></span>
+     <button class="ghost" onclick="location='/logout'">Switch user</button>`;
+  $('c2').className='card done';
+  $('tok').innerHTML=`<div class="kv"><div>preferred_username</div><div><b>${s.username}</b></div>
+    <div>groups</div><div>${s.groups.map(g=>`<span class="pill hi">${g}</span>`).join('')}</div>
+    <div>issuer</div><div><code>${s.issuer}</code></div>
+    <div>expires</div><div>${s.token_exp}</div></div>
+    <p class="muted" style="margin-top:10px">Decoded locally for display &mdash; no signature check happens here.
+       MaaS verifies the signature against the issuer's public keys.</p>`;
+  $('c3').className='card done';
+  $('key').innerHTML=`<div class="kv"><div>subscription</div><div><b>${s.subscription}</b></div>
+    <div>api key</div><div><code>${s.api_key_masked}</code></div>
+    <div>expires</div><div>${s.key_expires}</div></div>`;
+  $('c4').className='card done';
+}
+async function send(){
+  $('sendb').disabled=true; $('out').innerHTML='<p class="muted">calling…</p>';
+  const r=await (await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({prompt:$('p').value})})).json();
+  $('sendb').disabled=false;
+  $('out').innerHTML = r.ok
+    ? `<pre>${r.content}</pre><p class="muted">usage: ${JSON.stringify(r.usage)}</p>`
+    : `<pre>HTTP ${r.status}\n${JSON.stringify(r.body,null,1)}</pre>`;
+}
+async function burst(){
+  $('burstb').disabled=true; $('out').innerHTML='<p class="muted">sending 15 requests…</p>';
+  const r=await (await fetch('/api/burst',{method:'POST'})).json();
+  $('burstb').disabled=false;
+  const t=r.ok+r.limited+r.other||1;
+  $('out').innerHTML=`<div class="bar">
+      <i class="ok" style="width:${r.ok/t*100}%"></i><i class="lim" style="width:${r.limited/t*100}%"></i></div>
+    <p class="muted"><b>${r.ok}</b> succeeded &nbsp;·&nbsp; <b>${r.limited}</b> rate-limited (HTTP 429)
+       &nbsp;·&nbsp; ${r.other} other &nbsp;·&nbsp; ${r.tokens} tokens consumed</p>`;
+}
+refresh();
+</script>
+"""
+
+
+# ----------------------------------------------------------------- server ---
+class Handler(http.server.BaseHTTPRequestHandler):
+    def _send(self, code, body, ctype="application/json"):
+        raw = body if isinstance(body, bytes) else body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *a):
+        pass
+
+    # ---- GET
+    def do_GET(self):
+        path = urllib.parse.urlparse(self.path).path
+        qs = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+
+        if path == "/":
+            return self._send(200, PAGE, "text/html; charset=utf-8")
+
+        if path == "/api/config":
+            return self._send(200, json.dumps(
+                {"issuer": CFG["issuer"], "client_id": CFG["client_id"], "maas_url": CFG["maas_url"]}))
+
+        if path == "/api/session":
+            if not SESSION:
+                return self._send(200, json.dumps({"signed_in": False}))
+            return self._send(200, json.dumps({"signed_in": True, **SESSION["public"]}))
+
+        if path == "/logout":
+            SESSION.clear()
+            self.send_response(302); self.send_header("Location", "/"); self.end_headers()
+            return
+
+        if path == "/login":
+            verifier = secrets.token_urlsafe(64)
+            PKCE["v"] = verifier
+            challenge = base64.urlsafe_b64encode(
+                hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+            params = urllib.parse.urlencode({
+                "client_id": CFG["client_id"], "response_type": "code",
+                "scope": "openid groups", "redirect_uri": CFG["redirect_uri"],
+                "code_challenge": challenge, "code_challenge_method": "S256",
+                "state": secrets.token_urlsafe(12), "prompt": "login",
+            })
+            self.send_response(302)
+            self.send_header("Location", f"{CFG['oidc']['authorization_endpoint']}?{params}")
+            self.end_headers()
+            return
+
+        if path == "/callback":
+            code = qs.get("code", [None])[0]
+            if not code:
+                return self._send(400, "no authorization code", "text/plain")
+            status, tok = http_json(CFG["oidc"]["token_endpoint"], {
+                "grant_type": "authorization_code", "client_id": CFG["client_id"],
+                "code": code, "redirect_uri": CFG["redirect_uri"], "code_verifier": PKCE.get("v", ""),
+            })
+            if "access_token" not in tok:
+                return self._send(400, f"token exchange failed: {tok}", "text/plain")
+
+            oidc_token = tok["access_token"]
+            claims = decode_claims(oidc_token)
+
+            # The exchange this demo is about: OIDC token in, MaaS API key out.
+            status, resp = http_json(
+                f"{CFG['maas_url']}/maas-api/v1/api-keys",
+                json.dumps({"name": "maas-ui", "description": "issued by maas-ui",
+                            "expiresIn": "8h"}).encode(),
+                headers={"Content-Type": "application/json"}, token=oidc_token)
+            if "key" not in resp:
+                return self._send(400, f"no API key issued: {resp}", "text/plain")
+
+            import datetime
+            SESSION["api_key"] = resp["key"]
+            SESSION["public"] = {
+                "username": claims.get("preferred_username"),
+                "groups": claims.get("groups", []),
+                "issuer": claims.get("iss"),
+                "token_exp": datetime.datetime.utcfromtimestamp(
+                    claims.get("exp", 0)).strftime("%H:%M:%SZ"),
+                "subscription": resp.get("subscription"),
+                "key_expires": resp.get("expiresAt"),
+                "api_key_masked": resp["key"][:18] + "…",
+            }
+            self.send_response(302); self.send_header("Location", "/"); self.end_headers()
+            return
+
+        self._send(404, "not found", "text/plain")
+
+    # ---- POST
+    def do_POST(self):
+        path = urllib.parse.urlparse(self.path).path
+        if not SESSION:
+            return self._send(401, json.dumps({"ok": False, "error": "not signed in"}))
+        length = int(self.headers.get("Content-Length") or 0)
+        payload = json.loads(self.rfile.read(length) or b"{}") if length else {}
+
+        if path == "/api/chat":
+            status, resp = self._infer(payload.get("prompt", "hello"), 32)
+            if status == 200:
+                return self._send(200, json.dumps({
+                    "ok": True, "content": resp["choices"][0]["message"]["content"],
+                    "usage": resp.get("usage")}))
+            return self._send(200, json.dumps({"ok": False, "status": status, "body": resp}))
+
+        if path == "/api/burst":
+            ok = lim = other = tokens = 0
+            for _ in range(15):
+                status, resp = self._infer("hi", 4)
+                if status == 200:
+                    ok += 1
+                    tokens += (resp.get("usage") or {}).get("total_tokens", 0)
+                elif status == 429:
+                    lim += 1
+                else:
+                    other += 1
+            return self._send(200, json.dumps(
+                {"ok": ok, "limited": lim, "other": other, "tokens": tokens}))
+
+        self._send(404, json.dumps({"error": "not found"}))
+
+    def _infer(self, prompt, max_tokens):
+        body = json.dumps({"model": CFG["model_served"],
+                           "messages": [{"role": "user", "content": prompt}],
+                           "max_tokens": max_tokens}).encode()
+        return http_json(f"{CFG['maas_url']}/llm/{CFG['model_path']}/v1/chat/completions",
+                         body, headers={"Content-Type": "application/json"},
+                         token=SESSION["api_key"])
+
+
+class ThreadingHTTP(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+
+def main():
+    p = argparse.ArgumentParser(description="Click-through UI for the MaaS OIDC demo.")
+    p.add_argument("--from-cluster", action="store_true",
+                   help="read issuer/client/MaaS URL from the cluster via oc")
+    p.add_argument("--issuer", default=os.environ.get("MAAS_ISSUER"))
+    p.add_argument("--client-id", default=os.environ.get("MAAS_CLIENT_ID", "maas-oidc"))
+    p.add_argument("--maas-url", default=os.environ.get("MAAS_URL"))
+    p.add_argument("--port", type=int, default=8080)
+    p.add_argument("--model-served", default="facebook/opt-125m")
+    p.add_argument("--model-path", default="facebook-opt-125m-simulated")
+    p.add_argument("--no-browser", action="store_true")
+    a = p.parse_args()
+
+    issuer, client_id, maas_url = a.issuer, a.client_id, a.maas_url
+    if a.from_cluster:
+        issuer, client_id, maas_url = from_cluster()
+    if not (issuer and client_id and maas_url):
+        sys.exit("Need --issuer, --client-id and --maas-url (or --from-cluster).")
+
+    CFG.update(issuer=issuer, client_id=client_id, maas_url=maas_url,
+               model_served=a.model_served, model_path=a.model_path,
+               redirect_uri=f"http://localhost:{a.port}/callback")
+    _, CFG["oidc"] = http_json(f"{issuer}/.well-known/openid-configuration")
+
+    url = f"http://localhost:{a.port}/"
+    print(f"MaaS OIDC demo UI\n  issuer: {issuer}\n  MaaS:   {maas_url}\n  open:   {url}\n"
+          f"(Ctrl-C to stop)")
+    if not a.no_browser:
+        threading.Timer(0.6, webbrowser.open, args=(url,)).start()
+    try:
+        ThreadingHTTP(("127.0.0.1", a.port), Handler).serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/oidc-authentication/setup-oidc-demo.sh
+++ b/demo/oidc-authentication/setup-oidc-demo.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Configure MaaS external OIDC authentication against an EXISTING Keycloak.
+#
+# MaaS needs only an OIDC issuer URL and a client ID. It does not care which
+# Keycloak provides them, so if the cluster already runs one (common on RHOAI
+# demo clusters, where Keycloak often backs cluster login) there is no need to
+# deploy a second instance and second database.
+#
+# This script:
+#   1. finds an existing Keycloak instance (or uses --keycloak-namespace)
+#   2. imports the `maas` realm into it - a NEW realm, isolated from any existing one
+#   3. derives the issuer URL from that instance's route
+#   4. patches the AITenant (RHOAI 3.5+) or Tenant (3.4) with the OIDC config
+#   5. applies the OIDC MaaSAuthPolicies and MaaSSubscription
+#
+# To deploy a standalone Keycloak instead, use the guide's own script:
+#   ../../manifests/09-external-oidc/setup-keycloak.sh
+#
+# Usage:
+#   ./setup-oidc-demo.sh
+#   ./setup-oidc-demo.sh --keycloak-namespace keycloak
+#   ./setup-oidc-demo.sh --keep-shipped-limits   # leave both tiers at 100000 tokens/min
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAAS_NS=models-as-a-service
+OIDC_MANIFESTS="${DIR}/../../manifests/09-external-oidc/maas-oidc"
+KC_NS=""
+KEEP_LIMITS=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --keycloak-namespace) KC_NS="$2"; shift 2 ;;
+    --keep-shipped-limits) KEEP_LIMITS=true; shift ;;
+    -h|--help) sed -n '2,/^set -euo/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "unknown option: $1"; exit 1 ;;
+  esac
+done
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+# --- 1. locate an existing Keycloak -----------------------------------------
+if [ -z "$KC_NS" ]; then
+  # `mapfile` is bash 4+; keep this portable to the bash 3.2 on macOS.
+  FOUND=$(oc get keycloak -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' 2>/dev/null | sed '/^$/d')
+  COUNT=$(printf '%s\n' "$FOUND" | sed '/^$/d' | wc -l | tr -d ' ')
+  [ "$COUNT" -eq 0 ] && {
+    echo "No Keycloak found. Deploy one first:"
+    echo "  ../../manifests/09-external-oidc/setup-keycloak.sh"
+    exit 1; }
+  [ "$COUNT" -gt 1 ] && {
+    echo "Multiple Keycloak instances found - pick one with --keycloak-namespace:"
+    printf '  %s\n' "$FOUND"; exit 1; }
+  KC_NS="${FOUND%%/*}"
+fi
+KC_NAME=$(oc get keycloak -n "$KC_NS" -o jsonpath='{.items[0].metadata.name}')
+echo "==> Using Keycloak ${KC_NS}/${KC_NAME}"
+
+[ "$(oc get keycloak "$KC_NAME" -n "$KC_NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ] \
+  || { echo "Keycloak is not Ready - aborting"; exit 1; }
+
+EXISTING=$(oc get keycloakrealmimport -n "$KC_NS" -o jsonpath='{range .items[*]}{.spec.realm.realm} {end}' 2>/dev/null)
+[ -n "$EXISTING" ] && echo "    existing realms on this instance (untouched): ${EXISTING}"
+
+# --- 2. import the maas realm -----------------------------------------------
+echo "==> Importing realm 'maas' (a new realm; existing realms are not modified)"
+sed "s/REALM_NAMESPACE/${KC_NS}/" "${DIR}/realm-import.yaml" | oc apply -f -
+
+echo "==> Waiting for the realm import to complete"
+for i in $(seq 1 60); do
+  DONE=$(oc get keycloakrealmimport maas -n "$KC_NS" -o jsonpath='{.status.conditions[?(@.type=="Done")].status}' 2>/dev/null || true)
+  [ "$DONE" = "True" ] && { echo "    realm imported"; break; }
+  sleep 5
+done
+[ "${DONE:-}" = "True" ] || { echo "    realm import did not finish; check:"; \
+  echo "      oc get keycloakrealmimport maas -n $KC_NS -o yaml"; exit 1; }
+
+# --- 3. derive the issuer ----------------------------------------------------
+KC_HOST=$(oc get keycloak "$KC_NAME" -n "$KC_NS" -o jsonpath='{.spec.hostname.hostname}' 2>/dev/null)
+[ -z "$KC_HOST" ] && KC_HOST=$(oc get route -n "$KC_NS" -o jsonpath='{.items[0].spec.host}')
+ISSUER="https://${KC_HOST}/realms/maas"
+echo "==> Issuer: ${ISSUER}"
+
+echo "==> Checking the discovery document is reachable"
+CODE=$(curl -sSk -o /dev/null -w '%{http_code}' "${ISSUER}/.well-known/openid-configuration" || echo 000)
+[ "$CODE" = "200" ] || { echo "    discovery returned HTTP ${CODE} - aborting"; exit 1; }
+echo "    HTTP 200"
+
+# --- 4. point MaaS at it -----------------------------------------------------
+if oc get crd aitenants.maas.opendatahub.io >/dev/null 2>&1; then
+  echo "==> RHOAI 3.5+: patching AITenant"
+  oc patch aitenants.maas.opendatahub.io "$MAAS_NS" -n ai-tenants --type merge \
+    -p "{\"spec\":{\"oidc\":{\"clientId\":\"maas-oidc\",\"issuerUrl\":\"${ISSUER}\",\"ttl\":300}}}"
+else
+  echo "==> RHOAI 3.4: patching Tenant"
+  oc patch tenants.maas.opendatahub.io default-tenant -n "$MAAS_NS" --type merge \
+    -p "{\"spec\":{\"externalOIDC\":{\"clientId\":\"maas-oidc\",\"issuerUrl\":\"${ISSUER}\"}}}"
+fi
+
+# --- 5. group-based access policies -----------------------------------------
+echo "==> Applying OIDC auth policies and subscription"
+oc apply -k "$OIDC_MANIFESTS"
+
+# --- 6. make the tiers visibly different -------------------------------------
+# Both shipped OIDC subscriptions carry the same 100000 tokens/min limit, so
+# nothing throttles and the two groups look identical. Lower the data-scientists
+# tier so the difference between the two demo users is actually observable.
+if [ "$KEEP_LIMITS" = false ]; then
+  echo "==> Lowering oidc-data-scientists to 20 tokens/min so throttling is demonstrable"
+  echo "    (skip with --keep-shipped-limits)"
+  oc patch maassubscription oidc-data-scientists -n "$MAAS_NS" --type=merge \
+    -p '{"spec":{"modelRefs":[{"name":"facebook-opt-125m-simulated","namespace":"llm","tokenRateLimits":[{"limit":20,"window":"1m"}]}]}}' \
+    >/dev/null
+  echo "    oidc-data-scientists  20 tokens/min   <- restricted-user"
+  echo "    oidc-ml-engineers     100000 tokens/min <- maas-user"
+fi
+
+echo
+echo "Done. Issuer: ${ISSUER}"
+echo "Realm users: maas-user (data-scientists + ml-engineers), restricted-user (data-scientists)"
+echo "Run ./run-demo.sh to exercise it."

--- a/demo/oidc-authentication/user-scoped-access.yaml
+++ b/demo/oidc-authentication/user-scoped-access.yaml
@@ -1,0 +1,55 @@
+# User-scoped access for an OIDC identity that belongs to NO group with a tier.
+#
+# Everything solo-user can do comes from these two objects. They are separate on
+# purpose - access and entitlement are different decisions:
+#
+#   MaaSAuthPolicy.subjects  -> MAY they call the model at all
+#   MaaSSubscription.owner   -> WHAT tier (rate limit) do they get
+#
+# Both take `users` as a plain []string of usernames, matched against the token's
+# preferred_username claim. `groups` entries are objects with a required `name`.
+#
+# IMPORTANT: this alone is not enough. maas-api rejects any request whose token
+# carries no `groups` claim at all ("Missing group header" -> HTTP 500
+# AUTH_FAILURE), and Keycloak omits the claim entirely for a user in zero groups.
+# add-solo-user.sh therefore puts the user in a group called `no-tier`, which no
+# subscription references - enough to satisfy the check, contributing no
+# entitlement of its own.
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: solo-user-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Solo user access"
+    openshift.io/description: "Grants one named OIDC user access to the simulator model"
+spec:
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+  subjects:
+    groups: []
+    users:
+      - solo-user
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: solo-user-tier
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Solo user tier"
+    openshift.io/description: "Per-user rate limit for an OIDC user with no group tier"
+spec:
+  owner:
+    groups: []
+    users:
+      - solo-user
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 30
+          window: 1m
+  priority: 60

--- a/demo/preflight.sh
+++ b/demo/preflight.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Pre-flight for all four demos. Read-only: creates no users, applies no YAML.
+#
+# Checks that every identity can authenticate AND resolves the subscription its
+# demo depends on - the two things that actually break between sessions.
+#
+# It also sends a warm-up request: maas-api returns 500 on the first call after
+# an idle period while it reopens its database connection, and you do not want
+# that on your first click.
+#
+# Usage:  ./preflight.sh
+set -uo pipefail
+
+PASS=0; FAIL=0
+ok(){   printf '  \033[32mPASS\033[0m  %s\n' "$*"; PASS=$((PASS+1)); }
+bad(){  printf '  \033[31mFAIL\033[0m  %s\n' "$*"; FAIL=$((FAIL+1)); }
+hr(){   printf '\n\033[1m%s\033[0m\n' "$*"; }
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+MAAS="https://maas.${DOMAIN}"
+API=$(oc whoami --show-server)
+ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants -o jsonpath='{.spec.oidc.issuerUrl}' 2>/dev/null)
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+OCP_PW=${DEMO_PASSWORD:-MaaSDemo2026!}
+
+echo "cluster: $API"
+echo "MaaS:    $MAAS"
+
+# ---------------------------------------------------------------- platform ---
+hr "Platform"
+[ "$(oc get maasmodelref facebook-opt-125m-simulated -n llm -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" = "True" ] \
+  && ok "model facebook-opt-125m-simulated is Ready" || bad "model is not Ready"
+[ "$(oc get pods -n llm --no-headers 2>/dev/null | grep -c '1/1')" -ge 1 ] \
+  && ok "model pod running" || bad "model pod not running"
+oc get deployment maas-api -n redhat-ai-gateway-infra >/dev/null 2>&1 \
+  && ok "maas-api deployed" || bad "maas-api missing"
+
+# Warm-up: absorb the cold-start 500 so the first demo click is clean.
+curl -sk -m 30 -o /dev/null -H "Authorization: Bearer $(oc whoami -t)" "$MAAS/maas-api/v1/models" 2>/dev/null
+H=$(curl -sk -m 30 -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $(oc whoami -t)" "$MAAS/maas-api/v1/models")
+[ "$H" = "200" ] && ok "MaaS API reachable (warm-up done)" \
+  || bad "MaaS API returned HTTP ${H} — if 503, restart the gateway pods (see below)"
+
+# Mint a key as $1 (bearer token) and report which subscription resolved.
+resolved() {
+  curl -sSk -m 30 -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -X POST \
+    -d '{"name":"preflight","description":"preflight","expiresIn":"10m"}' \
+    "$MAAS/maas-api/v1/api-keys" 2>/dev/null \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("subscription","UNRESOLVED"))' 2>/dev/null \
+    || echo UNRESOLVED
+}
+check() {   # check <label> <token> <expected-subscription>
+  local got; got=$(resolved "$2")
+  [ "$got" = "$3" ] && ok "$1 -> $got" || bad "$1 -> got '${got}', expected '$3'"
+}
+
+# ------------------------------------------------- 1. user-level rate limiting ---
+hr "1. user-level-rate-limiting  (OpenShift users)"
+for pair in "alice:demo-alice-gold" "bob:demo-bob-throttled" "carol:demo-team-standard"; do
+  U="${pair%%:*}"; WANT="${pair##*:}"
+  if KUBECONFIG="$TMP/$U" oc login -u "$U" -p "$OCP_PW" --server="$API" --insecure-skip-tls-verify=true >/dev/null 2>&1; then
+    check "$U" "$(KUBECONFIG="$TMP/$U" oc whoami -t)" "$WANT"
+  else
+    bad "$U cannot log in (password? htpasswd IdP removed?)"
+  fi
+done
+
+# ------------------------------------------------------ 2. oidc authentication ---
+hr "2. oidc-authentication  (Keycloak identities)"
+if [ -z "$ISSUER" ]; then
+  bad "MaaS has no OIDC issuer configured — run oidc-authentication/setup-oidc-demo.sh"
+else
+  ok "issuer configured: $ISSUER"
+  for pair in "maas-user:oidc-ml-engineers" "restricted-user:oidc-data-scientists" "solo-user:solo-user-tier"; do
+    U="${pair%%:*}"; WANT="${pair##*:}"
+    T=$(curl -sSk -m 20 -X POST "$ISSUER/protocol/openid-connect/token" \
+        -d grant_type=password -d client_id=maas-oidc \
+        -d "username=$U" -d "password=$U" -d scope=openid \
+        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
+    [ -n "$T" ] && check "$U" "$T" "$WANT" || bad "$U could not get a token from Keycloak"
+  done
+fi
+
+# -------------------------------------------------------------- 3. jwks cache ---
+hr "3. jwks-cache  (signature verification)"
+if [ -n "$ISSUER" ]; then
+  T=$(curl -sSk -m 20 -X POST "$ISSUER/protocol/openid-connect/token" -d grant_type=password \
+      -d client_id=maas-oidc -d username=maas-user -d password=maas-user -d scope=openid \
+      | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
+  JW=$(curl -sSk -m 20 "$ISSUER/.well-known/openid-configuration" \
+       | python3 -c 'import sys,json; print(json.load(sys.stdin)["jwks_uri"])' 2>/dev/null)
+  N=$(curl -sSk -m 20 "$JW" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)["keys"]))' 2>/dev/null)
+  [ "${N:-0}" -ge 1 ] && ok "JWKS reachable (${N} keys published)" || bad "could not read the JWKS"
+
+  FORGED=$(echo "$T" | python3 -c 'import sys,json,base64
+def d(p): p += "="*(-len(p)%4); return base64.urlsafe_b64decode(p)
+def e(b): return base64.urlsafe_b64encode(b).decode().rstrip("=")
+h,p,s = sys.stdin.read().strip().split(".")
+c = json.loads(d(p)); c["groups"] = ["platform-admins"]
+print("%s.%s.%s" % (h, e(json.dumps(c).encode()), s))' 2>/dev/null)
+  F=$(curl -sSk -m 30 -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $FORGED" \
+      -H 'Content-Type: application/json' -X POST \
+      -d '{"name":"pf","description":"d","expiresIn":"5m"}' "$MAAS/maas-api/v1/api-keys")
+  { [ "$F" = "401" ] || [ "$F" = "403" ]; } && ok "forged token rejected (HTTP $F)" \
+    || bad "forged token returned HTTP $F — expected 401/403"
+else
+  bad "skipped: no OIDC issuer configured"
+fi
+
+# --------------------------------------------------- 4. service account access ---
+hr "4. service-account-access  (in-cluster workloads)"
+for pair in "batch-scorer:sa-batch-scorer-tier" "report-writer:sa-report-writer-tier"; do
+  SA="${pair%%:*}"; WANT="${pair##*:}"
+  T=$(oc create token "$SA" -n maas-clients --duration=15m 2>/dev/null)
+  [ -n "$T" ] && check "$SA" "$T" "$WANT" || bad "$SA: could not mint a token"
+done
+if R=$(oc get route model-client -n maas-clients -o jsonpath='{.spec.host}' 2>/dev/null) && [ -n "$R" ]; then
+  A=$(curl -sk -m 30 -o /dev/null -w '%{http_code}' "https://${R}/healthz")
+  [ "$A" = "200" ] && ok "in-cluster app reachable: https://${R}" || bad "app returned HTTP ${A}"
+else
+  bad "model-client route missing — run service-account-access/setup-demo.sh"
+fi
+
+# ------------------------------------------------------------------- summary ---
+hr "Summary"
+printf '  %s passed, %s failed\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  cat <<'TXT'
+
+  Common fixes
+    every request 503        the Envoy WASM filter failed closed:
+                             oc delete pod -n openshift-ingress \
+                               -l gateway.networking.k8s.io/gateway-name=maas-default-gateway
+    OIDC tokens fail         Keycloak may be restarting: oc get pods -n keycloak
+    a subscription is wrong  check nothing else matches that identity:
+                             oc get maassubscription -n models-as-a-service \
+                               -o custom-columns=NAME:.metadata.name,GROUPS:.spec.owner.groups,USERS:.spec.owner.users
+TXT
+  exit 1
+fi
+echo "  Ready to demo."

--- a/demo/service-account-access/README.md
+++ b/demo/service-account-access/README.md
@@ -1,0 +1,172 @@
+# ServiceAccount access to a model
+
+An in-cluster workload calling a MaaS-governed model using its **own
+ServiceAccount token** — no human identity, no external identity provider, and no
+credential to distribute. Kubernetes projects the token into the pod; MaaS
+validates it via TokenReview.
+
+Requires MaaS deployed with the `simulator` model — from the repository root,
+`./scripts/setup-maas.sh --model simulator`.
+
+## How MaaS sees a ServiceAccount
+
+A ServiceAccount token is issued by the Kubernetes API, not an IdP:
+
+```
+token sub: system:serviceaccount:maas-clients:batch-scorer
+issued by: https://kubernetes.default.svc
+```
+
+It is validated by the `openshift-identities` method in the Authorino
+`AuthConfig` (Kubernetes TokenReview), rather than the OIDC/JWT path. MaaS then
+sees:
+
+| Field | Value |
+| --- | --- |
+| username | `system:serviceaccount:<namespace>:<name>` |
+| groups | `system:authenticated`, `system:serviceaccounts`, `system:serviceaccounts:<namespace>` |
+
+Both are usable in MaaS objects, which is what makes the design below work.
+
+## The design
+
+Access is granted **once for the namespace**; the rate limit is **per workload**:
+
+| Object | Effect |
+| --- | --- |
+| `MaaSAuthPolicy` on group `system:serviceaccounts:maas-clients` | every ServiceAccount in the namespace may call the model — no SA is named |
+| `MaaSSubscription` per SA, matching `owner.users` | each workload gets its own limit |
+
+| Workload | Subscription | Limit |
+| --- | --- | --- |
+| `batch-scorer` | `sa-batch-scorer-tier` | 120 tokens/min |
+| `report-writer` | `sa-report-writer-tier` | 15 tokens/min |
+
+## Run it
+
+```bash
+cd demo/service-account-access
+./setup-demo.sh
+./run-demo.sh
+```
+
+Verified output:
+
+```
+=== system:serviceaccount:maas-clients:batch-scorer ===
+  token sub: system:serviceaccount:maas-clients:batch-scorer
+  issued by: https://kubernetes.default.svc
+  resolved subscription: sa-batch-scorer-tier
+  inference with the SA token directly (no API key) -> HTTP 200
+  burst 18 -> 11 ok / 7 rate-limited / 0 other
+
+=== system:serviceaccount:maas-clients:report-writer ===
+  resolved subscription: sa-report-writer-tier
+  inference with the SA token directly (no API key) -> HTTP 200
+  burst 18 -> 4 ok / 14 rate-limited / 0 other
+```
+
+Tear down with `./cleanup-demo.sh`.
+
+## The app
+
+`setup-demo.sh` also deploys `model-client`, a small app in the `maas-clients`
+namespace that runs **as the `batch-scorer` ServiceAccount** and calls the model.
+
+```bash
+oc get route model-client -n maas-clients -o jsonpath='{.spec.host}'
+oc logs -f deployment/model-client -n maas-clients
+```
+
+The page shows the identity the pod is running as, an *Ask the model* box, and a
+*Burst 20 requests* button that trips the subscription's rate limit:
+
+```
+running as     system:serviceaccount:maas-clients:batch-scorer
+token source   /var/run/secrets/kubernetes.io/serviceaccount/token
+
+Ask            HTTP 200   usage: {'total_tokens': 37}
+Burst 20       11 ok / 9 rate-limited   (39 tokens)
+```
+
+The thing to point at is what the manifest and the code do **not** contain:
+
+```yaml
+spec:
+  serviceAccountName: batch-scorer     # the only line that sets its MaaS identity
+```
+
+```python
+def sa_token():                        # re-read each call - kubelet rotates it
+    with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as f:
+        return f.read().strip()
+
+headers = {"Authorization": f"Bearer {sa_token()}"}
+```
+
+No API key, no client secret, nothing in a Secret, nothing to rotate. Change
+`serviceAccountName` and the app lands in a different subscription with a
+different rate limit — entitlement is a deployment-time decision, not a code one.
+
+The code is delivered as a ConfigMap, so the demo needs no image build or
+registry push. `setup-demo.sh --no-app` skips it.
+
+> **Note:** the app skips TLS verification when calling MaaS, because the cluster
+> ingress certificate is not in the base image's trust store. A production
+> deployment would mount the CA bundle; the code marks the spot.
+
+## Two ways a workload can call the model
+
+Both work, and the choice matters for how you build the client:
+
+1. **Straight with the ServiceAccount token** — no API key at all. Usually what you
+   want in-cluster: the token is already mounted at
+   `/var/run/secrets/kubernetes.io/serviceaccount/token`, rotated by Kubernetes,
+   and there is nothing to store or revoke.
+2. **Exchange it for a MaaS API key** — useful when the caller is outside the
+   cluster, or when you want a credential with its own lifetime and revocation.
+
+```bash
+# in a pod, using the projected token
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+curl -sk -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -X POST -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"hi"}]}' \
+  https://maas.<cluster-domain>/llm/facebook-opt-125m-simulated/v1/chat/completions
+```
+
+## Why each SA has its own subscription
+
+The obvious design — one namespace-wide subscription plus higher-priority
+per-SA overrides — hits a bug. **If an identity matches more than one
+`MaaSSubscription`, the two call paths disagree:**
+
+| Path | With overlapping subscriptions |
+| --- | --- |
+| token → API key → inference | works; resolves the higher priority correctly |
+| ServiceAccount token used **directly** | **HTTP 403** |
+
+Reproduced deliberately while building this demo: with both a namespace tier
+(priority 20) and a per-SA tier (priority 70) matching `batch-scorer`, key
+issuance returned `sa-batch-scorer-tier` correctly every time, but a direct token
+call returned 403 consistently. Deleting the per-SA subscription — changing
+nothing else — restored 200.
+
+It is not the auth policies (removing the overlapping one did not help), not rate
+limiting (403 rather than 429, and reproduced after the window reset), and not
+specific to ServiceAccounts.
+
+Keeping every identity matched to exactly one subscription avoids it entirely,
+which is why the tiers here are per-SA rather than namespace-plus-override.
+
+> **Note:** the same overlap exists for human users in the `user-level-rate-limiting`
+> demo, where `alice` and `bob` match both a team tier and a per-user tier. Those
+> demos only use the API-key path, so the problem stays latent there.
+
+## Notes
+
+- The inference body needs the *served* model name `facebook/opt-125m`, not the
+  KServe resource name `facebook-opt-125m-simulated` (that is the URL path).
+- Deleting a ServiceAccount does **not** revoke API keys already issued to it —
+  those live in the MaaS database until they expire.
+- `oc create token` mints a short-lived token for testing. A real workload uses
+  the projected token in its pod, which Kubernetes rotates automatically.

--- a/demo/service-account-access/README.md
+++ b/demo/service-account-access/README.md
@@ -1,25 +1,26 @@
-# ServiceAccount access to a model
+# Application access with a ServiceAccount
 
-An in-cluster workload calling a MaaS-governed model using its **own
-ServiceAccount token** — no human identity, no external identity provider, and no
-credential to distribute. Kubernetes projects the token into the pod; MaaS
-validates it via TokenReview.
+An application calls a MaaS-governed model using its **own Kubernetes
+ServiceAccount token**. No human identity, no external identity provider, and no
+credential to distribute: Kubernetes projects the token into the pod and rotates
+it, and MaaS validates it through TokenReview.
+
+This is the pattern for anything that runs unattended — batch jobs, pipelines,
+scheduled reports, agents.
 
 Requires MaaS deployed with the `simulator` model — from the repository root,
 `./scripts/setup-maas.sh --model simulator`.
 
 ## How MaaS sees a ServiceAccount
 
-A ServiceAccount token is issued by the Kubernetes API, not an IdP:
+A ServiceAccount token is issued by the Kubernetes API:
 
 ```
 token sub: system:serviceaccount:maas-clients:batch-scorer
 issued by: https://kubernetes.default.svc
 ```
 
-It is validated by the `openshift-identities` method in the Authorino
-`AuthConfig` (Kubernetes TokenReview), rather than the OIDC/JWT path. MaaS then
-sees:
+MaaS validates it with Kubernetes TokenReview and sees:
 
 | Field | Value |
 | --- | --- |
@@ -30,7 +31,8 @@ Both are usable in MaaS objects, which is what makes the design below work.
 
 ## The design
 
-Access is granted **once for the namespace**; the rate limit is **per workload**:
+Access is granted **once for the namespace**; the consumption tier is set **per
+workload**:
 
 | Object | Effect |
 | --- | --- |
@@ -42,6 +44,9 @@ Access is granted **once for the namespace**; the rate limit is **per workload**
 | `batch-scorer` | `sa-batch-scorer-tier` | 120 tokens/min |
 | `report-writer` | `sa-report-writer-tier` | 15 tokens/min |
 
+Deploying a new application into the namespace needs no access change — grant
+access once to the team's namespace, then size each workload individually.
+
 ## Run it
 
 ```bash
@@ -50,7 +55,7 @@ cd demo/service-account-access
 ./run-demo.sh
 ```
 
-Verified output:
+Output:
 
 ```
 === system:serviceaccount:maas-clients:batch-scorer ===
@@ -66,11 +71,13 @@ Verified output:
   burst 18 -> 4 ok / 14 rate-limited / 0 other
 ```
 
+Two workloads, same namespace, same model, different limits.
+
 Tear down with `./cleanup-demo.sh`.
 
 ## The app
 
-`setup-demo.sh` also deploys `model-client`, a small app in the `maas-clients`
+`setup-demo.sh` also deploys `model-client`, an application in the `maas-clients`
 namespace that runs **as the `batch-scorer` ServiceAccount** and calls the model.
 
 ```bash
@@ -78,8 +85,8 @@ oc get route model-client -n maas-clients -o jsonpath='{.spec.host}'
 oc logs -f deployment/model-client -n maas-clients
 ```
 
-The page shows the identity the pod is running as, an *Ask the model* box, and a
-*Burst 20 requests* button that trips the subscription's rate limit:
+The page shows the identity the pod runs as, an *Ask the model* box, and a
+*Burst 20 requests* button that reaches the subscription's rate limit:
 
 ```
 running as     system:serviceaccount:maas-clients:batch-scorer
@@ -97,33 +104,30 @@ spec:
 ```
 
 ```python
-def sa_token():                        # re-read each call - kubelet rotates it
+def sa_token():                        # re-read each call - Kubernetes rotates it
     with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as f:
         return f.read().strip()
 
 headers = {"Authorization": f"Bearer {sa_token()}"}
 ```
 
-No API key, no client secret, nothing in a Secret, nothing to rotate. Change
-`serviceAccountName` and the app lands in a different subscription with a
-different rate limit — entitlement is a deployment-time decision, not a code one.
+No API key, no client secret, nothing in a Secret, nothing to rotate, nothing to
+leak in a build log. Change `serviceAccountName` and the application lands in a
+different subscription with a different limit — entitlement becomes a
+deployment-time decision rather than a code change.
 
-The code is delivered as a ConfigMap, so the demo needs no image build or
+The application is delivered as a ConfigMap, so the demo needs no image build or
 registry push. `setup-demo.sh --no-app` skips it.
-
-> **Note:** the app skips TLS verification when calling MaaS, because the cluster
-> ingress certificate is not in the base image's trust store. A production
-> deployment would mount the CA bundle; the code marks the spot.
 
 ## Two ways a workload can call the model
 
-Both work, and the choice matters for how you build the client:
+Both work, and the choice shapes how you build the client:
 
-1. **Straight with the ServiceAccount token** — no API key at all. Usually what you
-   want in-cluster: the token is already mounted at
-   `/var/run/secrets/kubernetes.io/serviceaccount/token`, rotated by Kubernetes,
-   and there is nothing to store or revoke.
-2. **Exchange it for a MaaS API key** — useful when the caller is outside the
+1. **Directly with the ServiceAccount token** — no API key at all. Usually what
+   you want in-cluster: the token is already mounted at
+   `/var/run/secrets/kubernetes.io/serviceaccount/token`, Kubernetes rotates it,
+   and there is nothing to store, distribute or revoke.
+2. **Exchanged for a MaaS API key** — useful when the caller sits outside the
    cluster, or when you want a credential with its own lifetime and revocation.
 
 ```bash
@@ -134,39 +138,11 @@ curl -sk -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   https://maas.<cluster-domain>/llm/facebook-opt-125m-simulated/v1/chat/completions
 ```
 
-## Why each SA has its own subscription
-
-The obvious design — one namespace-wide subscription plus higher-priority
-per-SA overrides — hits a bug. **If an identity matches more than one
-`MaaSSubscription`, the two call paths disagree:**
-
-| Path | With overlapping subscriptions |
-| --- | --- |
-| token → API key → inference | works; resolves the higher priority correctly |
-| ServiceAccount token used **directly** | **HTTP 403** |
-
-Reproduced deliberately while building this demo: with both a namespace tier
-(priority 20) and a per-SA tier (priority 70) matching `batch-scorer`, key
-issuance returned `sa-batch-scorer-tier` correctly every time, but a direct token
-call returned 403 consistently. Deleting the per-SA subscription — changing
-nothing else — restored 200.
-
-It is not the auth policies (removing the overlapping one did not help), not rate
-limiting (403 rather than 429, and reproduced after the window reset), and not
-specific to ServiceAccounts.
-
-Keeping every identity matched to exactly one subscription avoids it entirely,
-which is why the tiers here are per-SA rather than namespace-plus-override.
-
-> **Note:** the same overlap exists for human users in the `user-level-rate-limiting`
-> demo, where `alice` and `bob` match both a team tier and a per-user tier. Those
-> demos only use the API-key path, so the problem stays latent there.
-
 ## Notes
 
-- The inference body needs the *served* model name `facebook/opt-125m`, not the
-  KServe resource name `facebook-opt-125m-simulated` (that is the URL path).
-- Deleting a ServiceAccount does **not** revoke API keys already issued to it —
-  those live in the MaaS database until they expire.
-- `oc create token` mints a short-lived token for testing. A real workload uses
-  the projected token in its pod, which Kubernetes rotates automatically.
+- The URL path carries the KServe resource name
+  (`facebook-opt-125m-simulated`); the request body carries the served model
+  name (`facebook/opt-125m`).
+- `oc create token` mints a short-lived token, which is how `run-demo.sh` tests
+  each ServiceAccount from outside. A real workload uses the token projected
+  into its pod, which Kubernetes rotates automatically.

--- a/demo/service-account-access/app/app.py
+++ b/demo/service-account-access/app/app.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+model-client - a tiny in-cluster app that calls a MaaS-governed model using its
+own ServiceAccount token.
+
+The point of this app is what it does NOT contain: no API key, no client secret,
+no credential of any kind. It reads the token Kubernetes projects into the pod at
+
+    /var/run/secrets/kubernetes.io/serviceaccount/token
+
+and sends it as the bearer token. MaaS validates it with TokenReview, resolves
+the ServiceAccount's subscription, and applies that subscription's rate limit.
+
+The token is re-read on every call because kubelet rotates it in place.
+
+Environment:
+    MAAS_URL        base URL, e.g. https://maas.apps.<domain>
+    MODEL_PATH      KServe resource name, used in the URL path
+    MODEL_SERVED    served model name, used in the request body
+    PORT            listen port (default 8080)
+"""
+import json
+import os
+import ssl
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+NS_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+MAAS_URL = os.environ.get("MAAS_URL", "").rstrip("/")
+MODEL_PATH = os.environ.get("MODEL_PATH", "facebook-opt-125m-simulated")
+MODEL_SERVED = os.environ.get("MODEL_SERVED", "facebook/opt-125m")
+PORT = int(os.environ.get("PORT", "8080"))
+
+# The cluster's ingress certificate is not in this image's trust store. A real
+# deployment would mount the CA bundle; for a demo we skip verification.
+SSL_CTX = ssl.create_default_context()
+SSL_CTX.check_hostname = False
+SSL_CTX.verify_mode = ssl.CERT_NONE
+
+
+def sa_token():
+    """Re-read on every call - kubelet rotates this file in place."""
+    with open(TOKEN_PATH) as f:
+        return f.read().strip()
+
+
+def identity():
+    """Decode the projected token to show who this pod is. Display only."""
+    import base64
+    try:
+        p = sa_token().split(".")[1]
+        p += "=" * (-len(p) % 4)
+        return json.loads(base64.urlsafe_b64decode(p)).get("sub", "unknown")
+    except Exception:
+        return "unknown"
+
+
+def call_model(prompt, max_tokens=32, retries=1):
+    """Call the model as this pod's ServiceAccount.
+
+    Retries once on 5xx: maas-api returns 500 on the first request after an idle
+    period, while it reopens its database connection. Not worth surfacing.
+    """
+    body = json.dumps({
+        "model": MODEL_SERVED,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+    }).encode()
+
+    last = (0, {"error": "no attempt made"})
+    for attempt in range(retries + 1):
+        req = urllib.request.Request(
+            f"{MAAS_URL}/llm/{MODEL_PATH}/v1/chat/completions",
+            data=body, method="POST",
+            headers={"Content-Type": "application/json",
+                     # The whole trick: the projected ServiceAccount token,
+                     # re-read each call because kubelet rotates it.
+                     "Authorization": f"Bearer {sa_token()}"},
+        )
+        try:
+            with urllib.request.urlopen(req, context=SSL_CTX, timeout=30) as r:
+                return r.status, json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            raw = e.read().decode(errors="replace")
+            try:
+                parsed = json.loads(raw)
+            except Exception:
+                parsed = {"error": raw[:200]}
+            last = (e.code, parsed)
+            if e.code < 500 or attempt == retries:
+                return last
+        except Exception as e:
+            last = (0, {"error": str(e)})
+            if attempt == retries:
+                return last
+    return last
+
+
+PAGE = """<!doctype html>
+<meta charset="utf-8"><title>model-client</title>
+<style>
+ body{font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+      background:#f6f7f9;color:#1a1d21;margin:0}
+ .w{max-width:760px;margin:0 auto;padding:32px 20px}
+ h1{font-size:20px;margin:0 0 4px}
+ .sub{color:#6a7280;font-size:13px;margin:0 0 22px}
+ .card{background:#fff;border:1px solid #e2e5ea;border-radius:10px;padding:18px 20px;margin:0 0 16px}
+ .kv{display:grid;grid-template-columns:130px 1fr;gap:6px 14px;font-size:13px}
+ .kv div:nth-child(odd){color:#6a7280}
+ code{font-family:ui-monospace,Menlo,monospace;font-size:12.5px}
+ pre{background:#0f1115;color:#e6e6e6;padding:12px 14px;border-radius:8px;overflow-x:auto;margin:10px 0 0}
+ input{width:100%;padding:9px 11px;border:1px solid #e2e5ea;border-radius:6px;font-size:14px}
+ .row{display:flex;gap:8px;margin-top:10px}
+ button{background:#c9342b;color:#fff;border:0;border-radius:6px;padding:9px 16px;font-size:14px;cursor:pointer}
+ button.ghost{background:#fff;color:#1a1d21;border:1px solid #e2e5ea}
+ .bar{display:flex;height:10px;border-radius:5px;overflow:hidden;margin:12px 0 6px}
+ .bar i{display:block}.ok{background:#2e7d32}.lim{background:#b26a00}
+</style>
+<div class="w">
+  <h1>model-client</h1>
+  <p class="sub">An in-cluster app calling a MaaS model with its ServiceAccount token.
+     It holds no API key and no secret.</p>
+
+  <div class="card">
+    <div class="kv">
+      <div>running as</div><div><code id="id">…</code></div>
+      <div>token source</div><div><code>/var/run/secrets/kubernetes.io/serviceaccount/token</code></div>
+      <div>MaaS</div><div><code id="maas">…</code></div>
+      <div>model</div><div><code id="model">…</code></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <input id="p" value="say hello in three words" onkeydown="if(event.key==='Enter')ask()">
+    <div class="row">
+      <button onclick="ask()">Ask the model</button>
+      <button class="ghost" onclick="burst()">Burst 20 requests</button>
+    </div>
+    <div id="out"></div>
+  </div>
+</div>
+<script>
+const $=i=>document.getElementById(i);
+fetch('/api/whoami').then(r=>r.json()).then(d=>{
+  $('id').textContent=d.identity; $('maas').textContent=d.maas_url;
+  $('model').textContent=d.model_served+'  (path: '+d.model_path+')';});
+async function ask(){
+  $('out').innerHTML='<p style="color:#6a7280">calling…</p>';
+  const r=await (await fetch('/api/ask',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({prompt:$('p').value})})).json();
+  $('out').innerHTML = r.status===200
+    ? '<pre>'+r.content+'</pre><p style="color:#6a7280;font-size:13px">usage: '+JSON.stringify(r.usage)+'</p>'
+    : '<pre>HTTP '+r.status+'\\n'+JSON.stringify(r.body,null,1)+'</pre>';
+}
+async function burst(){
+  $('out').innerHTML='<p style="color:#6a7280">sending 20 requests…</p>';
+  const r=await (await fetch('/api/burst',{method:'POST'})).json();
+  const t=(r.ok+r.limited+r.other)||1;
+  $('out').innerHTML='<div class="bar"><i class="ok" style="width:'+(r.ok/t*100)+'%"></i>'+
+    '<i class="lim" style="width:'+(r.limited/t*100)+'%"></i></div>'+
+    '<p style="color:#6a7280;font-size:13px"><b>'+r.ok+'</b> ok · <b>'+r.limited+
+    '</b> rate-limited (429) · '+r.other+' other · '+r.tokens+' tokens</p>';
+}
+</script>
+"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code, body, ctype="application/json"):
+        raw = body if isinstance(body, bytes) else body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, fmt, *a):
+        print(fmt % a, flush=True)          # so `oc logs` shows the calls
+
+    def do_GET(self):
+        if self.path == "/":
+            return self._send(200, PAGE, "text/html; charset=utf-8")
+        if self.path == "/healthz":
+            return self._send(200, json.dumps({"ok": True}))
+        if self.path == "/api/whoami":
+            return self._send(200, json.dumps({
+                "identity": identity(), "maas_url": MAAS_URL,
+                "model_served": MODEL_SERVED, "model_path": MODEL_PATH}))
+        self._send(404, json.dumps({"error": "not found"}))
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        payload = json.loads(self.rfile.read(n) or b"{}") if n else {}
+
+        if self.path == "/api/ask":
+            status, resp = call_model(payload.get("prompt", "hello"))
+            if status == 200:
+                print(f"model call ok: {resp.get('usage')}", flush=True)
+                return self._send(200, json.dumps({
+                    "status": 200,
+                    "content": resp["choices"][0]["message"]["content"],
+                    "usage": resp.get("usage")}))
+            print(f"model call failed: HTTP {status} {str(resp)[:120]}", flush=True)
+            return self._send(200, json.dumps({"status": status, "body": resp}))
+
+        if self.path == "/api/burst":
+            ok = lim = other = tokens = 0
+            for _ in range(20):
+                status, resp = call_model("hi", max_tokens=4)
+                if status == 200:
+                    ok += 1
+                    tokens += (resp.get("usage") or {}).get("total_tokens", 0)
+                elif status == 429:
+                    lim += 1
+                else:
+                    other += 1
+            print(f"burst: {ok} ok / {lim} rate-limited / {other} other", flush=True)
+            return self._send(200, json.dumps(
+                {"ok": ok, "limited": lim, "other": other, "tokens": tokens}))
+
+        self._send(404, json.dumps({"error": "not found"}))
+
+
+if __name__ == "__main__":
+    print(f"model-client starting as {identity()}", flush=True)
+    print(f"  MaaS:  {MAAS_URL}", flush=True)
+    print(f"  model: {MODEL_SERVED} (path {MODEL_PATH})", flush=True)
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/demo/service-account-access/app/deployment.yaml
+++ b/demo/service-account-access/app/deployment.yaml
@@ -1,0 +1,89 @@
+# model-client - an in-cluster app that calls a MaaS model as its ServiceAccount.
+#
+# Runs as `batch-scorer`, so it inherits that ServiceAccount's subscription and
+# rate limit. No API key, no secret, no credential in the manifest: the only
+# thing it needs is the token Kubernetes projects into the pod automatically.
+#
+# The code is delivered via a ConfigMap so the demo needs no image build or
+# registry push. setup-demo.sh creates it from app/app.py.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-client
+  namespace: maas-clients
+  labels: {app: model-client}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: model-client}
+  template:
+    metadata:
+      labels: {app: model-client}
+    spec:
+      # This is the line that decides the app's MaaS identity.
+      serviceAccountName: batch-scorer
+      containers:
+        - name: app
+          image: registry.access.redhat.com/ubi9/python-311:latest
+          command: ["python3", "/opt/app/app.py"]
+          env:
+            - name: MAAS_URL
+              value: "REPLACED_BY_SETUP"
+            - name: MODEL_PATH
+              value: facebook-opt-125m-simulated
+            - name: MODEL_SERVED
+              value: facebook/opt-125m
+            - name: PORT
+              value: "8080"
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: app-code
+              mountPath: /opt/app
+          readinessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests: {cpu: 50m, memory: 128Mi}
+            limits: {cpu: 500m, memory: 512Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities: {drop: ["ALL"]}
+            seccompProfile: {type: RuntimeDefault}
+      volumes:
+        - name: app-code
+          configMap:
+            name: model-client-code
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: model-client
+  namespace: maas-clients
+  labels: {app: model-client}
+spec:
+  selector: {app: model-client}
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: model-client
+  namespace: maas-clients
+  labels: {app: model-client}
+spec:
+  to:
+    kind: Service
+    name: model-client
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/demo/service-account-access/cleanup-demo.sh
+++ b/demo/service-account-access/cleanup-demo.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Remove everything this demo created.
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+echo "==> Removing the in-cluster app"
+oc delete -f "${DIR}/app/deployment.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+oc delete configmap model-client-code -n maas-clients --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing MaaS objects"
+oc delete -f "${DIR}/subscriptions.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing ServiceAccounts and namespace"
+oc delete -f "${DIR}/serviceaccounts.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo
+echo "Done. Any API keys already issued to these ServiceAccounts remain valid"
+echo "until they expire - deleting the ServiceAccount does not revoke them."

--- a/demo/service-account-access/run-demo.sh
+++ b/demo/service-account-access/run-demo.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# ServiceAccount access to a model, via MaaS subscriptions.
+#
+# No humans, no Keycloak, no external IdP: an in-cluster workload authenticates
+# with its own ServiceAccount token, which MaaS validates through Kubernetes
+# TokenReview.
+#
+#   batch-scorer   -> sa-batch-scorer-tier   (40 tokens/min)
+#   report-writer  -> sa-report-writer-tier  (15 tokens/min)
+#
+# ACCESS is granted once for the whole namespace, by a MaaSAuthPolicy matching
+# the group system:serviceaccounts:maas-clients - neither SA is named there.
+# The TIER is per-workload, via a subscription matching each SA username.
+#
+# Usage:  ./run-demo.sh [requests_per_sa]      (default 18)
+set -uo pipefail
+
+N=${1:-18}
+SA_NS=maas-clients
+declare -a SAS=("batch-scorer" "report-writer")
+MODEL_RESOURCE=facebook-opt-125m-simulated
+MODEL_SERVED=facebook/opt-125m
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+MAAS=https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+EP="${MAAS}/llm/${MODEL_RESOURCE}/v1/chat/completions"
+BODY="{\"model\":\"${MODEL_SERVED}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4}"
+
+echo "MaaS: $MAAS"
+
+for SA in "${SAS[@]}"; do
+  printf '\n=== %s ===\n' "system:serviceaccount:${SA_NS}:${SA}"
+
+  TOKEN=$(oc create token "$SA" -n "$SA_NS" --duration=1h 2>/dev/null)
+  [ -z "$TOKEN" ] && { echo "  could not mint a token - run ./setup-demo.sh first"; continue; }
+
+  # The identity is in the token's `sub`, issued by the Kubernetes API - not an IdP.
+  echo "$TOKEN" | python3 -c 'import sys,json,base64
+p = sys.stdin.read().strip().split(".")[1]; p += "=" * (-len(p) % 4)
+c = json.loads(base64.urlsafe_b64decode(p))
+print("  token sub: %s" % c.get("sub"))
+print("  issued by: %s" % c.get("iss"))'
+
+  RESP=$(curl -sSk -m 30 -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+    -X POST -d "{\"name\":\"${SA}-demo\",\"description\":\"sa demo\",\"expiresIn\":\"30m\"}" \
+    "${MAAS}/maas-api/v1/api-keys")
+  SUB=$(echo "$RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("subscription","UNRESOLVED"))' 2>/dev/null)
+  KEY=$(echo "$RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("key",""))' 2>/dev/null)
+  echo "  resolved subscription: ${SUB}"
+  [ -z "$KEY" ] && { echo "  no key issued: $(echo "$RESP" | head -c 160)"; continue; }
+
+  # A ServiceAccount token also works directly on the model endpoint, with no
+  # API key at all - usually what you want for an in-cluster workload.
+  D=$(curl -sSk -m 30 -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $TOKEN" \
+    -H 'Content-Type: application/json' -X POST -d "$BODY" "$EP")
+  echo "  inference with the SA token directly (no API key) -> HTTP ${D}"
+
+  ok=0; lim=0; other=0
+  for _ in $(seq 1 "$N"); do
+    c=$(curl -sk -m 30 -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $KEY" \
+      -H 'Content-Type: application/json' -X POST -d "$BODY" "$EP")
+    [ "$c" = "500" ] && c=$(curl -sk -m 30 -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $KEY" \
+      -H 'Content-Type: application/json' -X POST -d "$BODY" "$EP")   # absorb cold-start 500
+    case "$c" in 200) ok=$((ok+1));; 429) lim=$((lim+1));; *) other=$((other+1));; esac
+  done
+  printf '  burst %s -> %s ok / %s rate-limited / %s other\n' "$N" "$ok" "$lim" "$other"
+done
+
+cat <<'TXT'
+
+Both workloads authenticated with their own ServiceAccount token, validated by
+Kubernetes TokenReview. No human identity, no external identity provider, and no
+credential to distribute - the token is projected into the pod by Kubernetes.
+
+Access came from one namespace-wide MaaSAuthPolicy; the differing rate limits
+came from a per-workload MaaSSubscription.
+TXT

--- a/demo/service-account-access/serviceaccounts.yaml
+++ b/demo/service-account-access/serviceaccounts.yaml
@@ -1,0 +1,34 @@
+# Two in-cluster workloads that need model access.
+#
+# A ServiceAccount token authenticates through the AuthConfig's
+# `openshift-identities` method (Kubernetes TokenReview), not the OIDC path - so
+# no Keycloak, no external IdP, no human involved.
+#
+# MaaS sees the SA as:
+#   username  system:serviceaccount:<namespace>:<name>
+#   groups    system:authenticated, system:serviceaccounts,
+#             system:serviceaccounts:<namespace>
+#
+# Both the username and the per-namespace group are usable in MaaS objects,
+# which is what makes the two grant patterns below possible.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maas-clients
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: batch-scorer
+  namespace: maas-clients
+  annotations:
+    openshift.io/description: "Gets a dedicated tier via a per-SA subscription"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: report-writer
+  namespace: maas-clients
+  annotations:
+    openshift.io/description: "Gets the shared namespace tier - no per-SA object"

--- a/demo/service-account-access/setup-demo.sh
+++ b/demo/service-account-access/setup-demo.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Create the ServiceAccounts, the MaaS objects that grant them model access, and
+# (optionally) an in-cluster app that calls the model as one of them.
+#
+# Idempotent - safe to re-run.
+#
+# Usage:
+#   ./setup-demo.sh            # ServiceAccounts + MaaS objects + the app
+#   ./setup-demo.sh --no-app   # skip the app
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_APP=true
+[ "${1:-}" = "--no-app" ] && DEPLOY_APP=false
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+echo "==> ServiceAccounts"
+oc apply -f "${DIR}/serviceaccounts.yaml" | sed 's/^/  /'
+
+echo "==> MaaS auth policy and subscriptions"
+oc apply -f "${DIR}/subscriptions.yaml" | sed 's/^/  /'
+
+echo "==> Waiting for reconcile"
+for _ in $(seq 1 20); do
+  R=$(oc get maassubscription sa-report-writer-tier -n models-as-a-service \
+        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+  [ "$R" = "True" ] && break
+  sleep 3
+done
+oc get maassubscription -n models-as-a-service --no-headers 2>/dev/null \
+  | grep '^sa-' | awk '{print "  "$1, $2, "priority="$3}'
+
+if [ "$DEPLOY_APP" = true ]; then
+  MAAS=https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+  echo
+  echo "==> In-cluster app (runs as the batch-scorer ServiceAccount)"
+  oc create configmap model-client-code -n maas-clients \
+    --from-file=app.py="${DIR}/app/app.py" --dry-run=client -o yaml \
+    | oc apply -f - | sed 's/^/  /'
+  sed "s|REPLACED_BY_SETUP|${MAAS}|" "${DIR}/app/deployment.yaml" \
+    | oc apply -f - | sed 's/^/  /'
+
+  # Pick up code changes on a re-run.
+  oc rollout restart deployment/model-client -n maas-clients >/dev/null 2>&1
+  echo "  waiting for rollout..."
+  oc rollout status deployment/model-client -n maas-clients --timeout=180s 2>&1 | sed 's/^/  /'
+
+  URL=$(oc get route model-client -n maas-clients -o jsonpath='{.spec.host}' 2>/dev/null)
+  echo
+  echo "  App:  https://${URL}"
+  echo "  Logs: oc logs -f deployment/model-client -n maas-clients"
+fi
+
+echo
+echo "Run ./run-demo.sh for the CLI walkthrough."

--- a/demo/service-account-access/subscriptions.yaml
+++ b/demo/service-account-access/subscriptions.yaml
@@ -1,0 +1,81 @@
+# ServiceAccount access to a model, via MaaS subscriptions.
+#
+# Design: access is granted ONCE for the whole namespace, and each workload gets
+# its OWN subscription. That gives per-workload rate limits while ensuring no
+# identity ever matches more than one subscription.
+#
+#   MaaSAuthPolicy  (group)  -> every SA in maas-clients may call the model
+#   MaaSSubscription (users) -> one per SA, so tiers differ without overlapping
+#
+# IMPORTANT - why not a namespace-wide subscription plus per-SA overrides:
+# if an identity matches TWO subscriptions, key issuance still resolves the
+# higher priority correctly, but using the ServiceAccount token DIRECTLY on the
+# model endpoint returns 403. Keeping subscriptions non-overlapping avoids it.
+# See the README.
+#
+# MaaS sees a ServiceAccount as:
+#   username  system:serviceaccount:<namespace>:<name>
+#   groups    system:authenticated, system:serviceaccounts,
+#             system:serviceaccounts:<namespace>
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: sa-namespace-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "ServiceAccounts in maas-clients"
+    openshift.io/description: "Grants every ServiceAccount in the namespace access to the model"
+spec:
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+  subjects:
+    groups:
+      - name: system:serviceaccounts:maas-clients
+    users: []
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: sa-batch-scorer-tier
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "batch-scorer tier"
+    openshift.io/description: "Higher throughput for the batch workload"
+spec:
+  owner:
+    groups: []
+    users:
+      - system:serviceaccount:maas-clients:batch-scorer
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        # Sized so a single "Ask" (~37 tokens) leaves room for a burst of 20
+        # (~5 tokens each) to trip the limit part-way. Too tight and one Ask
+        # spends the whole budget, which reads as broken rather than throttled.
+        - limit: 120
+          window: 1m
+  priority: 10
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: sa-report-writer-tier
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "report-writer tier"
+    openshift.io/description: "Modest tier for the reporting workload"
+spec:
+  owner:
+    groups: []
+    users:
+      - system:serviceaccount:maas-clients:report-writer
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 15
+          window: 1m
+  priority: 10

--- a/demo/subscription-priority/README.md
+++ b/demo/subscription-priority/README.md
@@ -140,10 +140,18 @@ and the realm itself are left alone.
    names them directly at priority 50, so they get 5000 — less than either group
    tier. This is how you cap one person without touching their team's entitlement.
 
+Expect one follow-up question: *what if two subscriptions have the same
+priority?* The largest limit wins, so a tie resolves to the most permissive
+tier — see [Designing priorities](#designing-priorities) for why a cap therefore
+needs a strictly higher number.
+
 ## How resolution works
 
 - **Highest `priority` wins.** The winning subscription becomes the entitlement in
   full; the others contribute nothing.
+- **At equal priority, the largest limit wins.** A tie resolves toward the most
+  permissive subscription, so priority is what restricts an identity — an equal
+  number does not.
 - **Group and user subscriptions rank in the same list.** A user subscription
   does not automatically beat a group one — it wins here because its priority is
   higher. Priority is the whole mechanism.
@@ -162,5 +170,13 @@ A workable convention, and the one used here:
 | 30–49 | narrower group tiers that should beat the defaults |
 | 50+ | individual users — exceptions, caps, and pilots |
 
-Leave gaps. Inserting a tier between two existing ones is a one-line change if
+Two rules make this work:
+
+**Give a restriction a strictly higher number.** Because a tie resolves to the
+largest limit, an equal priority will not hold someone down. This demo depends on
+it: `quota-individual-tier` caps `capped-user` at 5000 because it sits at priority
+50, above both group tiers. Set it to 30 — tying with `quota-standard-tier` — and
+the cap is ignored, because 10000 is the more permissive of the two.
+
+**Leave gaps.** Inserting a tier between two existing ones is a one-line change if
 the numbers are spaced, and a renumbering exercise if they are not.

--- a/demo/subscription-priority/README.md
+++ b/demo/subscription-priority/README.md
@@ -1,0 +1,166 @@
+# Subscription priority
+
+Entitlement is **selected, not accumulated**. A user who belongs to two groups
+worth 10000 and 20000 tokens per hour is not entitled to 30000 — MaaS ranks every
+subscription the identity matches and applies the highest-priority one in full.
+
+This is the question that comes up as soon as more than one team shares a model:
+*what happens when someone is in several groups?* The answer is that quotas never
+add up, and that a subscription naming an individual user outranks every group
+they belong to — so an individual can also be capped **below** all of their group
+tiers.
+
+## Prerequisites
+
+- MaaS deployed with the `simulator` model — from the repository root,
+  `./scripts/setup-maas.sh --model simulator`
+- The [OIDC demo](../oidc-authentication/), which imports the `maas` realm and
+  points MaaS at it. `setup-demo.sh` checks for this and runs it if it is missing.
+
+## The setup
+
+Three subscriptions on one model:
+
+| Subscription | Applies to | Limit | Priority |
+| --- | --- | --- | --- |
+| `quota-individual-tier` | user `capped-user` | 5000 tokens/hour | 50 |
+| `quota-standard-tier` | group `quota-standard` | 10000 tokens/hour | 30 |
+| `quota-bulk-tier` | group `quota-bulk` | 20000 tokens/hour | 20 |
+
+Two users, with **identical group membership** — both belong to `quota-standard`
+*and* `quota-bulk`:
+
+| User | Matches | Resolves to | Entitlement |
+| --- | --- | --- | --- |
+| `dual-user` | both group tiers | `quota-standard-tier` (priority 30) | 10000 tokens/hour |
+| `capped-user` | both group tiers **and** the user tier | `quota-individual-tier` (priority 50) | 5000 tokens/hour |
+
+Two details make the point sharply:
+
+- The higher-priority group tier is deliberately the **smaller** one. Joining a
+  group with a larger allowance does not raise the ceiling.
+- The individual tier is smaller still. Naming a user directly is how you set a
+  cap that overrides whatever their team is entitled to.
+
+## Run it
+
+```bash
+cd demo/subscription-priority
+./setup-demo.sh
+./run-demo.sh
+```
+
+`run-demo.sh` shows which subscription each user resolves to. It reads only, so
+it is repeatable as often as you like:
+
+```
+   5000 tokens/hour   quota-individual-tier   priority 50   user  capped-user
+  10000 tokens/hour   quota-standard-tier     priority 30   group quota-standard
+  20000 tokens/hour   quota-bulk-tier         priority 20   group quota-bulk
+
+Both users belong to BOTH groups.
+
+=== dual-user ===
+  groups claim: ['quota-bulk', 'quota-standard']
+  resolved subscription: quota-standard-tier
+  entitlement: 10000 tokens/hour  (not 30000 - the tiers do not add up)
+
+=== capped-user ===
+  groups claim: ['quota-bulk', 'quota-standard']
+  resolved subscription: quota-individual-tier
+  entitlement: 5000 tokens/hour  (not 30000 - the tiers do not add up)
+```
+
+## Proving the limit is real
+
+`--burn` spends actual tokens until the quota is reached, so the ceiling is
+demonstrated rather than asserted:
+
+```bash
+./run-demo.sh --burn
+```
+
+Verified output for `dual-user`:
+
+```
+=== dual-user ===
+  groups claim: ['quota-bulk', 'quota-standard']
+  resolved subscription: quota-standard-tier
+
+  spending tokens (~970 per request, 25 requests maximum)...
+     5 requests OK     4628 tokens spent
+    10 requests OK     9310 tokens spent
+    11 requests OK    10278 tokens spent   next request -> 429, quota reached
+
+  stopped after 11 successful requests, ~10278 tokens
+      5000  quota-individual-tier
+     10000  quota-standard-tier  <- landed here
+     20000  quota-bulk-tier
+     30000  the two group tiers added together
+```
+
+Eleven requests, then 429. The ladder at the end is the whole argument: had the
+two group tiers added up, the run would have continued past twenty requests.
+`capped-user`, with the same group membership, stops at around five.
+
+Each request carries a padded ~970-token prompt, so an hour's quota is reached in
+a handful of calls rather than hundreds. A burn takes a few seconds.
+
+> `--burn` spends the real hour-long window. Running it twice within the hour
+> shows the quota already spent — the script says so plainly. The default mode
+> consumes nothing and can be repeated freely, so rehearse with that.
+
+Tear down with `./cleanup-demo.sh`, which removes the subscriptions, the auth
+policy, and the two users and groups from the realm. The OIDC demo's own users
+and the realm itself are left alone.
+
+## Talk track
+
+1. **Show the three subscriptions** and their priorities:
+
+   ```bash
+   # quoted, so zsh does not try to glob the [0] indexes
+   oc get maassubscription -n models-as-a-service \
+     quota-individual-tier quota-standard-tier quota-bulk-tier \
+     -o 'custom-columns=NAME:.metadata.name,PRIORITY:.spec.priority,LIMIT:.spec.modelRefs[0].tokenRateLimits[0].limit,WINDOW:.spec.modelRefs[0].tokenRateLimits[0].window'
+   ```
+
+2. **Ask the question before showing the answer.** "This user is in a group worth
+   10000 tokens an hour and another worth 20000. What are they entitled to?"
+   30000 is the intuitive answer, and it is wrong.
+
+3. **Run `./run-demo.sh`.** Point at the `groups` claim — both memberships are
+   genuinely present in the token — and then at the resolved subscription. One
+   subscription won; the other contributed nothing.
+
+4. **Run `./run-demo.sh --burn`** and let it stop at eleven requests. The ladder
+   printed at the end shows where the run would have ended under each alternative.
+
+5. **Contrast `capped-user`.** Identical group membership, but a subscription
+   names them directly at priority 50, so they get 5000 — less than either group
+   tier. This is how you cap one person without touching their team's entitlement.
+
+## How resolution works
+
+- **Highest `priority` wins.** The winning subscription becomes the entitlement in
+  full; the others contribute nothing.
+- **Group and user subscriptions rank in the same list.** A user subscription
+  does not automatically beat a group one — it wins here because its priority is
+  higher. Priority is the whole mechanism.
+- **Limits are counted per subscription**, in tokens rather than requests, so the
+  quota reflects real consumption.
+- Callers do not name a subscription when requesting an API key. MaaS resolves it,
+  which is why the same request produces a different entitlement for each user.
+
+## Designing priorities
+
+A workable convention, and the one used here:
+
+| Band | Use |
+| --- | --- |
+| 10–29 | broad group tiers — the default entitlement for a team |
+| 30–49 | narrower group tiers that should beat the defaults |
+| 50+ | individual users — exceptions, caps, and pilots |
+
+Leave gaps. Inserting a tier between two existing ones is a one-line change if
+the numbers are spaced, and a renumbering exercise if they are not.

--- a/demo/subscription-priority/cleanup-demo.sh
+++ b/demo/subscription-priority/cleanup-demo.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Remove everything the subscription priority demo created.
+#
+# Leaves the `maas` realm, its client and the OIDC demo's own users in place -
+# this demo adds to that realm rather than owning it.
+#
+# Usage:  ./cleanup-demo.sh
+set -uo pipefail
+
+REALM=maas
+declare -a KC_GROUPS=("quota-standard" "quota-bulk")
+declare -a USERS=("dual-user" "capped-user")
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+echo "==> MaaS objects"
+oc delete maassubscription -n models-as-a-service \
+  quota-standard-tier quota-bulk-tier quota-individual-tier \
+  --ignore-not-found 2>/dev/null | sed 's/^/   /'
+oc delete maasauthpolicy -n models-as-a-service quota-groups-access \
+  --ignore-not-found 2>/dev/null | sed 's/^/   /'
+
+# --- Keycloak ---------------------------------------------------------------
+KC_NS=$(oc get keycloakrealmimport -A -o jsonpath="{range .items[?(@.spec.realm.realm=='${REALM}')]}{.metadata.namespace}{end}" 2>/dev/null)
+[ -z "$KC_NS" ] && KC_NS=$(oc get keycloak -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null)
+if [ -z "$KC_NS" ]; then
+  echo "==> No Keycloak found - nothing else to remove"
+  exit 0
+fi
+KC_HOST=$(oc get keycloak -n "$KC_NS" -o jsonpath='{.items[0].spec.hostname.hostname}' 2>/dev/null)
+[ -z "$KC_HOST" ] && KC_HOST=$(oc get route -n "$KC_NS" -o jsonpath='{.items[0].spec.host}')
+KC="https://${KC_HOST}"
+
+ADMIN_USER=$(oc get secret keycloak-initial-admin -n "$KC_NS" -o jsonpath='{.data.username}' 2>/dev/null | base64 -d)
+ADMIN_PASS=$(oc get secret keycloak-initial-admin -n "$KC_NS" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d)
+AT=$(curl -sSk -X POST "${KC}/realms/master/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=admin-cli \
+  -d "username=${ADMIN_USER}" -d "password=${ADMIN_PASS}" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
+[ -n "$AT" ] || { echo "==> Could not authenticate to Keycloak - remove the users and groups by hand"; exit 0; }
+
+api() { curl -sSk -H "Authorization: Bearer ${AT}" -H 'Content-Type: application/json' "$@"; }
+
+echo "==> Keycloak users"
+for U in "${USERS[@]}"; do
+  UID_=$(api "${KC}/admin/realms/${REALM}/users?username=${U}&exact=true" \
+    | python3 -c 'import sys,json; u=json.load(sys.stdin); print(u[0]["id"] if u else "")' 2>/dev/null)
+  if [ -n "$UID_" ]; then
+    api -o /dev/null -X DELETE "${KC}/admin/realms/${REALM}/users/${UID_}" >/dev/null 2>&1
+    echo "   removed ${U}"
+  else
+    echo "   ${U} not present"
+  fi
+done
+
+echo "==> Keycloak groups"
+for G in "${KC_GROUPS[@]}"; do
+  GID=$(api "${KC}/admin/realms/${REALM}/groups?search=${G}" \
+    | python3 -c "import sys,json; g=[x for x in json.load(sys.stdin) if x['name']=='${G}']; print(g[0]['id'] if g else '')" 2>/dev/null)
+  if [ -n "$GID" ]; then
+    api -o /dev/null -X DELETE "${KC}/admin/realms/${REALM}/groups/${GID}" >/dev/null 2>&1
+    echo "   removed ${G}"
+  else
+    echo "   ${G} not present"
+  fi
+done
+
+echo
+echo "Done. API keys already issued to these users expire on their own."

--- a/demo/subscription-priority/run-demo.sh
+++ b/demo/subscription-priority/run-demo.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Subscription priority: entitlement is selected, not accumulated.
+#
+#   dual-user     groups quota-standard + quota-bulk   -> quota-standard-tier    10000 tokens/hour
+#   capped-user   same two groups, plus a user tier    -> quota-individual-tier   5000 tokens/hour
+#
+# Both users hold group memberships worth 10000 and 20000 tokens/hour. Neither
+# gets 30000: the highest-priority subscription wins outright.
+#
+# Usage:
+#   ./run-demo.sh            show which subscription each user resolves to (repeatable)
+#   ./run-demo.sh --burn     also spend real tokens to show where the limit lands
+#
+# --burn consumes the hour-long window for real. Re-running it inside the same
+# hour will show the quota already spent.
+set -uo pipefail
+
+BURN=0
+[ "${1:-}" = "--burn" ] && BURN=1
+
+MODEL_RESOURCE=facebook-opt-125m-simulated   # KServe resource name -> URL path
+MODEL_SERVED=facebook/opt-125m               # served name -> JSON body
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+MAAS="https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')"
+ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants \
+         -o jsonpath='{.spec.oidc.issuerUrl}' 2>/dev/null)
+[ -n "$ISSUER" ] || { echo "MaaS has no OIDC issuer configured - run ./setup-demo.sh first"; exit 1; }
+
+echo "MaaS:   $MAAS"
+echo "Issuer: $ISSUER"
+
+# The three tiers in play, printed as a ladder so the audience can see which
+# rung each user lands on.
+cat <<'TXT'
+
+The tiers, and the priority that ranks them:
+
+   5000 tokens/hour   quota-individual-tier   priority 50   user  capped-user
+  10000 tokens/hour   quota-standard-tier     priority 30   group quota-standard
+  20000 tokens/hour   quota-bulk-tier         priority 20   group quota-bulk
+
+Both users belong to BOTH groups.
+TXT
+
+for pair in "dual-user:10000:quota-standard-tier" "capped-user:5000:quota-individual-tier"; do
+  U="${pair%%:*}"; rest="${pair#*:}"; LIMIT="${rest%%:*}"; WANT="${rest##*:}"
+  printf '\n=== %s ===\n' "$U"
+
+  # Retried: Keycloak can be slow to answer the first request after an idle spell.
+  TOKEN=""
+  for _ in 1 2 3; do
+    TOKEN=$(curl -sSk -m 30 -X POST "${ISSUER}/protocol/openid-connect/token" \
+      -d grant_type=password -d client_id=maas-oidc \
+      -d "username=${U}" -d "password=${U}" -d scope=openid 2>/dev/null \
+      | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
+    [ -n "$TOKEN" ] && break
+  done
+  [ -z "$TOKEN" ] && { echo "  token request failed - run ./setup-demo.sh"; continue; }
+
+  echo "$TOKEN" | python3 -c 'import sys,json,base64
+p=sys.stdin.read().strip().split(".")[1]; p+="="*(-len(p)%4)
+c=json.loads(base64.urlsafe_b64decode(p))
+print("  groups claim: %s" % sorted(c.get("groups") or []))'
+
+  RESP=$(curl -sSk -m 30 -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -X POST \
+    -d "{\"name\":\"${U}-priority\",\"description\":\"priority demo\",\"expiresIn\":\"2h\"}" \
+    "${MAAS}/maas-api/v1/api-keys")
+  SUB=$(echo "$RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("subscription","UNRESOLVED"))' 2>/dev/null)
+  KEY=$(echo "$RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("key",""))' 2>/dev/null)
+  printf '  resolved subscription: %s\n' "$SUB"
+  [ -z "$KEY" ] && { echo "  no key issued: $(echo "$RESP" | head -c 160)"; continue; }
+
+  if [ "$BURN" -eq 0 ]; then
+    printf '  entitlement: %s tokens/hour  (not 30000 - the tiers do not add up)\n' "$LIMIT"
+    continue
+  fi
+
+  # Spend real tokens. Each request carries a padded prompt of roughly 970
+  # tokens, so an hour's quota is reached in a handful of calls rather than
+  # hundreds.
+  python3 - "$MAAS" "$KEY" "$MODEL_RESOURCE" "$MODEL_SERVED" "$LIMIT" <<'PY'
+import json, ssl, sys, urllib.error, urllib.request
+
+maas, key, path, served, limit = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], int(sys.argv[5])
+ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
+url = f"{maas}/llm/{path}/v1/chat/completions"
+prompt = "Summarise this document. " + ("data point analysis result summary " * 180)
+
+def once():
+    body = json.dumps({"model": served,
+                       "messages": [{"role": "user", "content": prompt}],
+                       "max_tokens": 64}).encode()
+    req = urllib.request.Request(url, data=body, method="POST",
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {key}"})
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=60) as r:
+            return 200, json.loads(r.read()).get("usage", {}).get("total_tokens", 0)
+    except urllib.error.HTTPError as e:
+        return e.code, 0
+    except Exception:
+        return 0, 0
+
+def call(retries=2):
+    """Retry a 5xx: the first call after an idle period can fail while the
+    gateway reopens its connection pool. A 429 is a real answer, never retried."""
+    for attempt in range(retries + 1):
+        code, used = once()
+        if code == 200 or code == 429 or attempt == retries:
+            return code, used
+    return code, used
+
+print("\n  spending tokens (~970 per request, 25 requests maximum)...")
+spent = ok = 0
+for i in range(1, 26):
+    code, used = call()
+    spent += used
+    if code == 200:
+        ok += 1
+        if ok % 5 == 0:
+            print(f"    {ok:2} requests OK   {spent:6} tokens spent")
+    elif code == 429:
+        if ok == 0:
+            print(f"    429 on the first request - this hour's {limit} tokens are already spent.")
+            print( "    The window is an hour long; wait for it to roll, or run without --burn")
+            print( "    to show which subscription resolves.")
+            break
+        print(f"    {ok:2} requests OK   {spent:6} tokens spent   next request -> 429, quota reached")
+        break
+    else:
+        print(f"    request {i} returned HTTP {code}")
+        break
+
+if ok:
+    print(f"\n  stopped after {ok} successful requests, ~{spent} tokens")
+    for value, label in ((5000, "quota-individual-tier"),
+                         (10000, "quota-standard-tier"),
+                         (20000, "quota-bulk-tier"),
+                         (30000, "the two group tiers added together")):
+        mark = "  <- landed here" if value == limit else ""
+        print(f"    {value:6}  {label}{mark}")
+PY
+done
+
+cat <<'TXT'
+
+Both users hold the same two group memberships, worth 10000 and 20000 tokens per
+hour. Neither is entitled to 30000.
+
+MaaS ranks every subscription an identity matches and applies the highest
+priority one in full. Adding a user to a group with a larger allowance does not
+raise their ceiling, and a subscription naming an individual user outranks the
+groups they belong to - so it can also cap someone BELOW every group tier they
+hold, which is what capped-user shows.
+TXT

--- a/demo/subscription-priority/setup-demo.sh
+++ b/demo/subscription-priority/setup-demo.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Set up the subscription priority demo.
+#
+# Creates two Keycloak groups and two users who belong to BOTH of them, then
+# applies three subscriptions:
+#
+#   quota-standard-tier    group quota-standard   10000 tokens/hour  priority 30
+#   quota-bulk-tier        group quota-bulk       20000 tokens/hour  priority 20
+#   quota-individual-tier  user  capped-user       5000 tokens/hour  priority 50
+#
+# Prerequisite: the OIDC demo, which imports the `maas` realm and points MaaS at
+# it. This script checks for it and runs it if it is missing.
+#
+# Idempotent - safe to re-run.
+#
+# Usage:  ./setup-demo.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REALM=maas
+declare -a KC_GROUPS=("quota-standard" "quota-bulk")
+declare -a USERS=("dual-user" "capped-user")
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+# --- prerequisites ----------------------------------------------------------
+echo "==> Prerequisites"
+
+if [ "$(oc get maasmodelref facebook-opt-125m-simulated -n llm \
+        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" != "True" ]; then
+  echo "   the simulator model is not Ready."
+  echo "   From the repository root: ./scripts/setup-maas.sh --model simulator"
+  exit 1
+fi
+echo "   model facebook-opt-125m-simulated is Ready"
+
+ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants \
+         -o jsonpath='{.spec.oidc.issuerUrl}' 2>/dev/null)
+if [ -z "$ISSUER" ]; then
+  echo "   MaaS has no OIDC issuer configured - running the OIDC demo setup first"
+  "${DIR}/../oidc-authentication/setup-oidc-demo.sh" || {
+    echo "   OIDC setup failed; run demo/oidc-authentication/setup-oidc-demo.sh by hand"; exit 1; }
+  ISSUER=$(oc get aitenants.maas.opendatahub.io models-as-a-service -n ai-tenants \
+           -o jsonpath='{.spec.oidc.issuerUrl}' 2>/dev/null)
+  [ -n "$ISSUER" ] || { echo "   still no issuer configured"; exit 1; }
+fi
+echo "   OIDC issuer: ${ISSUER}"
+
+# --- locate Keycloak and its bootstrap admin --------------------------------
+KC_NS=$(oc get keycloakrealmimport -A -o jsonpath="{range .items[?(@.spec.realm.realm=='${REALM}')]}{.metadata.namespace}{end}" 2>/dev/null)
+[ -z "$KC_NS" ] && KC_NS=$(oc get keycloak -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null)
+[ -z "$KC_NS" ] && { echo "no Keycloak found"; exit 1; }
+KC_HOST=$(oc get keycloak -n "$KC_NS" -o jsonpath='{.items[0].spec.hostname.hostname}' 2>/dev/null)
+[ -z "$KC_HOST" ] && KC_HOST=$(oc get route -n "$KC_NS" -o jsonpath='{.items[0].spec.host}')
+KC="https://${KC_HOST}"
+echo "==> Keycloak ${KC_NS} at ${KC}"
+
+ADMIN_USER=$(oc get secret keycloak-initial-admin -n "$KC_NS" -o jsonpath='{.data.username}' 2>/dev/null | base64 -d)
+ADMIN_PASS=$(oc get secret keycloak-initial-admin -n "$KC_NS" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d)
+[ -z "$ADMIN_PASS" ] && { echo "could not read the keycloak-initial-admin secret in ${KC_NS}"; exit 1; }
+
+AT=$(curl -sSk -X POST "${KC}/realms/master/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=admin-cli \
+  -d "username=${ADMIN_USER}" -d "password=${ADMIN_PASS}" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))')
+[ -n "$AT" ] || { echo "could not obtain a Keycloak admin token"; exit 1; }
+
+api() { curl -sSk -H "Authorization: Bearer ${AT}" -H 'Content-Type: application/json' "$@"; }
+
+# --- groups -----------------------------------------------------------------
+echo "==> Groups"
+declare -a KC_GROUP_IDS=()
+for G in "${KC_GROUPS[@]}"; do
+  api -o /dev/null -X POST "${KC}/admin/realms/${REALM}/groups" -d "{\"name\":\"${G}\"}" >/dev/null 2>&1
+  GID=$(api "${KC}/admin/realms/${REALM}/groups?search=${G}" \
+    | python3 -c "import sys,json; g=[x for x in json.load(sys.stdin) if x['name']=='${G}']; print(g[0]['id'] if g else '')")
+  [ -n "$GID" ] || { echo "   could not create or find group ${G}"; exit 1; }
+  KC_GROUP_IDS+=("$GID")
+  echo "   ${G}"
+done
+
+# --- users ------------------------------------------------------------------
+# Both users join BOTH groups. An email is required, or Keycloak answers the
+# direct grant with "Account is not fully set up".
+echo "==> Users (both belong to both groups)"
+for U in "${USERS[@]}"; do
+  api -o /dev/null -X POST "${KC}/admin/realms/${REALM}/users" -d "{
+    \"username\":\"${U}\",\"enabled\":true,
+    \"email\":\"${U}@example.com\",\"emailVerified\":true,
+    \"firstName\":\"Quota\",\"lastName\":\"Demo\",\"requiredActions\":[],
+    \"credentials\":[{\"type\":\"password\",\"value\":\"${U}\",\"temporary\":false}]
+  }" >/dev/null 2>&1
+
+  UID_=$(api "${KC}/admin/realms/${REALM}/users?username=${U}&exact=true" \
+    | python3 -c 'import sys,json; u=json.load(sys.stdin); print(u[0]["id"] if u else "")')
+  [ -n "$UID_" ] || { echo "   could not create or find user ${U}"; exit 1; }
+
+  # Re-assert on a re-run, in case the user already existed without these.
+  api -o /dev/null -X PUT "${KC}/admin/realms/${REALM}/users/${UID_}" -d "{
+    \"email\":\"${U}@example.com\",\"emailVerified\":true,\"requiredActions\":[]}" >/dev/null 2>&1
+  api -o /dev/null -X PUT "${KC}/admin/realms/${REALM}/users/${UID_}/reset-password" \
+    -d "{\"type\":\"password\",\"value\":\"${U}\",\"temporary\":false}" >/dev/null 2>&1
+  for GID in "${KC_GROUP_IDS[@]}"; do
+    api -o /dev/null -X PUT "${KC}/admin/realms/${REALM}/users/${UID_}/groups/${GID}" >/dev/null 2>&1
+  done
+
+  MEMBERSHIP=$(api "${KC}/admin/realms/${REALM}/users/${UID_}/groups" \
+    | python3 -c 'import sys,json; print([g["name"] for g in json.load(sys.stdin)])')
+  printf '   %-12s password %-12s groups %s\n' "$U" "$U" "$MEMBERSHIP"
+done
+
+# --- MaaS objects -----------------------------------------------------------
+echo "==> Subscriptions"
+oc apply -f "${DIR}/subscriptions.yaml" | sed 's/^/   /'
+
+oc get maassubscription -n models-as-a-service \
+  quota-standard-tier quota-bulk-tier quota-individual-tier \
+  -o custom-columns=NAME:.metadata.name,PRIORITY:.spec.priority,LIMIT:.spec.modelRefs[0].tokenRateLimits[0].limit,WINDOW:.spec.modelRefs[0].tokenRateLimits[0].window \
+  2>/dev/null | sed 's/^/   /'
+
+# --- verify -----------------------------------------------------------------
+echo "==> Verifying resolution"
+MAAS=https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+sleep 10
+FAIL=0
+for pair in "dual-user:quota-standard-tier" "capped-user:quota-individual-tier"; do
+  U="${pair%%:*}"; WANT="${pair##*:}"
+  T=$(curl -sSk -m 20 -X POST "${ISSUER}/protocol/openid-connect/token" \
+    -d grant_type=password -d client_id=maas-oidc \
+    -d "username=${U}" -d "password=${U}" -d scope=openid \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
+  if [ -z "$T" ]; then echo "   ${U}: token request failed"; FAIL=1; continue; fi
+  SUB=$(curl -sSk -m 30 -H "Authorization: Bearer ${T}" -H 'Content-Type: application/json' -X POST \
+    -d "{\"name\":\"${U}-verify\",\"description\":\"d\",\"expiresIn\":\"10m\"}" "${MAAS}/maas-api/v1/api-keys" \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("subscription","UNRESOLVED"))' 2>/dev/null)
+  if [ "$SUB" = "$WANT" ]; then printf '   %-12s -> %s\n' "$U" "$SUB"
+  else printf '   %-12s -> %s (expected %s)\n' "$U" "$SUB" "$WANT"; FAIL=1; fi
+done
+
+if [ "$FAIL" -eq 0 ]; then
+  echo
+  echo "Ready.  ./run-demo.sh          show which subscription each user resolves to"
+  echo "        ./run-demo.sh --burn   spend real tokens and show where the limit lands"
+else
+  echo
+  echo "Resolution did not match. Check what else these identities match:"
+  echo "  oc get maassubscription -n models-as-a-service -o custom-columns=NAME:.metadata.name,PRIO:.spec.priority,GROUPS:.spec.owner.groups,USERS:.spec.owner.users"
+  exit 1
+fi

--- a/demo/subscription-priority/subscriptions.yaml
+++ b/demo/subscription-priority/subscriptions.yaml
@@ -1,0 +1,101 @@
+# Subscription priority: entitlement is selected, not accumulated.
+#
+# Two users, identical group membership - both belong to `quota-standard` AND
+# `quota-bulk`. Neither receives 30000 tokens/hour.
+#
+#   quota-standard-tier    group quota-standard   10000 tokens/hour  priority 30
+#   quota-bulk-tier        group quota-bulk       20000 tokens/hour  priority 20
+#   quota-individual-tier  user  capped-user       5000 tokens/hour  priority 50
+#
+# Resolution:
+#   dual-user    matches both group tiers   -> quota-standard-tier   (10000/hour)
+#   capped-user  matches both + the user tier -> quota-individual-tier (5000/hour)
+#
+# Priority is highest-wins. The winning subscription becomes the entitlement in
+# full; the others contribute nothing, so quotas never add up.
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: quota-groups-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Quota demo groups"
+    openshift.io/description: "Grants both quota demo groups access to the simulator model"
+spec:
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+  subjects:
+    groups:
+      - name: quota-standard
+      - name: quota-bulk
+    users: []
+---
+# The higher priority of the two group tiers, and deliberately the SMALLER quota.
+# This is what makes the point: adding a group with a bigger allowance does not
+# raise the ceiling.
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: quota-standard-tier
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Standard quota"
+    openshift.io/description: "10000 tokens/hour for the quota-standard group"
+spec:
+  owner:
+    groups:
+      - name: quota-standard
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 10000
+          window: 1h
+  priority: 30
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: quota-bulk-tier
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Bulk quota"
+    openshift.io/description: "20000 tokens/hour for the quota-bulk group"
+spec:
+  owner:
+    groups:
+      - name: quota-bulk
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 20000
+          window: 1h
+  priority: 20
+---
+# Named user, highest priority: overrides every group tier the user holds, and
+# can set a ceiling BELOW all of them.
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: quota-individual-tier
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Individual cap"
+    openshift.io/description: "5000 tokens/hour for one named user, overriding their group tiers"
+spec:
+  owner:
+    groups: []
+    users:
+      - capped-user
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 5000
+          window: 1h
+  priority: 50

--- a/demo/user-level-rate-limiting/README.md
+++ b/demo/user-level-rate-limiting/README.md
@@ -1,27 +1,31 @@
-# MaaS tiering demo
+# Tiering by group and by user
 
-Demonstrates how a `MaaSSubscription` is assigned to **groups** or to **individual
-users**, and how `priority` resolves the overlap when a user matches both.
+A `MaaSSubscription` sets a consumption tier — how many tokens an identity may
+spend in a window. Subscriptions can be assigned to a **group**, to **individual
+users**, or to both, with `priority` deciding which tier applies when a user
+matches more than one.
 
-Requires MaaS already deployed with the `simulator` model — from the repository
-root, `./scripts/setup-maas.sh --model simulator`.
+That combination is what lets you set a team-wide default and then give a named
+user their own tier without moving them out of the team.
+
+Requires MaaS deployed with the `simulator` model — from the repository root,
+`./scripts/setup-maas.sh --model simulator`.
 
 ## The mechanism
 
 ```yaml
 spec:
   owner:
-    groups:                  # []Object - each entry needs a `name` key
+    groups:                  # []Object - each entry takes a `name` key
       - name: maas-demo-users
-    users:                   # []string - PLAIN usernames, no `name` key
+    users:                   # []string - plain usernames
       - alice
   priority: 30               # higher wins when a user matches several
 ```
 
-The asymmetry between `groups` and `users` is easy to get wrong: groups are objects,
-users are bare strings.
-
 ## Cast
+
+Three users, all members of the same group:
 
 | User | Matches | Applied tier | Limit |
 | --- | --- | --- | --- |
@@ -29,15 +33,15 @@ users are bare strings.
 | `alice` | group + user override | `demo-alice-gold` (priority 30) | 5000 tokens/min |
 | `bob` | group + user override | `demo-bob-throttled` (priority 30) | 20 tokens/min |
 
-`bob` is the one to demo live — 20 tokens/min trips after about six requests.
+`bob` is the one to demo live — at 20 tokens/min his limit engages after about
+six requests, while `alice` and `carol` continue unaffected.
 
 ## Run it
 
 ```bash
 cd demo/user-level-rate-limiting
 
-# 1. Create alice/bob/carol and the maas-demo-users group.
-#    Adds an htpasswd IdP alongside any existing provider; backs up oauth/cluster first.
+# 1. Create alice/bob/carol and the maas-demo-users group
 ./setup-demo-users.sh
 
 # 2. Apply the tiers
@@ -63,9 +67,10 @@ Tear down with `./cleanup-demo.sh`.
 ## Talk track
 
 1. **Show `subscriptions.yaml`** — one group tier, two per-user overrides. Point at
-   `owner.groups` vs `owner.users`, and at `priority`.
+   `owner.groups` versus `owner.users`, and at `priority`.
 
-2. **Mint a key as bob**, noting the request does *not* name a subscription:
+2. **Mint a key as bob.** Note that the request does *not* name a subscription —
+   the platform resolves it:
 
    ```bash
    oc login -u bob -p "$DEMO_PASSWORD" --server=$(oc whoami --show-server)
@@ -75,44 +80,34 @@ Tear down with `./cleanup-demo.sh`.
      | jq .subscription
    ```
 
-   Returns `demo-bob-throttled` — MaaS resolved the highest-priority match itself.
+   Returns `demo-bob-throttled` — MaaS selected the highest-priority match on its own.
 
-3. **Run the burst** — bob hits 429 at his token limit; alice and carol sail through.
+3. **Run the burst** — bob receives 429 at his token limit; alice and carol sail through.
+   Same model, same endpoint, same request: the difference is entitlement.
 
-4. **Change a tier live** and re-run:
+4. **Change a tier live** and re-run, to show tiers are policy rather than deployment:
 
    ```bash
    oc patch maassubscription demo-bob-throttled -n models-as-a-service --type=merge \
      -p '{"spec":{"modelRefs":[{"name":"facebook-opt-125m-simulated","namespace":"llm","tokenRateLimits":[{"limit":5000,"window":"1m"}]}]}}'
    ```
 
-## Two gotchas
+## How limits behave
 
-**Model name.** The inference body needs the *served* model name `facebook/opt-125m`,
-not the KServe resource name `facebook-opt-125m-simulated`. The resource name is the
-URL path; the served name goes in the JSON body. Getting it wrong returns
-`404 The model ... does not exist`.
+- Limits are counted **per subscription**, not per API key. Issuing a second key
+  does not reset the quota, so a user cannot lift their own ceiling by minting
+  more credentials.
+- Subscription ownership is **enforced**. A request naming a subscription the
+  caller does not own is rejected.
+- Limits are measured in **tokens**, not requests, so the quota reflects actual
+  consumption rather than call count.
 
-**Cold-start 500.** The first request after an idle period can return HTTP 500 —
-`maas-api` logs `database lookup failed: context canceled`, a stale pooled DB
-connection. It retries fine and sustained traffic is stable. `run-demo.sh` retries once
-on a 500, so the demo stays clean; if you demo by hand, just send the request again.
+## Usage note
 
-## Behaviour worth stating accurately
+The URL path carries the KServe resource name (`facebook-opt-125m-simulated`)
+and the request body carries the served model name (`facebook/opt-125m`):
 
-- Rate limits are counted **per subscription**, not per key. Minting a second key does
-  not reset the quota — a fresh key on an exhausted subscription is throttled
-  immediately.
-
-- Subscription ownership is **enforced**. Requesting a subscription you do not own
-  returns `400 {"code":"invalid_subscription"}`.
-
-- A restrictive user tier is **not a ceiling**. If a user also matches a more permissive
-  subscription, they can name it at key-creation time and bypass the restriction. Any
-  subscription granting `system:authenticated` will match your demo users too, so check
-  what else they match before demoing:
-
-  ```bash
-  oc get maassubscription -A \
-    -o custom-columns=NAME:.metadata.name,GROUPS:.spec.owner.groups,USERS:.spec.owner.users,PRIO:.spec.priority
-  ```
+```bash
+curl ... -d '{"model":"facebook/opt-125m", ...}' \
+  https://maas.<domain>/llm/facebook-opt-125m-simulated/v1/chat/completions
+```

--- a/demo/user-level-rate-limiting/README.md
+++ b/demo/user-level-rate-limiting/README.md
@@ -1,0 +1,118 @@
+# MaaS tiering demo
+
+Demonstrates how a `MaaSSubscription` is assigned to **groups** or to **individual
+users**, and how `priority` resolves the overlap when a user matches both.
+
+Requires MaaS already deployed with the `simulator` model — from the repository
+root, `./scripts/setup-maas.sh --model simulator`.
+
+## The mechanism
+
+```yaml
+spec:
+  owner:
+    groups:                  # []Object - each entry needs a `name` key
+      - name: maas-demo-users
+    users:                   # []string - PLAIN usernames, no `name` key
+      - alice
+  priority: 30               # higher wins when a user matches several
+```
+
+The asymmetry between `groups` and `users` is easy to get wrong: groups are objects,
+users are bare strings.
+
+## Cast
+
+| User | Matches | Applied tier | Limit |
+| --- | --- | --- | --- |
+| `carol` | group only | `demo-team-standard` | 200 tokens/min |
+| `alice` | group + user override | `demo-alice-gold` (priority 30) | 5000 tokens/min |
+| `bob` | group + user override | `demo-bob-throttled` (priority 30) | 20 tokens/min |
+
+`bob` is the one to demo live — 20 tokens/min trips after about six requests.
+
+## Run it
+
+```bash
+cd demo/user-level-rate-limiting
+
+# 1. Create alice/bob/carol and the maas-demo-users group.
+#    Adds an htpasswd IdP alongside any existing provider; backs up oauth/cluster first.
+./setup-demo-users.sh
+
+# 2. Apply the tiers
+oc apply -f subscriptions.yaml
+
+# 3. Show it working
+./run-demo.sh
+```
+
+Representative output:
+
+```
+=== carol ===  resolved subscription: demo-team-standard
+  10 requests -> 10 ok / 0 rate-limited / 0 other   (39 tokens consumed)
+=== alice ===  resolved subscription: demo-alice-gold
+  10 requests -> 10 ok / 0 rate-limited / 0 other   (38 tokens consumed)
+=== bob ===    resolved subscription: demo-bob-throttled
+  10 requests -> 5 ok / 5 rate-limited / 0 other    (23 tokens consumed)
+```
+
+Tear down with `./cleanup-demo.sh`.
+
+## Talk track
+
+1. **Show `subscriptions.yaml`** — one group tier, two per-user overrides. Point at
+   `owner.groups` vs `owner.users`, and at `priority`.
+
+2. **Mint a key as bob**, noting the request does *not* name a subscription:
+
+   ```bash
+   oc login -u bob -p "$DEMO_PASSWORD" --server=$(oc whoami --show-server)
+   curl -sk -H "Authorization: Bearer $(oc whoami -t)" -H 'Content-Type: application/json' \
+     -X POST -d '{"name":"bob-demo","description":"demo","expiresIn":"8h"}' \
+     "https://maas.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')/maas-api/v1/api-keys" \
+     | jq .subscription
+   ```
+
+   Returns `demo-bob-throttled` — MaaS resolved the highest-priority match itself.
+
+3. **Run the burst** — bob hits 429 at his token limit; alice and carol sail through.
+
+4. **Change a tier live** and re-run:
+
+   ```bash
+   oc patch maassubscription demo-bob-throttled -n models-as-a-service --type=merge \
+     -p '{"spec":{"modelRefs":[{"name":"facebook-opt-125m-simulated","namespace":"llm","tokenRateLimits":[{"limit":5000,"window":"1m"}]}]}}'
+   ```
+
+## Two gotchas
+
+**Model name.** The inference body needs the *served* model name `facebook/opt-125m`,
+not the KServe resource name `facebook-opt-125m-simulated`. The resource name is the
+URL path; the served name goes in the JSON body. Getting it wrong returns
+`404 The model ... does not exist`.
+
+**Cold-start 500.** The first request after an idle period can return HTTP 500 —
+`maas-api` logs `database lookup failed: context canceled`, a stale pooled DB
+connection. It retries fine and sustained traffic is stable. `run-demo.sh` retries once
+on a 500, so the demo stays clean; if you demo by hand, just send the request again.
+
+## Behaviour worth stating accurately
+
+- Rate limits are counted **per subscription**, not per key. Minting a second key does
+  not reset the quota — a fresh key on an exhausted subscription is throttled
+  immediately.
+
+- Subscription ownership is **enforced**. Requesting a subscription you do not own
+  returns `400 {"code":"invalid_subscription"}`.
+
+- A restrictive user tier is **not a ceiling**. If a user also matches a more permissive
+  subscription, they can name it at key-creation time and bypass the restriction. Any
+  subscription granting `system:authenticated` will match your demo users too, so check
+  what else they match before demoing:
+
+  ```bash
+  oc get maassubscription -A \
+    -o custom-columns=NAME:.metadata.name,GROUPS:.spec.owner.groups,USERS:.spec.owner.users,PRIO:.spec.priority
+  ```

--- a/demo/user-level-rate-limiting/cleanup-demo.sh
+++ b/demo/user-level-rate-limiting/cleanup-demo.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Remove everything setup-demo-users.sh and subscriptions.yaml created.
+#
+# Usage:
+#   ./cleanup-demo.sh                                    # keeps other IdPs intact
+#   OAUTH_BACKUP=/path/oauth-cluster.backup.yaml ./cleanup-demo.sh
+set -uo pipefail
+
+USERS=(alice bob carol)
+GROUP=maas-demo-users
+SECRET=maas-demo-htpasswd
+IDP=maas-demo
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+echo "==> Removing demo subscriptions"
+oc delete -f "${DIR}/subscriptions.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing group and identities"
+oc delete group "$GROUP" --ignore-not-found 2>&1 | sed 's/^/  /'
+for u in "${USERS[@]}"; do
+  oc delete user "$u" --ignore-not-found >/dev/null 2>&1
+  oc delete identity "${IDP}:${u}" --ignore-not-found >/dev/null 2>&1
+done
+echo "  users and identities removed"
+
+echo "==> Removing htpasswd secret"
+oc delete secret "$SECRET" -n openshift-config --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing the ${IDP} identity provider"
+if [ -n "${OAUTH_BACKUP:-}" ] && [ -f "$OAUTH_BACKUP" ]; then
+  oc apply -f "$OAUTH_BACKUP" 2>&1 | sed 's/^/  /'
+else
+  # Drop just our provider by name, leaving any others in place.
+  REMAINING=$(oc get oauth cluster -o json \
+    | jq -c "[.spec.identityProviders[]? | select(.name != \"${IDP}\")]")
+  oc patch oauth cluster --type=merge -p "{\"spec\":{\"identityProviders\":${REMAINING}}}" 2>&1 | sed 's/^/  /'
+fi
+
+echo
+echo "Identity providers now:"
+oc get oauth cluster -o jsonpath='{range .spec.identityProviders[*]}  {.name} ({.type}){"\n"}{end}'
+echo
+echo "NOTE: if you re-scoped shipped subscriptions (e.g. simulator-free/premium) to make"
+echo "the demo deterministic, restore them by hand - this script does not touch them."

--- a/demo/user-level-rate-limiting/run-demo.sh
+++ b/demo/user-level-rate-limiting/run-demo.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# MaaS tiering demo: group baseline + per-user overrides.
+#
+#   carol -> demo-team-standard  (group tier)
+#   alice -> demo-alice-gold     (per-user upgrade)
+#   bob   -> demo-bob-throttled  (per-user downgrade, trips fast)
+#
+# Each user mints an API key WITHOUT naming a subscription - MaaS resolves the
+# highest-priority subscription the user matches. That resolution is the point.
+#
+# Usage:
+#   ./run-demo.sh [requests_per_user]           # default 12
+#   DEMO_PASSWORD='...' ./run-demo.sh 20
+set -uo pipefail
+
+N=${1:-12}
+USERS=(carol alice bob)
+MODEL_RESOURCE=facebook-opt-125m-simulated   # KServe resource name -> URL path
+MODEL_SERVED=facebook/opt-125m               # served name -> JSON body (NOT the same)
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+API=$(oc whoami --show-server)
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+H="https://maas.${CLUSTER_DOMAIN}"
+ENDPOINT="${H}/llm/${MODEL_RESOURCE}/v1/chat/completions"
+
+if [ -z "${DEMO_PASSWORD:-}" ]; then
+  read -rsp "Password for demo users: " DEMO_PASSWORD; echo
+fi
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+echo "MaaS: $H"
+
+# Warm-up: the first request after an idle period can return 500 (stale pooled DB
+# connection in maas-api). Absorb it here rather than during the demo.
+curl -sk --max-time 30 -o /dev/null -H "Authorization: Bearer $(oc whoami -t)" \
+  "${H}/maas-api/v1/models" 2>/dev/null || true
+
+for U in "${USERS[@]}"; do
+  printf '\n=== %s ===\n' "$U"
+
+  KUBECONFIG="$TMP/$U.kubeconfig" oc login -u "$U" -p "$DEMO_PASSWORD" --server="$API" \
+    --insecure-skip-tls-verify=true >/dev/null 2>&1 || { echo "  login FAILED"; continue; }
+  TOKEN=$(KUBECONFIG="$TMP/$U.kubeconfig" oc whoami -t)
+
+  RESP=$(curl -sk --max-time 30 -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" -X POST \
+    -d "{\"name\":\"${U}-demo\",\"description\":\"demo\",\"expiresIn\":\"8h\"}" \
+    "${H}/maas-api/v1/api-keys")
+  echo "  resolved subscription: $(echo "$RESP" | jq -r '.subscription // "UNRESOLVED"')"
+  KEY=$(echo "$RESP" | jq -r '.key // empty')
+  [ -z "$KEY" ] && { echo "  no key issued: $(echo "$RESP" | head -c 140)"; continue; }
+
+  ok=0; lim=0; other=0; tok=0
+  for _ in $(seq 1 "$N"); do
+    code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+      -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -X POST \
+      -d "{\"model\":\"${MODEL_SERVED}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4}" \
+      "$ENDPOINT")
+    # maas-api can return 500 on the first call after an idle period (stale pooled
+    # DB connection on the key-validation path). Retry once so the demo stays clean.
+    if [ "$code" = "500" ]; then
+      code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+        -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -X POST \
+        -d "{\"model\":\"${MODEL_SERVED}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4}" \
+        "$ENDPOINT")
+    fi
+    case "$code" in
+      200) ok=$((ok+1)); tok=$((tok + $(jq -r '.usage.total_tokens // 0' "$TMP/r" 2>/dev/null))) ;;
+      429) lim=$((lim+1)) ;;
+      *)   other=$((other+1)) ;;
+    esac
+  done
+  printf '  %s requests -> %s ok / %s rate-limited / %s other   (%s tokens consumed)\n' \
+    "$N" "$ok" "$lim" "$other" "$tok"
+done
+
+printf '\nExpected: bob rate-limited at his token limit; alice and carol unaffected at this volume.\n'

--- a/demo/user-level-rate-limiting/setup-demo-users.sh
+++ b/demo/user-level-rate-limiting/setup-demo-users.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Create demo users for the MaaS tiering demo.
+#
+# Adds an htpasswd identity provider ALONGSIDE whatever the cluster already uses,
+# creates three users, and puts them in an OpenShift group. Existing identity
+# providers are left untouched.
+#
+# Usage:
+#   ./setup-demo-users.sh                 # password prompted, or set DEMO_PASSWORD
+#   DEMO_PASSWORD='...' ./setup-demo-users.sh
+#
+# Reverse with ./cleanup-demo.sh
+set -euo pipefail
+
+USERS=(alice bob carol)
+GROUP=maas-demo-users
+SECRET=maas-demo-htpasswd
+IDP=maas-demo
+WORKDIR=${WORKDIR:-$(mktemp -d)}
+
+command -v htpasswd >/dev/null || { echo "htpasswd not found (install httpd-tools / apache2-utils)"; exit 1; }
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+if [ -z "${DEMO_PASSWORD:-}" ]; then
+  read -rsp "Password for demo users: " DEMO_PASSWORD; echo
+fi
+[ -n "$DEMO_PASSWORD" ] || { echo "empty password"; exit 1; }
+
+echo "==> Backing up oauth/cluster to ${WORKDIR}/oauth-cluster.backup.yaml"
+oc get oauth cluster -o yaml > "${WORKDIR}/oauth-cluster.backup.yaml"
+
+echo "==> Generating htpasswd for: ${USERS[*]}"
+HT="${WORKDIR}/demo.htpasswd"
+htpasswd -c -B -b "$HT" "${USERS[0]}" "$DEMO_PASSWORD" >/dev/null 2>&1
+for u in "${USERS[@]:1}"; do htpasswd -B -b "$HT" "$u" "$DEMO_PASSWORD" >/dev/null 2>&1; done
+
+echo "==> Creating secret ${SECRET} in openshift-config"
+oc create secret generic "$SECRET" --from-file=htpasswd="$HT" -n openshift-config \
+  --dry-run=client -o yaml | oc apply -f -
+
+if oc get oauth cluster -o jsonpath='{.spec.identityProviders[*].name}' | tr ' ' '\n' | grep -qx "$IDP"; then
+  echo "==> Identity provider ${IDP} already present, skipping"
+else
+  echo "==> Adding identity provider ${IDP} (additive - existing providers untouched)"
+  oc patch oauth cluster --type=json -p "[{\"op\":\"add\",\"path\":\"/spec/identityProviders/-\",\"value\":{\"name\":\"${IDP}\",\"mappingMethod\":\"claim\",\"type\":\"HTPasswd\",\"htpasswd\":{\"fileData\":{\"name\":\"${SECRET}\"}}}}]"
+fi
+
+echo "==> Creating group ${GROUP}"
+oc adm groups new "$GROUP" "${USERS[@]}" 2>/dev/null || \
+  { for u in "${USERS[@]}"; do oc adm groups add-users "$GROUP" "$u" >/dev/null 2>&1 || true; done; }
+
+echo
+echo "Identity providers now:"
+oc get oauth cluster -o jsonpath='{range .spec.identityProviders[*]}  {.name} ({.type}){"\n"}{end}'
+echo
+echo "The oauth pods restart before the new users can log in (usually under a minute)."
+echo "Backup and htpasswd kept in: ${WORKDIR}"
+echo
+echo "IMPORTANT: any subscription granting system:authenticated will also match these"
+echo "users and may outrank the demo tiers. Check with:"
+echo "  oc get maassubscription -A -o custom-columns=NAME:.metadata.name,GROUPS:.spec.owner.groups,USERS:.spec.owner.users,PRIO:.spec.priority"

--- a/demo/user-level-rate-limiting/subscriptions.yaml
+++ b/demo/user-level-rate-limiting/subscriptions.yaml
@@ -1,0 +1,89 @@
+# MaaS demo: group baseline + per-user overrides
+# ==============================================
+#
+# Demonstrates the two ways a MaaSSubscription can be assigned, and how
+# `priority` resolves the overlap when a user matches more than one.
+#
+#   spec.owner.groups  []Object  - each entry needs a `name` key
+#   spec.owner.users   []string  - PLAIN usernames, no `name` key (easy to get wrong)
+#
+# Cast:
+#   carol  -> only matches the group tier          -> 200 tokens/min  (baseline)
+#   alice  -> group tier + gold override           -> 5000 tokens/min (upgraded)
+#   bob    -> group tier + throttled override      -> 20 tokens/min   (downgraded)
+#
+# The overrides win because priority 30 > 10. That is the point of the demo:
+# a per-user subscription overrides the group tier in BOTH directions.
+#
+# Rate limits are counted per SUBSCRIPTION, not per key - minting a second key
+# does not reset the quota.
+#
+# Apply:   oc apply -f maas-demo-subscriptions.yaml
+# Revert:  oc delete -f maas-demo-subscriptions.yaml
+---
+# Baseline everyone on the team gets. carol has no override, so this is her tier.
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: demo-team-standard
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Demo Team - Standard"
+    openshift.io/description: "Baseline tier for everyone in maas-demo-users"
+spec:
+  owner:
+    groups:
+      - name: maas-demo-users
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 200
+          window: 1m
+  priority: 10
+---
+# alice is upgraded. Higher priority than the group tier, so this one applies.
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: demo-alice-gold
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Demo - alice (Gold)"
+    openshift.io/description: "Per-user upgrade: overrides the team baseline"
+spec:
+  owner:
+    groups: []
+    users:
+      - alice
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 5000
+          window: 1m
+  priority: 30
+---
+# bob is throttled. Same mechanism as alice, opposite direction - this is the
+# one to demo live, because 20 tokens/min trips within a handful of requests.
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: demo-bob-throttled
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Demo - bob (Throttled)"
+    openshift.io/description: "Per-user downgrade: overrides the team baseline"
+spec:
+  owner:
+    groups: []
+    users:
+      - bob
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 20
+          window: 1m
+  priority: 30


### PR DESCRIPTION
Self-contained demos that run against a cluster with MaaS already deployed. Each folder has a setup script, a runbook README with a talk track, and a teardown script.

  user-level-rate-limiting  MaaSSubscription assigned to individual users as
                            well as groups, and how priority resolves overlap
  oidc-authentication       authenticating with an external OIDC identity that
                            has no OpenShift account; the groups claim selects
                            the subscription. Includes a click-through UI and a
                            CLI sample client, and user-scoped access for an
                            identity with no group tier
  service-account-access    an in-cluster workload calling a model with its own
                            ServiceAccount token, validated by TokenReview.
                            Access per namespace, rate limits per workload
  jwks-cache                that signatures are genuinely verified and that
                            validation happens locally from a cached JWKS,
                            proven by cutting Authorino off from the IdP

demo/preflight.sh checks all four are ready to present without applying any YAML, and warms up maas-api to absorb its cold-start 500.

The READMEs also record three behaviours found while building these: an identity matching two subscriptions gets 403 on the direct-token path, a token with no groups claim fails with an opaque AUTH_FAILURE, and split-horizon DNS will produce a false pass in the caching proof if you block the wrong address.