### PR TITLE
fix: remove redundant TP note from top of Phase 8

### DIFF
--- a/content/modules/ROOT/pages/08-external-models.adoc
+++ b/content/modules/ROOT/pages/08-external-models.adoc
@@ -4,8 +4,6 @@ NOTE: This phase requires a completed MaaS installation (through xref:04-rhoai-c
 
 WARNING: This phase is NOT compatible with disconnected/air-gapped environments. External models require internet access to reach third-party APIs (OpenAI, Bedrock, Gemini). If you are running in disconnected mode, skip this phase entirely.
 
-NOTE: The RHOAI Dashboard also provides a *Technology Preview* UI for browsing deployed models (local and external) under *Gen AI studio > AI asset endpoints*. The CLI workflow documented below (Steps 1-3) is the fully supported (GA) method. See <<dashboard-ui>> for the Dashboard UI walkthrough.
-
 The `ExternalModel` CRD lets you expose third-party LLM APIs (OpenAI, AWS Bedrock, Google Gemini, Azure OpenAI, etc.) through the MaaS gateway. External models get the same API key management, authentication, rate limiting, and usage tracking as locally-served models - your consumers use a single gateway endpoint regardless of where the model runs.
 
 TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).


### PR DESCRIPTION
## Summary
- Removed the Technology Preview NOTE from the top of Phase 8 (External Models)
- The top of the page covers the GA CLI workflow, so the TP callout there was distracting
- The Dashboard UI section already has the IMPORTANT TP callout and the section title itself says "Technology Preview"

## Test plan
- [ ] Render locally with Antora and check Phase 8 top section is clean
- [ ] Dashboard UI section still has the TP disclaimer