### PR TITLE
demo: corporate scenario - division-level model governance

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -35,6 +35,7 @@
 
 .Demos
 * xref:demos.adoc[Demos]
+* xref:corporate-scenario.adoc[Corporate Scenario]
 
 .Cleanup
 * xref:09-cleanup.adoc[Cleanup & Teardown]

--- a/content/modules/ROOT/pages/corporate-scenario.adoc
+++ b/content/modules/ROOT/pages/corporate-scenario.adoc
@@ -1,0 +1,391 @@
+= Corporate Scenario: Division-Level Model Governance
+
+A realistic enterprise demo showing how a CIO rolls out {maas} across an organization. Three divisions get differentiated access to on-prem and cloud models, each with appropriate token budgets - all enforced by the platform through policy, not code.
+
+This is the recommended starting point when you want to show {maas} to stakeholders who care about governance, cost control, and multi-team model access.
+
+TIP: All file paths and `oc apply` commands in this guide are relative to the link:{repo-url}[rhoai-maas-guide] repository root. Make sure you have cloned it and are working from its root directory (see xref:index.adoc#_getting_started[Getting Started]).
+
+== The scenario
+
+A CIO at a mid-size company assigns three divisions access to AI models. Each division has different needs and different budgets:
+
+[cols="2,1,1,1", options="header"]
+|===
+| Division | General Purpose (on-prem) | Code Model - DeepSeek R2 (on-prem) | Multimodal - Gemini Flash (cloud)
+
+| **Sales**
+| Yes (500 tok/min)
+| No
+| No
+
+| **Engineering**
+| Yes (500 tok/min)
+| Yes (1000 tok/min)
+| Yes (20 tok/min)
+
+| **Products**
+| Yes (500 tok/min)
+| Yes (500 tok/min)
+| No
+|===
+
+The cloud model is expensive, so only Engineering gets access - and with a tight cap. Engineering gets higher limits on the code model because they use it more heavily. Sales only needs the general purpose chatbot.
+
+Each division gets ONE subscription covering all their allowed models. One API key per user, full access to everything their division is entitled to.
+
+== Prerequisites
+
+* Complete the guide through xref:05-maas-models.adoc[Phase 5] with at least the simulator model deployed
+* `oc` logged into the cluster as cluster-admin
+* `htpasswd`, `curl`, `jq` available on PATH
+
+Deploy the simulator if not already done:
+
+[source,bash]
+----
+./scripts/setup-maas.sh --model simulator
+----
+
+== Architecture
+
+=== Models
+
+All three models are backed by the CPU-only simulator (`llm-d-inference-sim`) - no GPU required. The namespace appears in the URL path, which is how you visually distinguish on-prem from cloud.
+
+[cols="2,2,1,2", options="header"]
+|===
+| Model | Namespace | Type | Served name
+
+| facebook-opt-125m-simulated
+| `llm`
+| On-prem (existing)
+| `facebook/opt-125m`
+
+| deepseek-r2-llmd
+| `llm`
+| On-prem (new)
+| `deepseek/deepseek-r2`
+
+| gemini-flash-cloud
+| `cloud-models`
+| Cloud (new)
+| `google/gemini-flash`
+|===
+
+URL examples:
+
+* On-prem: `\https://maas.<domain>/llm/deepseek-r2-llmd/v1/chat/completions`
+* Cloud: `\https://maas.<domain>/cloud-models/gemini-flash-cloud/v1/chat/completions`
+
+=== Users and groups
+
+Six users across three groups, created via htpasswd identity provider (`corp-demo`):
+
+[cols="2,3,2", options="header"]
+|===
+| Group | Users | Division
+
+| `corp-sales`
+| `sales-1`, `sales-2`
+| Sales
+
+| `corp-engineering`
+| `eng-1`, `eng-2`
+| Engineering
+
+| `corp-products`
+| `prod-1`, `prod-2`
+| Products
+|===
+
+=== MaaS CRDs
+
+The governance is expressed through three CRD types:
+
+**MaaSAuthPolicy** controls _who can see which models_:
+
+* `corp-deepseek-access` - grants `corp-engineering` + `corp-products` access to `deepseek-r2-llmd`
+* `corp-cloud-access` - grants `corp-engineering` ONLY access to `gemini-flash-cloud`
+* The existing `simulator-access` already grants `system:authenticated` access to the general model
+
+**MaaSSubscription** controls _how much each division can consume_:
+
+[cols="2,3,3", options="header"]
+|===
+| Subscription | Division | Models and limits
+
+| `corp-sales`
+| Sales
+| general: 500 tok/min
+
+| `corp-engineering`
+| Engineering
+| general: 500 tok/min, deepseek: 1000 tok/min, gemini: 20 tok/min
+
+| `corp-products`
+| Products
+| general: 500 tok/min, deepseek: 500 tok/min
+|===
+
+All subscriptions use priority 30 to outrank the shipped `simulator-premium` (priority 20) which targets `system:authenticated`.
+
+**MaaSModelRef** registers each model with the MaaS control plane. Must be in the same namespace as its `LLMInferenceService`.
+
+== Step 1: Setup
+
+The setup script creates everything: users, groups, models, and governance CRDs.
+
+[source,bash]
+----
+cd demo/corporate-scenario
+./setup-demo.sh
+----
+
+Set `DEMO_PASSWORD` to skip the interactive prompt:
+
+[source,bash]
+----
+DEMO_PASSWORD='redhat123' ./setup-demo.sh
+----
+
+The script:
+
+. Checks that the general-purpose model (`facebook-opt-125m-simulated`) is deployed and Ready
+. Creates 6 htpasswd users and adds the `corp-demo` identity provider (additive, does not touch existing providers)
+. Creates 3 OpenShift groups (`corp-sales`, `corp-engineering`, `corp-products`)
+. Deploys the `cloud-models` namespace with gateway labels
+. Deploys 2 new LLMInferenceService resources (simulator-backed, CPU-only)
+. Waits for simulator pods to start Running
+. Applies MaaSModelRef, MaaSAuthPolicy, and MaaSSubscription resources
+. Waits for both MaaSModelRefs to reach Ready
+. Prints a summary of all resources
+
+NOTE: The oauth pods restart after adding the identity provider. Wait about a minute before trying to log in as the demo users.
+
+=== What gets created
+
+After setup completes, verify the state:
+
+[source,bash]
+----
+# Models registered with MaaS
+oc get maasmodelref -A
+
+# Subscriptions
+oc get maassubscription -n models-as-a-service
+
+# Auth policies
+oc get maasauthpolicy -n models-as-a-service
+
+# Simulator pods
+oc get pods -n llm -l app.kubernetes.io/part-of=llminferenceservice
+oc get pods -n cloud-models -l app.kubernetes.io/part-of=llminferenceservice
+----
+
+== Step 2: Run the demo
+
+[source,bash]
+----
+DEMO_PASSWORD='redhat123' ./run-demo.sh
+----
+
+The script logs in as one user per division (`sales-1`, `eng-1`, `prod-1`), mints an API key, and tests:
+
+* **Model visibility** - which models each user can see in the catalog
+* **Inference on allowed models** - sends 8 requests per model, shows tokens consumed
+* **Denied model access** - proves 403 for unauthorized models
+* **Rate limiting** - eng-1's 20 tok/min cloud limit triggers within the burst
+
+=== Expected output
+
+[source]
+----
+=== sales-1 (corp-sales) ===
+  Visible models:
+    publishers/llm/models/facebook/opt-125m
+  Resolved subscription: corp-sales
+  General purpose (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (22 tokens)
+  DeepSeek R2 (on-prem):
+    deepseek-r2-llmd: 403 Forbidden (expected)
+  Gemini Flash (cloud):
+    gemini-flash-cloud: 403 Forbidden (expected)
+
+=== eng-1 (corp-engineering) ===
+  Visible models:
+    publishers/cloud-models/models/google/gemini-flash
+    publishers/llm/models/deepseek/deepseek-r2
+    publishers/llm/models/facebook/opt-125m
+  Resolved subscription: corp-engineering
+  General purpose (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (21 tokens)
+  DeepSeek R2 (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (27 tokens)
+  Gemini Flash (cloud) - expect rate limiting at ~20 tokens/min:
+    8 requests -> 6 ok / 2 rate-limited / 0 other  (20 tokens)
+
+=== prod-1 (corp-products) ===
+  Visible models:
+    publishers/llm/models/deepseek/deepseek-r2
+    publishers/llm/models/facebook/opt-125m
+  Resolved subscription: corp-products
+  General purpose (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (29 tokens)
+  DeepSeek R2 (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (32 tokens)
+  Gemini Flash (cloud):
+    gemini-flash-cloud: 403 Forbidden (expected)
+----
+
+Key observations:
+
+* **sales-1** sees only one model, gets 403 on the other two - Sales has no code model or cloud access
+* **eng-1** sees all three models, on-prem requests sail through, cloud model hits rate limiting at ~20 tokens - the CIO's cost control in action
+* **prod-1** sees two models (no cloud), both on-prem models work fine
+
+== Step 3: Verify
+
+The automated verification script runs 15 tests covering access control, rate limiting, key multiplication, and config drift.
+
+[source,bash]
+----
+DEMO_PASSWORD='redhat123' ./verify-scenario.sh
+----
+
+=== What it tests
+
+[cols="2,4", options="header"]
+|===
+| Test suite | What it proves
+
+| Access control (9 tests)
+| Full 3x3 matrix of users x models: 6 should allow (200), 3 should deny (403)
+
+| Rate limiting (1 test)
+| eng-1 hits 429 on the cloud model within 15 requests
+
+| Key multiplication (1 test)
+| eng-2 mints two keys, exhausts quota with key-1, verifies key-2 is also rate-limited immediately. Proves rate limits are per subscription, not per credential.
+
+| Config drift (4 tests)
+| Subscription token limits match expected values (catches manual edits or drift)
+|===
+
+Expected result:
+
+[source]
+----
+Results: 15 passed / 0 failed / 0 skipped (of 15)
+----
+
+== Step 4: Cleanup
+
+[source,bash]
+----
+./cleanup-demo.sh
+----
+
+Removes all demo resources (subscriptions, auth policies, MaaSModelRefs, LLMInferenceServices, namespace, groups, users, IDP). The existing general-purpose model is not touched.
+
+== Talk track
+
+Use this flow when presenting the scenario to stakeholders.
+
+=== 1. Start with the CIO's problem
+
+Three divisions, each with different needs. Sales wants a chatbot. Engineering wants code assistance plus cloud model access. Products needs the code model for sprint reviews. How do you give each team exactly what they need - no more, no less?
+
+=== 2. Show the manifests
+
+Open `auth-policies.yaml` and `subscriptions.yaml`. Point out how `MaaSAuthPolicy` controls visibility (who can see which models) and `MaaSSubscription` controls consumption (how much each group can use). The combination is the full governance picture.
+
+One subscription per division, covering all their models with per-model limits. One key, full access.
+
+=== 3. Show the model catalog per user
+
+Log in to the {rhoai} Dashboard as each division user:
+
+* **sales-1** sees one model
+* **prod-1** sees two models
+* **eng-1** sees all three models
+
+The platform hides what you cannot access. There is no "request access" button for models outside your policy.
+
+=== 4. Run the burst
+
+Point out that Engineering hits rate limiting on the cloud model (20 tokens/min) but not on the on-prem models. That is the CIO's intent: cloud is expensive, keep it tight. On-prem is cheaper, give them room.
+
+=== 5. Try denied access
+
+Sales calling the DeepSeek model gets a clean 403. Not a 500, not a timeout - the platform knows the policy and enforces it before the request reaches the model.
+
+=== 6. Key multiplication does not help
+
+Run `verify-scenario.sh` and point at the key multiplication test. Minting a second API key does not reset the quota. The rate limit is per subscription, not per credential.
+
+=== 7. Change a limit live
+
+Patch a subscription to show that governance is policy, not deployment:
+
+[source,bash]
+----
+oc patch maassubscription corp-engineering -n models-as-a-service --type=json \
+  -p '[{"op":"replace","path":"/spec/modelRefs/2/tokenRateLimits/0/limit","value":5000}]'
+----
+
+Re-run `./run-demo.sh` - Engineering no longer hits rate limiting on the cloud model. No redeployment, no restart, instant policy change.
+
+Restore the original limit:
+
+[source,bash]
+----
+oc patch maassubscription corp-engineering -n models-as-a-service --type=json \
+  -p '[{"op":"replace","path":"/spec/modelRefs/2/tokenRateLimits/0/limit","value":20}]'
+----
+
+== How the governance works
+
+=== MaaSAuthPolicy - who can see what
+
+Each `MaaSAuthPolicy` grants access to one or more models for specific groups or users. If a user is not covered by any auth policy for a model, the model does not appear in their catalog and API calls return 403.
+
+The existing `simulator-access` policy grants `system:authenticated` access to the general purpose model. The corporate policies add group-specific access to the two new models without touching the existing setup.
+
+=== MaaSSubscription - how much they can use
+
+Each division gets ONE subscription covering all their allowed models, with per-model token rate limits. When a user mints an API key, the platform resolves the highest-priority subscription they match and attaches it.
+
+All corporate subscriptions use priority 30 to outrank the shipped `simulator-premium` (priority 20, targeting `system:authenticated`). Without this, the shipped tier would win and the corporate limits would not apply.
+
+=== Priority resolution
+
+* Subscriptions are **selected**, not accumulated. A user gets ONE subscription - the highest priority match.
+* A single subscription can cover multiple models with different limits per model.
+* Minting multiple API keys does not multiply the quota. Rate limits are per subscription, not per credential.
+* Priority 30 for all corporate subscriptions means they win over shipped defaults (priority 10 and 20).
+
+=== MaaSModelRef governance pairing
+
+A `MaaSModelRef` reaches Ready only when BOTH a `MaaSSubscription` AND a `MaaSAuthPolicy` reference it. This is the governance pairing - without both, the model is not accessible through the MaaS control plane.
+
+== Files
+
+[source]
+----
+demo/corporate-scenario/
+  README.md              # quick reference
+  setup-demo.sh          # create users, groups, models, MaaS CRDs
+  run-demo.sh            # interactive demo - access + rate limits per division
+  verify-scenario.sh     # automated verification (15 tests)
+  cleanup-demo.sh        # tear down all demo resources
+  manifests/
+    namespace-cloud-models.yaml
+    model-deepseek-r2.yaml
+    model-gemini-flash.yaml
+    maas-model-deepseek-r2.yaml
+    maas-model-gemini-flash.yaml
+    auth-policies.yaml
+    subscriptions.yaml
+  screenshots/           # captured after setup on a live cluster
+----

--- a/content/modules/ROOT/pages/demos.adoc
+++ b/content/modules/ROOT/pages/demos.adoc
@@ -42,6 +42,10 @@ Expected result: 16 passed, 0 failed. The script also warms up `maas-api` to abs
 | Service Account Access
 | In-cluster workload calls a model with its ServiceAccount token via TokenReview. No API key or secret needed. Access per namespace, rate limits per workload.
 | link:{repo-url}/tree/main/demo/service-account-access[README]
+
+| Corporate Scenario
+| Division-level model governance: three divisions (Sales, Engineering, Products), on-prem + cloud models, differentiated access and rate limits. Demonstrates the full CIO-to-deployment policy lifecycle. *Recommended starting point for enterprise demos.*
+| xref:corporate-scenario.adoc[Full Guide] / link:{repo-url}/tree/main/demo/corporate-scenario[Scripts]
 |===
 
 == OIDC & Token Validation (xref:09-external-oidc.adoc[Phase 9])

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # MaaS demos
 
-Five demos showing how Models as a Service governs access to a model: **who may
+Six demos showing how Models as a Service governs access to a model: **who may
 call it**, and **how much they may consume**.
 
 Each demo runs against a cluster with MaaS deployed (`./scripts/setup-maas.sh`
@@ -15,6 +15,7 @@ runbook and a talk track, and a teardown script.
 | [subscription-priority](subscription-priority/) | That entitlement is selected rather than accumulated: a user in two groups worth 10000 and 20000 tokens/hour gets one of those tiers, not 30000 — and a subscription naming them individually can cap them below both. |
 | [oidc-authentication](oidc-authentication/) | Authenticating with an identity from your own identity provider — no OpenShift account required — with the token's `groups` claim selecting the subscription. Includes a click-through UI and a CLI sample client. |
 | [service-account-access](service-account-access/) | An application calling a model with its own Kubernetes ServiceAccount token. No API key to distribute, no credential to rotate. Access granted per namespace, rate limits set per workload. |
+| [corporate-scenario](corporate-scenario/) | A realistic CIO assignment: three divisions (Sales, Engineering, Products) with differentiated access to on-prem and cloud models, each with appropriate token budgets. Full governance lifecycle from policy to verification. |
 | [jwks-cache](jwks-cache/) | That JWT signatures are genuinely verified, and that verification happens locally against a cached copy of the issuer's public keys rather than a call to the identity provider on every request. |
 
 ## Readiness check

--- a/demo/corporate-scenario/README.md
+++ b/demo/corporate-scenario/README.md
@@ -1,0 +1,218 @@
+# Corporate scenario: division-level model governance
+
+> **Full step-by-step guide**: see the [Corporate Scenario page](../../content/modules/ROOT/pages/corporate-scenario.adoc) in the Antora documentation.
+
+A realistic scenario showing how a CIO might roll out MaaS across an organization.
+Three divisions get differentiated access to a mix of on-prem and cloud models,
+each with appropriate token budgets.
+
+This goes beyond the "free tier / premium tier" pattern and into how you would
+actually structure model governance for a company: who can see what, who pays
+for what, and how the platform enforces it all through policy.
+
+Requires MaaS deployed with the `simulator` model - from the repository root,
+`./scripts/setup-maas.sh --model simulator`.
+
+## The scenario
+
+A CIO assigns three divisions access to AI models:
+
+| Division | On-prem general purpose | On-prem code model (DeepSeek R2) | Cloud model (Gemini Flash) |
+|----------|------------------------|----------------------------------|----------------------------|
+| **Sales** | Yes (500 tok/min) | No | No |
+| **Engineering** | Yes (500 tok/min) | Yes (1000 tok/min) | Yes (20 tok/min) |
+| **Products** | Yes (500 tok/min) | Yes (500 tok/min) | No |
+
+The cloud model is expensive, so only Engineering gets access - and with a tight
+cap (20 tokens/min triggers rate limiting within a few requests). Engineering gets
+higher limits on the code model because they use it more heavily. Sales only needs
+the general purpose model.
+
+Each division gets ONE subscription covering all their allowed models. This means
+a single API key gives a user access to everything their division is entitled to.
+
+## Models
+
+All three models are backed by the CPU-only simulator - no GPU required.
+
+| Model | Namespace | Type | Served name |
+|-------|-----------|------|-------------|
+| facebook-opt-125m-simulated | llm | On-prem (existing) | facebook/opt-125m |
+| deepseek-r2-llmd | llm | On-prem | deepseek/deepseek-r2 |
+| gemini-flash-cloud | cloud-models | Cloud | google/gemini-flash |
+
+The namespace shows up in the URL path, which is how you visually distinguish
+on-prem from cloud:
+- On-prem: `https://maas.<domain>/llm/deepseek-r2-llmd/v1/chat/completions`
+- Cloud: `https://maas.<domain>/cloud-models/gemini-flash-cloud/v1/chat/completions`
+
+## Users
+
+Six htpasswd users across three groups (IDP name: `corp-demo`):
+
+| Group | Users | Division |
+|-------|-------|----------|
+| corp-sales | sales-1, sales-2 | Sales |
+| corp-engineering | eng-1, eng-2 | Engineering |
+| corp-products | prod-1, prod-2 | Products |
+
+## Run it
+
+```bash
+cd demo/corporate-scenario
+
+# 1. Create users, groups, models, and MaaS governance CRDs
+./setup-demo.sh
+
+# 2. Show it working - access control + rate limits per division
+./run-demo.sh
+
+# 3. Automated verification (access matrix, rate limits, key multiplication)
+./verify-scenario.sh
+```
+
+Representative output from `run-demo.sh`:
+
+```
+=== sales-1 (corp-sales) ===
+  Visible models:
+    publishers/llm/models/facebook/opt-125m
+  Resolved subscription: corp-sales
+  General purpose (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (22 tokens)
+  DeepSeek R2 (on-prem):
+    deepseek-r2-llmd: 403 Forbidden (expected)
+  Gemini Flash (cloud):
+    gemini-flash-cloud: 403 Forbidden (expected)
+
+=== eng-1 (corp-engineering) ===
+  Visible models:
+    publishers/cloud-models/models/google/gemini-flash
+    publishers/llm/models/deepseek/deepseek-r2
+    publishers/llm/models/facebook/opt-125m
+  Resolved subscription: corp-engineering
+  General purpose (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (21 tokens)
+  DeepSeek R2 (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (27 tokens)
+  Gemini Flash (cloud) - expect rate limiting at ~20 tokens/min:
+    8 requests -> 6 ok / 2 rate-limited / 0 other  (20 tokens)
+
+=== prod-1 (corp-products) ===
+  Visible models:
+    publishers/llm/models/deepseek/deepseek-r2
+    publishers/llm/models/facebook/opt-125m
+  Resolved subscription: corp-products
+  General purpose (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (29 tokens)
+  DeepSeek R2 (on-prem):
+    8 requests -> 8 ok / 0 rate-limited / 0 other  (32 tokens)
+  Gemini Flash (cloud):
+    gemini-flash-cloud: 403 Forbidden (expected)
+```
+
+Tear down with `./cleanup-demo.sh`.
+
+## Talk track
+
+1. **Start with the CIO's problem.** Three divisions, each with different needs.
+   Sales wants a chatbot, Engineering wants code assistance plus cloud model access,
+   Products needs the code model for sprint reviews. How do you give each team
+   exactly what they need - no more, no less?
+
+2. **Show the manifests.** Open `auth-policies.yaml` and `subscriptions.yaml`.
+   Point out how `MaaSAuthPolicy` controls visibility (who can see which models)
+   and `MaaSSubscription` controls consumption (how much each group can use).
+   The combination is the full governance picture.
+
+3. **Show the model catalog per user.** Log in to the RHOAI Dashboard as each
+   division user. Sales sees one model. Products sees two. Engineering sees all
+   three. The platform hides what you cannot access - there is no "request access"
+   button for models outside your policy.
+
+   <!-- screenshots go here once captured -->
+
+4. **Run the burst.** Point out that Engineering hits rate limiting on the cloud
+   model (50 tokens/min) but not on the on-prem models. That is the CIO's intent:
+   cloud is expensive, keep it tight. On-prem is cheaper, give them room.
+
+5. **Try denied access.** Sales calling the DeepSeek model gets a clean 403. Not a
+   500, not a timeout - the platform knows the policy and enforces it before the
+   request reaches the model.
+
+6. **Key multiplication does not help.** Run `verify-scenario.sh` and point at
+   the key multiplication test. Minting a second API key does not reset the quota.
+   The rate limit is per subscription, not per credential.
+
+7. **Change a limit live.** Patch a subscription to show that governance is policy,
+   not deployment:
+
+   ```bash
+   oc patch maassubscription corp-eng-cloud -n models-as-a-service --type=merge \
+     -p '{"spec":{"modelRefs":[{"name":"gemini-flash-cloud","namespace":"cloud-models","tokenRateLimits":[{"limit":5000,"window":"1m"}]}]}}'
+   ```
+
+   Re-run `./run-demo.sh` - Engineering no longer hits rate limiting on the cloud
+   model. No redeployment, no restart, instant policy change.
+
+## How it works
+
+### MaaSAuthPolicy - who can see what
+
+Each `MaaSAuthPolicy` grants access to one or more models for specific groups or
+users. If a user is not covered by any auth policy for a model, the model does not
+appear in their catalog and API calls return 403.
+
+The existing `simulator-access` policy grants `system:authenticated` access to the
+general purpose model. The corporate policies add group-specific access to the two
+new models without touching the existing setup.
+
+### MaaSSubscription - how much they can use
+
+Each division gets ONE `MaaSSubscription` covering all their allowed models,
+with per-model token rate limits. When a user mints an API key, the platform
+resolves the highest-priority subscription they match and attaches it - so one
+key gives access to all models in the subscription.
+
+All corporate subscriptions use priority 30 to outrank the shipped
+`simulator-premium` (priority 20, targeting `system:authenticated`). Without this,
+the shipped tier would win and the corporate limits would not apply.
+
+### Priority resolution
+
+- Subscriptions are **selected**, not accumulated. A user gets ONE subscription -
+  the highest priority match.
+- A single subscription can cover multiple models with different limits per model.
+- Minting multiple API keys does not multiply the quota. Rate limits are per
+  subscription, not per credential.
+- Priority 30 for all corporate subscriptions means they win over shipped defaults
+  (priority 10 and 20).
+
+## What the verify script checks
+
+| Test | What it proves |
+|------|----------------|
+| Access control (9 tests) | Full 3x3 matrix: 6 allow, 3 deny |
+| Rate limiting (1 test) | eng-1 hits 429 on the 20 tok/min cloud model |
+| Key multiplication (1 test) | Second key shares the first key's exhausted quota |
+| Config drift (4 tests) | Subscription limits match expected values |
+
+## Files
+
+```
+demo/corporate-scenario/
+  README.md              # this file
+  setup-demo.sh          # create users, groups, models, MaaS CRDs
+  run-demo.sh            # interactive demo - access + rate limits per division
+  verify-scenario.sh     # automated verification (15 tests)
+  cleanup-demo.sh        # tear down all demo resources
+  manifests/
+    namespace-cloud-models.yaml
+    model-deepseek-r2.yaml
+    model-gemini-flash.yaml
+    maas-model-deepseek-r2.yaml
+    maas-model-gemini-flash.yaml
+    auth-policies.yaml
+    subscriptions.yaml
+  screenshots/           # captured after setup on a live cluster
+```

--- a/demo/corporate-scenario/cleanup-demo.sh
+++ b/demo/corporate-scenario/cleanup-demo.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Remove everything setup-demo.sh created.
+#
+# Deletes CRs before namespaces to avoid finalizer blocks.
+# Leaves the existing general-purpose model (facebook-opt-125m-simulated) untouched.
+#
+# Usage:
+#   ./cleanup-demo.sh
+#   OAUTH_BACKUP=/path/oauth-cluster.backup.yaml ./cleanup-demo.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+USERS_SALES=(sales-1 sales-2)
+USERS_ENG=(eng-1 eng-2)
+USERS_PROD=(prod-1 prod-2)
+ALL_USERS=("${USERS_SALES[@]}" "${USERS_ENG[@]}" "${USERS_PROD[@]}")
+
+GROUP_SALES=corp-sales
+GROUP_ENG=corp-engineering
+GROUP_PROD=corp-products
+
+SECRET=corp-demo-htpasswd
+IDP=corp-demo
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+echo "==> Removing subscriptions"
+oc delete -f "${DIR}/manifests/subscriptions.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing auth policies"
+oc delete -f "${DIR}/manifests/auth-policies.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing MaaSModelRef resources"
+oc delete -f "${DIR}/manifests/maas-model-deepseek-r2.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+oc delete -f "${DIR}/manifests/maas-model-gemini-flash.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing LLMInferenceService resources"
+oc delete -f "${DIR}/manifests/model-deepseek-r2.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+oc delete -f "${DIR}/manifests/model-gemini-flash.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing cloud-models namespace"
+oc delete -f "${DIR}/manifests/namespace-cloud-models.yaml" --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing groups"
+for grp in $GROUP_SALES $GROUP_ENG $GROUP_PROD; do
+  oc delete group "$grp" --ignore-not-found 2>&1 | sed 's/^/  /'
+done
+
+echo "==> Removing users and identities"
+for u in "${ALL_USERS[@]}"; do
+  oc delete user "$u" --ignore-not-found >/dev/null 2>&1
+  oc delete identity "${IDP}:${u}" --ignore-not-found >/dev/null 2>&1
+done
+echo "  users and identities removed"
+
+echo "==> Removing htpasswd secret"
+oc delete secret "$SECRET" -n openshift-config --ignore-not-found 2>&1 | sed 's/^/  /'
+
+echo "==> Removing the ${IDP} identity provider"
+if [ -n "${OAUTH_BACKUP:-}" ] && [ -f "$OAUTH_BACKUP" ]; then
+  oc apply -f "$OAUTH_BACKUP" 2>&1 | sed 's/^/  /'
+else
+  REMAINING=$(oc get oauth cluster -o json \
+    | jq -c "[.spec.identityProviders[]? | select(.name != \"${IDP}\")]")
+  oc patch oauth cluster --type=merge -p "{\"spec\":{\"identityProviders\":${REMAINING}}}" 2>&1 | sed 's/^/  /'
+fi
+
+echo
+echo "Identity providers now:"
+oc get oauth cluster -o jsonpath='{range .spec.identityProviders[*]}  {.name} ({.type}){"\n"}{end}'
+echo
+echo "Cleanup complete. The existing general-purpose model was not touched."

--- a/demo/corporate-scenario/manifests/auth-policies.yaml
+++ b/demo/corporate-scenario/manifests/auth-policies.yaml
@@ -1,0 +1,45 @@
+# Corporate scenario: group-based model access control
+#
+# Access matrix:
+#   facebook-opt-125m-simulated  Sales + Engineering + Products  (existing simulator-access covers this)
+#   deepseek-r2-llmd             Engineering + Products
+#   gemini-flash-cloud           Engineering only
+#
+# The general model (facebook-opt-125m-simulated) already has a MaaSAuthPolicy
+# granting system:authenticated, so corporate users inherit access to it. Only
+# the two new models need explicit policies.
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: corp-deepseek-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Corporate - DeepSeek R2 Access"
+    openshift.io/description: "Engineering and Products divisions may call DeepSeek R2"
+spec:
+  modelRefs:
+    - name: deepseek-r2-llmd
+      namespace: llm
+  subjects:
+    groups:
+      - name: corp-engineering
+      - name: corp-products
+    users: []
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: corp-cloud-access
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Corporate - Gemini Flash (Cloud) Access"
+    openshift.io/description: "Engineering division only - cloud model access is restricted"
+spec:
+  modelRefs:
+    - name: gemini-flash-cloud
+      namespace: cloud-models
+  subjects:
+    groups:
+      - name: corp-engineering
+    users: []

--- a/demo/corporate-scenario/manifests/maas-model-deepseek-r2.yaml
+++ b/demo/corporate-scenario/manifests/maas-model-deepseek-r2.yaml
@@ -1,0 +1,12 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: deepseek-r2-llmd
+  namespace: llm
+  annotations:
+    openshift.io/display-name: "DeepSeek R2 (On-Prem)"
+    openshift.io/description: "On-prem code and reasoning model served via llm-d (simulator)"
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: deepseek-r2-llmd

--- a/demo/corporate-scenario/manifests/maas-model-gemini-flash.yaml
+++ b/demo/corporate-scenario/manifests/maas-model-gemini-flash.yaml
@@ -1,0 +1,12 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: gemini-flash-cloud
+  namespace: cloud-models
+  annotations:
+    openshift.io/display-name: "Gemini Flash (Cloud)"
+    openshift.io/description: "Cloud-hosted multimodal model (simulator for demo)"
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: gemini-flash-cloud

--- a/demo/corporate-scenario/manifests/model-deepseek-r2.yaml
+++ b/demo/corporate-scenario/manifests/model-deepseek-r2.yaml
@@ -1,0 +1,65 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: deepseek-r2-llmd
+  namespace: llm
+spec:
+  model:
+    uri: hf://sshleifer/tiny-gpt2
+    name: deepseek/deepseek-r2
+  replicas: 1
+  router:
+    route: {}
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
+  template:
+    containers:
+      - name: main
+        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+        imagePullPolicy: Always
+        command: ["/app/llm-d-inference-sim"]
+        args:
+          - --port
+          - "8000"
+          - --model
+          - deepseek/deepseek-r2
+          - --mode
+          - random
+          - --ssl-certfile
+          - /var/run/kserve/tls/tls.crt
+          - --ssl-keyfile
+          - /var/run/kserve/tls/tls.key
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+        ports:
+          - name: https
+            containerPort: 8000
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: https
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: https
+            scheme: HTTPS
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/demo/corporate-scenario/manifests/model-gemini-flash.yaml
+++ b/demo/corporate-scenario/manifests/model-gemini-flash.yaml
@@ -1,0 +1,65 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: gemini-flash-cloud
+  namespace: cloud-models
+spec:
+  model:
+    uri: hf://sshleifer/tiny-gpt2
+    name: google/gemini-flash
+  replicas: 1
+  router:
+    route: {}
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
+  template:
+    containers:
+      - name: main
+        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+        imagePullPolicy: Always
+        command: ["/app/llm-d-inference-sim"]
+        args:
+          - --port
+          - "8000"
+          - --model
+          - google/gemini-flash
+          - --mode
+          - random
+          - --ssl-certfile
+          - /var/run/kserve/tls/tls.crt
+          - --ssl-keyfile
+          - /var/run/kserve/tls/tls.key
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+        ports:
+          - name: https
+            containerPort: 8000
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: https
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: https
+            scheme: HTTPS
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/demo/corporate-scenario/manifests/namespace-cloud-models.yaml
+++ b/demo/corporate-scenario/manifests/namespace-cloud-models.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloud-models
+  labels:
+    opendatahub.io/generated-namespace: "true"
+    maas.opendatahub.io/gateway-access: "true"

--- a/demo/corporate-scenario/manifests/subscriptions.yaml
+++ b/demo/corporate-scenario/manifests/subscriptions.yaml
@@ -1,0 +1,86 @@
+# Corporate scenario: one subscription per division
+#
+# Each division gets a single subscription covering all models they can access,
+# with per-model token rate limits. This means one API key per user gives access
+# to all their models - no need to mint separate keys per model.
+#
+# Priority 30 outranks the shipped simulator-free (10) and simulator-premium (20)
+# subscriptions, both of which target system:authenticated.
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: corp-sales
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Corporate - Sales Division"
+    openshift.io/description: "Sales: general purpose model only, 500 tokens/min"
+spec:
+  owner:
+    groups:
+      - name: corp-sales
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 500
+          window: 1m
+  priority: 30
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: corp-engineering
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Corporate - Engineering Division"
+    openshift.io/description: "Engineering: all models, highest on-prem limits, capped cloud"
+spec:
+  owner:
+    groups:
+      - name: corp-engineering
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 500
+          window: 1m
+    - name: deepseek-r2-llmd
+      namespace: llm
+      tokenRateLimits:
+        - limit: 1000
+          window: 1m
+    - name: gemini-flash-cloud
+      namespace: cloud-models
+      tokenRateLimits:
+        - limit: 20
+          window: 1m
+  priority: 30
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: corp-products
+  namespace: models-as-a-service
+  annotations:
+    openshift.io/display-name: "Corporate - Products Division"
+    openshift.io/description: "Products: general purpose + code model, 500 tokens/min each"
+spec:
+  owner:
+    groups:
+      - name: corp-products
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: llm
+      tokenRateLimits:
+        - limit: 500
+          window: 1m
+    - name: deepseek-r2-llmd
+      namespace: llm
+      tokenRateLimits:
+        - limit: 500
+          window: 1m
+  priority: 30

--- a/demo/corporate-scenario/run-demo.sh
+++ b/demo/corporate-scenario/run-demo.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Corporate scenario: demonstrate differentiated model access and rate limits.
+#
+# Runs one user per division (sales-1, eng-1, prod-1) through:
+#   1. Model visibility - which models each division can see
+#   2. Inference on allowed models - proving access + showing rate limits
+#   3. Denied model access - proving 403 for unauthorized models
+#
+# Usage:
+#   ./run-demo.sh [requests_per_model]       # default 8
+#   DEMO_PASSWORD='...' ./run-demo.sh 12
+set -uo pipefail
+
+N=${1:-8}
+
+# Models: plain variables instead of associative arrays (bash 3 compat)
+GENERAL_RESOURCE="facebook-opt-125m-simulated"
+GENERAL_SERVED="facebook/opt-125m"
+GENERAL_NS="llm"
+
+DEEPSEEK_RESOURCE="deepseek-r2-llmd"
+DEEPSEEK_SERVED="deepseek/deepseek-r2"
+DEEPSEEK_NS="llm"
+
+GEMINI_RESOURCE="gemini-flash-cloud"
+GEMINI_SERVED="google/gemini-flash"
+GEMINI_NS="cloud-models"
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+API=$(oc whoami --show-server)
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+H="https://maas.${CLUSTER_DOMAIN}"
+
+if [ -z "${DEMO_PASSWORD:-}" ]; then
+  read -rsp "Password for demo users: " DEMO_PASSWORD; echo
+fi
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+echo "MaaS endpoint: $H"
+echo "Requests per model: $N"
+
+# Warm-up: absorb stale-connection 500
+curl -sk --max-time 30 -o /dev/null -H "Authorization: Bearer $(oc whoami -t)" \
+  "${H}/maas-api/v1/models" 2>/dev/null || true
+
+fire_burst() {
+  local key="$1" endpoint="$2" model_served="$3" count="$4"
+  local ok=0 lim=0 other=0 tok=0
+  for _ in $(seq 1 "$count"); do
+    code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+      -H "Authorization: Bearer $key" -H "Content-Type: application/json" -X POST \
+      -d "{\"model\":\"${model_served}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4}" \
+      "$endpoint")
+    if [ "$code" = "500" ]; then
+      code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+        -H "Authorization: Bearer $key" -H "Content-Type: application/json" -X POST \
+        -d "{\"model\":\"${model_served}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4}" \
+        "$endpoint")
+    fi
+    case "$code" in
+      200) ok=$((ok+1)); tok=$((tok + $(jq -r '.usage.total_tokens // 0' "$TMP/r" 2>/dev/null))) ;;
+      429) lim=$((lim+1)) ;;
+      *)   other=$((other+1)) ;;
+    esac
+  done
+  printf '    %s requests -> %s ok / %s rate-limited / %s other  (%s tokens)\n' \
+    "$count" "$ok" "$lim" "$other" "$tok"
+}
+
+fire_denied() {
+  local key="$1" endpoint="$2" model_served="$3" label="$4"
+  code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+    -H "Authorization: Bearer $key" -H "Content-Type: application/json" -X POST \
+    -d "{\"model\":\"${model_served}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4}" \
+    "$endpoint")
+  if [ "$code" = "403" ]; then
+    printf '    %s: 403 Forbidden (expected)\n' "$label"
+  else
+    printf '    %s: %s (expected 403!)\n' "$label" "$code"
+  fi
+}
+
+login_and_key() {
+  local user="$1"
+  KUBECONFIG="$TMP/${user}.kubeconfig" oc login -u "$user" -p "$DEMO_PASSWORD" --server="$API" \
+    --insecure-skip-tls-verify=true >/dev/null 2>&1 || { echo "  login FAILED"; return 1; }
+  TOKEN=$(KUBECONFIG="$TMP/${user}.kubeconfig" oc whoami -t)
+
+  echo "  Visible models:"
+  curl -sk --max-time 30 -H "Authorization: Bearer $TOKEN" "${H}/maas-api/v1/models" \
+    | jq -r '.data[]?.id // empty' 2>/dev/null | sed 's/^/    /'
+
+  RESP=$(curl -sk --max-time 30 -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" -X POST \
+    -d "{\"name\":\"${user}-demo\",\"description\":\"demo\",\"expiresIn\":\"8h\"}" \
+    "${H}/maas-api/v1/api-keys")
+  echo "  Resolved subscription: $(echo "$RESP" | jq -r '.subscription // "UNRESOLVED"')"
+  KEY=$(echo "$RESP" | jq -r '.key // empty')
+  [ -z "$KEY" ] && { echo "  no key issued: $(echo "$RESP" | head -c 140)"; return 1; }
+  return 0
+}
+
+# --- sales-1 ---
+printf '\n============================\n'
+printf '=== sales-1 (corp-sales) ===\n'
+printf '============================\n'
+
+login_and_key "sales-1" || exit 1
+
+echo "  General purpose (on-prem):"
+fire_burst "$KEY" "${H}/${GENERAL_NS}/${GENERAL_RESOURCE}/v1/chat/completions" "${GENERAL_SERVED}" "$N"
+
+echo "  DeepSeek R2 (on-prem):"
+fire_denied "$KEY" "${H}/${DEEPSEEK_NS}/${DEEPSEEK_RESOURCE}/v1/chat/completions" "${DEEPSEEK_SERVED}" "deepseek-r2-llmd"
+
+echo "  Gemini Flash (cloud):"
+fire_denied "$KEY" "${H}/${GEMINI_NS}/${GEMINI_RESOURCE}/v1/chat/completions" "${GEMINI_SERVED}" "gemini-flash-cloud"
+
+# --- eng-1 ---
+printf '\n====================================\n'
+printf '=== eng-1 (corp-engineering) ===\n'
+printf '====================================\n'
+
+login_and_key "eng-1" || exit 1
+
+echo "  General purpose (on-prem):"
+fire_burst "$KEY" "${H}/${GENERAL_NS}/${GENERAL_RESOURCE}/v1/chat/completions" "${GENERAL_SERVED}" "$N"
+
+echo "  DeepSeek R2 (on-prem):"
+fire_burst "$KEY" "${H}/${DEEPSEEK_NS}/${DEEPSEEK_RESOURCE}/v1/chat/completions" "${DEEPSEEK_SERVED}" "$N"
+
+echo "  Gemini Flash (cloud) - expect rate limiting at ~20 tokens/min:"
+fire_burst "$KEY" "${H}/${GEMINI_NS}/${GEMINI_RESOURCE}/v1/chat/completions" "${GEMINI_SERVED}" "$N"
+
+# --- prod-1 ---
+printf '\n================================\n'
+printf '=== prod-1 (corp-products) ===\n'
+printf '================================\n'
+
+login_and_key "prod-1" || exit 1
+
+echo "  General purpose (on-prem):"
+fire_burst "$KEY" "${H}/${GENERAL_NS}/${GENERAL_RESOURCE}/v1/chat/completions" "${GENERAL_SERVED}" "$N"
+
+echo "  DeepSeek R2 (on-prem):"
+fire_burst "$KEY" "${H}/${DEEPSEEK_NS}/${DEEPSEEK_RESOURCE}/v1/chat/completions" "${DEEPSEEK_SERVED}" "$N"
+
+echo "  Gemini Flash (cloud):"
+fire_denied "$KEY" "${H}/${GEMINI_NS}/${GEMINI_RESOURCE}/v1/chat/completions" "${GEMINI_SERVED}" "gemini-flash-cloud"
+
+# --- summary ---
+printf '\n=== Summary ===\n'
+echo "Expected behavior:"
+echo "  sales-1:  sees 1 model, general OK, deepseek 403, gemini 403"
+echo "  eng-1:    sees 3 models, general OK, deepseek OK, gemini rate-limited (~20 tok/min)"
+echo "  prod-1:   sees 2 models, general OK, deepseek OK, gemini 403"

--- a/demo/corporate-scenario/setup-demo.sh
+++ b/demo/corporate-scenario/setup-demo.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Set up the corporate scenario demo: three divisions, three models, differentiated
+# access and rate limits.
+#
+# Creates six htpasswd users across three groups:
+#   corp-sales:       sales-1, sales-2
+#   corp-engineering: eng-1, eng-2
+#   corp-products:    prod-1, prod-2
+#
+# Deploys two additional simulator-backed models alongside the existing general-purpose
+# model (facebook-opt-125m-simulated) and applies MaaS governance CRDs.
+#
+# Usage:
+#   ./setup-demo.sh                         # password prompted, or set DEMO_PASSWORD
+#   DEMO_PASSWORD='s3cret' ./setup-demo.sh
+#
+# Reverse with ./cleanup-demo.sh
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+USERS_SALES=(sales-1 sales-2)
+USERS_ENG=(eng-1 eng-2)
+USERS_PROD=(prod-1 prod-2)
+ALL_USERS=("${USERS_SALES[@]}" "${USERS_ENG[@]}" "${USERS_PROD[@]}")
+
+GROUP_SALES=corp-sales
+GROUP_ENG=corp-engineering
+GROUP_PROD=corp-products
+
+SECRET=corp-demo-htpasswd
+IDP=corp-demo
+WORKDIR=${WORKDIR:-$(mktemp -d)}
+
+# --- prerequisites ---
+
+command -v htpasswd >/dev/null || { echo "htpasswd not found (install httpd-tools / apache2-utils)"; exit 1; }
+command -v jq >/dev/null || { echo "jq not found"; exit 1; }
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+
+echo "==> Checking existing setup"
+if ! oc get maasmodelref facebook-opt-125m-simulated -n llm >/dev/null 2>&1; then
+  echo "ERROR: facebook-opt-125m-simulated MaaSModelRef not found in namespace llm."
+  echo "Run setup-maas.sh --model simulator first."
+  exit 1
+fi
+
+PHASE=$(oc get maasmodelref facebook-opt-125m-simulated -n llm -o jsonpath='{.status.phase}' 2>/dev/null || echo "unknown")
+if [ "$PHASE" != "Ready" ]; then
+  echo "WARNING: facebook-opt-125m-simulated phase is '${PHASE}', not Ready."
+  echo "The demo may not work correctly. Continue anyway? (Ctrl+C to abort)"
+  sleep 3
+fi
+
+# --- password ---
+
+if [ -z "${DEMO_PASSWORD:-}" ]; then
+  read -rsp "Password for demo users: " DEMO_PASSWORD; echo
+fi
+[ -n "$DEMO_PASSWORD" ] || { echo "empty password"; exit 1; }
+
+# --- oauth backup ---
+
+echo "==> Backing up oauth/cluster to ${WORKDIR}/oauth-cluster.backup.yaml"
+oc get oauth cluster -o yaml > "${WORKDIR}/oauth-cluster.backup.yaml"
+
+# --- htpasswd users ---
+
+echo "==> Generating htpasswd for: ${ALL_USERS[*]}"
+HT="${WORKDIR}/corp-demo.htpasswd"
+htpasswd -c -B -b "$HT" "${ALL_USERS[0]}" "$DEMO_PASSWORD" >/dev/null 2>&1
+for u in "${ALL_USERS[@]:1}"; do htpasswd -B -b "$HT" "$u" "$DEMO_PASSWORD" >/dev/null 2>&1; done
+
+echo "==> Creating secret ${SECRET} in openshift-config"
+oc create secret generic "$SECRET" --from-file=htpasswd="$HT" -n openshift-config \
+  --dry-run=client -o yaml | oc apply -f -
+
+if oc get oauth cluster -o jsonpath='{.spec.identityProviders[*].name}' | tr ' ' '\n' | grep -qx "$IDP"; then
+  echo "==> Identity provider ${IDP} already present, skipping"
+else
+  echo "==> Adding identity provider ${IDP} (additive - existing providers untouched)"
+  oc patch oauth cluster --type=json -p "[{\"op\":\"add\",\"path\":\"/spec/identityProviders/-\",\"value\":{\"name\":\"${IDP}\",\"mappingMethod\":\"claim\",\"type\":\"HTPasswd\",\"htpasswd\":{\"fileData\":{\"name\":\"${SECRET}\"}}}}]"
+fi
+
+# --- groups ---
+
+echo "==> Creating groups"
+for grp_var in GROUP_SALES GROUP_ENG GROUP_PROD; do
+  grp="${!grp_var}"
+  case "$grp_var" in
+    GROUP_SALES) members=("${USERS_SALES[@]}") ;;
+    GROUP_ENG)   members=("${USERS_ENG[@]}") ;;
+    GROUP_PROD)  members=("${USERS_PROD[@]}") ;;
+  esac
+  oc adm groups new "$grp" "${members[@]}" 2>/dev/null || \
+    { for u in "${members[@]}"; do oc adm groups add-users "$grp" "$u" >/dev/null 2>&1 || true; done; }
+  echo "  ${grp}: ${members[*]}"
+done
+
+# --- cloud-models namespace ---
+
+echo "==> Creating cloud-models namespace"
+oc apply -f "${DIR}/manifests/namespace-cloud-models.yaml"
+
+# --- deploy new models ---
+
+echo "==> Deploying LLMInferenceService resources"
+oc apply -f "${DIR}/manifests/model-deepseek-r2.yaml"
+oc apply -f "${DIR}/manifests/model-gemini-flash.yaml"
+
+echo "==> Waiting for simulator pods (up to 3 min)..."
+for ref in "deepseek-r2-llmd:llm" "gemini-flash-cloud:cloud-models"; do
+  name="${ref%%:*}"; ns="${ref##*:}"
+  timeout=180; elapsed=0
+  while true; do
+    ready=$(oc get pods -n "$ns" -l "app.kubernetes.io/name=${name}" --no-headers 2>/dev/null \
+      | grep -c "Running" || true)
+    if [ "$ready" -ge 1 ]; then
+      echo "  ${ns}/${name}: simulator pod Running"
+      break
+    fi
+    if [ "$elapsed" -ge "$timeout" ]; then
+      echo "  WARNING: timeout waiting for ${name} pod in ${ns}"
+      break
+    fi
+    sleep 5; elapsed=$((elapsed+5))
+  done
+done
+
+# --- MaaSModelRef ---
+
+echo "==> Applying MaaSModelRef resources"
+oc apply -f "${DIR}/manifests/maas-model-deepseek-r2.yaml"
+oc apply -f "${DIR}/manifests/maas-model-gemini-flash.yaml"
+
+# --- auth policies and subscriptions ---
+
+echo "==> Applying auth policies"
+oc apply -f "${DIR}/manifests/auth-policies.yaml"
+
+echo "==> Applying subscriptions"
+oc apply -f "${DIR}/manifests/subscriptions.yaml"
+
+# --- wait for MaaSModelRef Ready ---
+
+echo "==> Waiting for MaaSModelRef resources to reach Ready (up to 3 min)..."
+for ref in "deepseek-r2-llmd:llm" "gemini-flash-cloud:cloud-models"; do
+  name="${ref%%:*}"; ns="${ref##*:}"
+  timeout=180; elapsed=0
+  while true; do
+    phase=$(oc get maasmodelref "$name" -n "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [ "$phase" = "Ready" ]; then
+      echo "  ${name} (${ns}): Ready"
+      break
+    fi
+    if [ "$elapsed" -ge "$timeout" ]; then
+      echo "  WARNING: ${name} (${ns}) still in phase '${phase}' after ${timeout}s"
+      echo "  Check: oc get maasmodelref ${name} -n ${ns} -o yaml"
+      break
+    fi
+    sleep 5; elapsed=$((elapsed+5))
+  done
+done
+
+# --- priority check ---
+
+echo "==> Checking for priority conflicts"
+CONFLICTS=$(oc get maassubscription -n models-as-a-service -o json 2>/dev/null \
+  | jq -r '.items[] | select(.metadata.name | startswith("corp-") | not) | select(.spec.priority >= 30) | .metadata.name' 2>/dev/null || true)
+if [ -n "$CONFLICTS" ]; then
+  echo "  WARNING: These non-corporate subscriptions have priority >= 30 and may interfere:"
+  echo "$CONFLICTS" | sed 's/^/    /'
+  echo "  The corporate subscriptions also use priority 30. Higher priority wins."
+fi
+
+# --- summary ---
+
+echo
+echo "Identity providers:"
+oc get oauth cluster -o jsonpath='{range .spec.identityProviders[*]}  {.name} ({.type}){"\n"}{end}'
+echo
+echo "Groups:"
+for grp in $GROUP_SALES $GROUP_ENG $GROUP_PROD; do
+  members=$(oc get group "$grp" -o jsonpath='{.users[*]}' 2>/dev/null || echo "?")
+  echo "  ${grp}: ${members}"
+done
+echo
+echo "Models:"
+oc get maasmodelref -A --no-headers 2>/dev/null | awk '{printf "  %-35s %-20s %s\n", $2, $1, $5}'
+echo
+echo "Subscriptions:"
+oc get maassubscription -n models-as-a-service --no-headers 2>/dev/null | awk '{printf "  %-25s prio=%s\n", $1, $4}'
+echo
+echo "Setup complete. The oauth pods restart before new users can log in (usually under a minute)."
+echo "Backup and htpasswd kept in: ${WORKDIR}"
+echo
+echo "Next: ./run-demo.sh"

--- a/demo/corporate-scenario/verify-scenario.sh
+++ b/demo/corporate-scenario/verify-scenario.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Corporate scenario: automated verification.
+#
+# Tests:
+#   1. Access control - 3x3 matrix (users x models): 6 allow, 3 deny
+#   2. Rate limiting  - burst eng-1 on gemini-flash-cloud, expect 429
+#   3. Key multiplication - two keys share the same quota
+#   4. Config drift   - subscription limits match expected values
+#
+# Usage:
+#   ./verify-scenario.sh
+#   DEMO_PASSWORD='...' ./verify-scenario.sh
+set -uo pipefail
+
+PASS=0; FAIL=0; SKIP=0
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %s\n' "$label"
+    PASS=$((PASS+1))
+  elif [ "$expected" = "200" ] && [ "$actual" = "429" ]; then
+    # 429 means the user HAS access but is rate-limited (e.g. from a previous run).
+    # This still proves access is granted.
+    printf '  PASS  %s (429 = access granted, rate-limited from previous run)\n' "$label"
+    PASS=$((PASS+1))
+  else
+    printf '  FAIL  %s (expected %s, got %s)\n' "$label" "$expected" "$actual"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+oc whoami >/dev/null 2>&1 || { echo "not logged in to a cluster"; exit 1; }
+API=$(oc whoami --show-server)
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+H="https://maas.${CLUSTER_DOMAIN}"
+
+if [ -z "${DEMO_PASSWORD:-}" ]; then
+  read -rsp "Password for demo users: " DEMO_PASSWORD; echo
+fi
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# Warm-up
+curl -sk --max-time 30 -o /dev/null -H "Authorization: Bearer $(oc whoami -t)" \
+  "${H}/maas-api/v1/models" 2>/dev/null || true
+
+login_and_key() {
+  local user="$1" key_name="${2:-${1}-verify}"
+  KUBECONFIG="$TMP/${user}.kubeconfig" oc login -u "$user" -p "$DEMO_PASSWORD" --server="$API" \
+    --insecure-skip-tls-verify=true >/dev/null 2>&1 || { echo "LOGIN_FAILED"; return; }
+  local token
+  token=$(KUBECONFIG="$TMP/${user}.kubeconfig" oc whoami -t)
+  local resp
+  resp=$(curl -sk --max-time 30 -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" -X POST \
+    -d "{\"name\":\"${key_name}\",\"description\":\"verify\",\"expiresIn\":\"8h\"}" \
+    "${H}/maas-api/v1/api-keys")
+  echo "$resp" | jq -r '.key // empty'
+}
+
+fire_one() {
+  local key="$1" ns="$2" resource="$3" served="$4"
+  local endpoint="${H}/${ns}/${resource}/v1/chat/completions"
+  local code
+  code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+    -H "Authorization: Bearer $key" -H "Content-Type: application/json" -X POST \
+    -d "{\"model\":\"${served}\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":4}" \
+    "$endpoint")
+  if [ "$code" = "500" ]; then
+    code=$(curl -sk --max-time 30 -o "$TMP/r" -w "%{http_code}" \
+      -H "Authorization: Bearer $key" -H "Content-Type: application/json" -X POST \
+      -d "{\"model\":\"${served}\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":4}" \
+      "$endpoint")
+  fi
+  echo "$code"
+}
+
+# ========================================
+echo "=== 1. Access control (9 tests) ==="
+# ========================================
+
+for user in sales-1 eng-1 prod-1; do
+  KEY=$(login_and_key "$user")
+  if [ -z "$KEY" ] || [ "$KEY" = "LOGIN_FAILED" ]; then
+    echo "  SKIP  ${user}: login or key mint failed"
+    SKIP=$((SKIP+3))
+    continue
+  fi
+
+  case "$user" in
+    sales-1)
+      actual=$(fire_one "$KEY" "llm" "facebook-opt-125m-simulated" "facebook/opt-125m")
+      check "sales-1 -> facebook-opt-125m-simulated" "200" "$actual"
+      actual=$(fire_one "$KEY" "llm" "deepseek-r2-llmd" "deepseek/deepseek-r2")
+      check "sales-1 -> deepseek-r2-llmd" "403" "$actual"
+      actual=$(fire_one "$KEY" "cloud-models" "gemini-flash-cloud" "google/gemini-flash")
+      check "sales-1 -> gemini-flash-cloud" "403" "$actual"
+      ;;
+    eng-1)
+      actual=$(fire_one "$KEY" "llm" "facebook-opt-125m-simulated" "facebook/opt-125m")
+      check "eng-1 -> facebook-opt-125m-simulated" "200" "$actual"
+      actual=$(fire_one "$KEY" "llm" "deepseek-r2-llmd" "deepseek/deepseek-r2")
+      check "eng-1 -> deepseek-r2-llmd" "200" "$actual"
+      actual=$(fire_one "$KEY" "cloud-models" "gemini-flash-cloud" "google/gemini-flash")
+      check "eng-1 -> gemini-flash-cloud" "200" "$actual"
+      ;;
+    prod-1)
+      actual=$(fire_one "$KEY" "llm" "facebook-opt-125m-simulated" "facebook/opt-125m")
+      check "prod-1 -> facebook-opt-125m-simulated" "200" "$actual"
+      actual=$(fire_one "$KEY" "llm" "deepseek-r2-llmd" "deepseek/deepseek-r2")
+      check "prod-1 -> deepseek-r2-llmd" "200" "$actual"
+      actual=$(fire_one "$KEY" "cloud-models" "gemini-flash-cloud" "google/gemini-flash")
+      check "prod-1 -> gemini-flash-cloud" "403" "$actual"
+      ;;
+  esac
+done
+
+# ======================================
+echo ""
+echo "=== 2. Rate limiting (1 test) ==="
+# ======================================
+
+KEY_ENG=$(login_and_key "eng-1" "eng1-ratelimit")
+if [ -n "$KEY_ENG" ] && [ "$KEY_ENG" != "LOGIN_FAILED" ]; then
+  got_429=false
+  for _ in $(seq 1 15); do
+    code=$(fire_one "$KEY_ENG" "cloud-models" "gemini-flash-cloud" "google/gemini-flash")
+    [ "$code" = "429" ] && { got_429=true; break; }
+  done
+  if $got_429; then
+    printf '  PASS  eng-1 hits 429 on gemini-flash-cloud (50 tokens/min limit)\n'
+    PASS=$((PASS+1))
+  else
+    printf '  FAIL  eng-1 never hit 429 on gemini-flash-cloud after 15 requests\n'
+    FAIL=$((FAIL+1))
+  fi
+else
+  echo "  SKIP  rate limit test: login failed"
+  SKIP=$((SKIP+1))
+fi
+
+# ==============================================
+echo ""
+echo "=== 3. Key multiplication (1 test) ==="
+# ==============================================
+
+KEY2_USER="eng-2"
+KUBECONFIG="$TMP/${KEY2_USER}.kubeconfig" oc login -u "$KEY2_USER" -p "$DEMO_PASSWORD" --server="$API" \
+  --insecure-skip-tls-verify=true >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  TOKEN2=$(KUBECONFIG="$TMP/${KEY2_USER}.kubeconfig" oc whoami -t)
+
+  RESP1=$(curl -sk --max-time 30 -H "Authorization: Bearer $TOKEN2" \
+    -H "Content-Type: application/json" -X POST \
+    -d '{"name":"eng2-key1","description":"verify","expiresIn":"8h"}' \
+    "${H}/maas-api/v1/api-keys")
+  K1=$(echo "$RESP1" | jq -r '.key // empty')
+
+  RESP2=$(curl -sk --max-time 30 -H "Authorization: Bearer $TOKEN2" \
+    -H "Content-Type: application/json" -X POST \
+    -d '{"name":"eng2-key2","description":"verify","expiresIn":"8h"}' \
+    "${H}/maas-api/v1/api-keys")
+  K2=$(echo "$RESP2" | jq -r '.key // empty')
+
+  if [ -n "$K1" ] && [ -n "$K2" ]; then
+    for _ in $(seq 1 20); do
+      fire_one "$K1" "cloud-models" "gemini-flash-cloud" "google/gemini-flash" >/dev/null
+    done
+    code_k2=$(fire_one "$K2" "cloud-models" "gemini-flash-cloud" "google/gemini-flash")
+    check "eng-2 key-2 rate-limited after key-1 exhausted quota" "429" "$code_k2"
+  else
+    echo "  SKIP  could not mint two keys for ${KEY2_USER}"
+    SKIP=$((SKIP+1))
+  fi
+else
+  echo "  SKIP  ${KEY2_USER} login failed"
+  SKIP=$((SKIP+1))
+fi
+
+# ==========================================
+echo ""
+echo "=== 4. Config drift (4 tests) ==="
+# ==========================================
+
+check_sub_limit() {
+  local name="$1" expected_limit="$2"
+  local actual
+  actual=$(oc get maassubscription "$name" -n models-as-a-service \
+    -o jsonpath='{.spec.modelRefs[0].tokenRateLimits[0].limit}' 2>/dev/null || echo "NOT_FOUND")
+  check "subscription ${name} limit" "$expected_limit" "$actual"
+}
+
+check_sub_limit "corp-sales"       "500"
+check_sub_limit "corp-engineering"  "500"
+check_sub_limit "corp-products"    "500"
+
+# Also check eng cloud limit (third modelRef)
+ENG_CLOUD_LIMIT=$(oc get maassubscription "corp-engineering" -n models-as-a-service \
+  -o jsonpath='{.spec.modelRefs[2].tokenRateLimits[0].limit}' 2>/dev/null || echo "NOT_FOUND")
+check "subscription corp-engineering cloud limit" "20" "$ENG_CLOUD_LIMIT"
+
+# --- summary ---
+echo ""
+echo "=============================="
+printf 'Results: %s passed / %s failed / %s skipped (of %s)\n' \
+  "$PASS" "$FAIL" "$SKIP" "$((PASS+FAIL+SKIP))"
+echo "=============================="
+
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- New demo showing a realistic enterprise scenario: three corporate divisions (Sales, Engineering, Products) with different model access and token budgets
- Each division gets one subscription covering all their allowed models with per-model rate limits. One API key per user, full access to everything their group is entitled to
- Three models (all simulator-backed, no GPU needed): general purpose (existing), DeepSeek R2 (on-prem), Gemini Flash (cloud). The namespace in the URL path (`/llm/` vs `/cloud-models/`) visually distinguishes on-prem from cloud
- Group-based auth policies: Sales sees 1 model, Products sees 2, Engineering sees all 3
- Cloud model has a tight 20 tok/min limit to show cost control in action
- Full Antora documentation page with step-by-step guide and talk track for enterprise demos - this is the recommended starting point when showing MaaS to stakeholders
- Scripts: setup-demo.sh, run-demo.sh, verify-scenario.sh (15 automated tests), cleanup-demo.sh

## What I learned during testing

- API keys bind to ONE subscription. Had to restructure from 4 per-model subscriptions to 3 per-division subscriptions so one key gives full access
- The models API returns `.data[].id` not `.items[].name`
- Pod labels are `app.kubernetes.io/name=<model>`, not `app=llm-d-inference-sim`
- Bash 3 on macOS does not support `declare -A` - had to avoid associative arrays

## Test plan

- [x] Full cycle on cluster-z67vp: setup -> run -> verify (15/15) -> cleanup
- [x] Access control matrix: 6 allow + 3 deny all correct
- [x] Rate limiting: eng-1 hits 429 on cloud model within 8 requests
- [x] Key multiplication: second key shares exhausted quota
- [x] Config drift: subscription limits match expected values
- [x] Cleanup removes everything without touching existing models
- [ ] Screenshots from RHOAI Dashboard (pending - need manual capture)