### PR TITLE
docs: add demos page with pointers to PR #152 demos

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -33,6 +33,9 @@
 * xref:08c-api-key-security.adoc[API Key Security]
 * xref:11-model-swap.adoc[Model Swap]
 
+.Demos
+* xref:demos.adoc[Demos]
+
 .Cleanup
 * xref:09-cleanup.adoc[Cleanup & Teardown]
 

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -105,6 +105,8 @@ Defines rate-limiting tiers for model access. Each model ships with two tiers:
 
 Higher-priority subscriptions take precedence. You can adjust limits, windows, and subject groups to match your usage policies.
 
+TIP: See the link:{repo-url}/tree/main/demo/user-level-rate-limiting[User-Level Rate Limiting demo] and link:{repo-url}/tree/main/demo/subscription-priority[Subscription Priority demo] for hands-on walkthroughs of tiering and priority resolution. All demos are listed on the xref:demos.adoc[Demos] page.
+
 [[governance-pairing]]
 === Governance Pairing: Why Both Are Required
 
@@ -386,6 +388,8 @@ curl -sk "https://${MAAS_URL}/v1/chat/completions" \
 ----
 
 A regular user trying to create an API key with `"subscription": "simulator-pipeline"` gets `invalid_subscription` - the maas-api checks the caller's identity against `spec.owner.users` and rejects anyone not listed.
+
+TIP: See the link:{repo-url}/tree/main/demo/service-account-access[Service Account Access demo] for a full walkthrough deploying an in-cluster app that calls a model with its SA token. Listed on the xref:demos.adoc[Demos] page.
 
 == Appendix
 

--- a/content/modules/ROOT/pages/09-external-oidc.adoc
+++ b/content/modules/ROOT/pages/09-external-oidc.adoc
@@ -357,6 +357,8 @@ curl -sSk -X POST \
     "https://maas.${CLUSTER_DOMAIN}/v1/chat/completions" | jq .
 ----
 
+TIP: See the link:{repo-url}/tree/main/demo/oidc-authentication[OIDC Authentication demo] for a presenter-ready walkthrough with a click-through UI and CLI client. The link:{repo-url}/tree/main/demo/jwks-cache[JWKS Cache demo] proves that JWT signatures are verified locally from cached keys. All demos are listed on the xref:demos.adoc[Demos] page.
+
 == Cleanup
 
 To remove the OIDC configuration and Keycloak:

--- a/content/modules/ROOT/pages/changelog.adoc
+++ b/content/modules/ROOT/pages/changelog.adoc
@@ -14,6 +14,8 @@ Each entry links to its pull request for full details.
 
 * *Platform Upgrade Guide (3.4 -> 3.5)* - End-to-end 10-step MaaS migration guide covering DSC fields, namespace migration, ExternalModel API changes, and dashboard config. (link:{repo-url}/pull/119[#119])
 
+* *Demos Page* - 5 presenter-ready demos for subscription tiering, priority resolution, OIDC authentication, service account access, and JWKS cache validation. Grouped by parent phase with inline TIP pointers from Phase 5 and Phase 9. (link:{repo-url}/pull/152[#152], link:{repo-url}/pull/153[#153])
+
 === Features
 
 * *Phase 9: External OIDC Authentication* - Full Keycloak integration with PostgreSQL backend, realm import, automation script, and 6-check test suite. Supports corporate SSO with JWT claim-based authorization. (link:{repo-url}/pull/98[#98])

--- a/content/modules/ROOT/pages/demos.adoc
+++ b/content/modules/ROOT/pages/demos.adoc
@@ -1,0 +1,75 @@
+= Demos
+
+Hands-on walkthroughs that go deeper on the subscription, access control, and authentication topics covered in xref:05-maas-models.adoc[Phase 5] and xref:09-external-oidc.adoc[Phase 9]. Each scenario has setup/run/cleanup scripts and a presenter talk track.
+
+== Prerequisites
+
+* Complete the guide through xref:05-maas-models.adoc[Phase 5] with at least the simulator model deployed
+* For the OIDC, JWKS Cache, and Subscription Priority demos, also complete xref:09-external-oidc.adoc[Phase 9] (they use Keycloak identities)
+
+Deploy the simulator if not already done:
+
+[source,bash]
+----
+./scripts/setup-maas.sh --model simulator
+----
+
+== Preflight Check
+
+Before presenting, run the preflight script to verify all demos are ready (it creates nothing and applies no YAML):
+
+[source,bash]
+----
+./demo/preflight.sh
+----
+
+Expected result: 16 passed, 0 failed. The script also warms up `maas-api` to absorb its cold-start 500.
+
+== Subscriptions & Access (xref:05-maas-models.adoc[Phase 5])
+
+[cols="2,4,2", options="header"]
+|===
+| Demo | What it shows | Link
+
+| User-Level Rate Limiting
+| Assign MaaSSubscription tiers to groups and individual users. Shows how `priority` resolves overlaps when a user belongs to multiple groups.
+| link:{repo-url}/tree/main/demo/user-level-rate-limiting[README]
+
+| Subscription Priority
+| Proves entitlement is selected, not accumulated. A user in two groups gets the higher-priority tier, not the sum. Per-user subscriptions can cap below group tiers. _Requires xref:09-external-oidc.adoc[Phase 9] (Keycloak)._
+| link:{repo-url}/tree/main/demo/subscription-priority[README]
+
+| Service Account Access
+| In-cluster workload calls a model with its ServiceAccount token via TokenReview. No API key or secret needed. Access per namespace, rate limits per workload.
+| link:{repo-url}/tree/main/demo/service-account-access[README]
+|===
+
+== OIDC & Token Validation (xref:09-external-oidc.adoc[Phase 9])
+
+[cols="2,4,2", options="header"]
+|===
+| Demo | What it shows | Link
+
+| OIDC Authentication
+| Authenticate users from an external OIDC provider (Keycloak) who have no OpenShift account. The `groups` claim in the token selects the subscription. Includes a click-through UI and CLI sample client.
+| link:{repo-url}/tree/main/demo/oidc-authentication[README]
+
+| JWKS Cache
+| Proves JWT signatures are verified locally from a cached JWKS, not per-request to the IdP. Blocks Authorino from reaching Keycloak and shows validation still succeeds.
+| link:{repo-url}/tree/main/demo/jwks-cache[README]
+|===
+
+== Demo Structure
+
+Every demo follows the same pattern:
+
+[source]
+----
+demo/<name>/
+  setup-demo.sh      # Create users, subscriptions, auth policies
+  run-demo.sh        # Repeatable runbook (read-only, safe to re-run)
+  cleanup-demo.sh    # Tear down demo-specific resources
+  README.md          # Full walkthrough with talk track and expected output
+----
+
+TIP: The READMEs document three edge-case behaviors found during demo development: an identity matching two subscriptions gets 403 on the direct-token path, a token with no `groups` claim fails with an opaque `AUTH_FAILURE`, and split-horizon DNS can produce a false pass in the JWKS caching proof if you block the wrong address.


### PR DESCRIPTION
## Summary

- New `demos.adoc` page listing all 5 MaaS demos from PR #152 (rate limiting, subscription priority, OIDC auth, service account access, JWKS cache)
- Each demo gets a description and link to its README in the `demo/` directory
- Added inline TIP boxes in the relevant guide sections so readers discover demos in context:
  - Phase 5 (MaaSSubscription section) - rate limiting + subscription priority demos
  - Phase 5 (ServiceAccount section) - service account access demo
  - Phase 9 (after verification) - OIDC auth + JWKS cache demos
- Nav entry added under new `.Demos` section before Cleanup

Depends on #152 being merged first (the demo/ directory needs to exist for the links to work).

## Test plan

- [ ] Check demos.adoc renders on GitHub Pages
- [ ] Verify demo links point to correct paths in `demo/`
- [ ] Check TIP boxes render in Phase 5 and Phase 9 pages
- [ ] Nav sidebar shows Demos section