### PR TITLE
Add install/architecture visualizers; fix llamastackoperator/ogx DSC …

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ See [AI-Assisted Installation](https://rh-aiservices-bu.github.io/rhoai-maas-gui
 
 ## Documentation
 
+- [Install & Configuration Visualizer](https://rh-aiservices-bu.github.io/rhoai-maas-guide/modules/main/_attachments/install-flow.html) — animated walkthrough of the phase sequence, the most common ordering mistake, governance pairing, and tiers/priority
 - [RHOAI 3.5 MaaS Official Docs](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index)
 - [RHOAI 3.4 MaaS Official Docs](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index)
 - [Upstream MaaS Documentation](https://opendatahub-io.github.io/models-as-a-service/latest/)

--- a/content/modules/ROOT/assets/attachments/architecture-flow.html
+++ b/content/modules/ROOT/assets/attachments/architecture-flow.html
@@ -1,0 +1,442 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>RHOAI MaaS — System Architecture Visualizer</title>
+<link rel="stylesheet" href="https://noyitz.github.io/flowstory/templates/style.css">
+</head>
+<body>
+<button class="fs-theme-toggle" id="fs-theme">&#9790;</button>
+<div class="fs-brand" id="fs-brand"></div>
+<div class="fs-title" id="fs-title"></div>
+<div class="fs-panel">
+  <div class="fs-flow-bar">
+    <select id="fs-flow-select"></select>
+    <button class="fs-start" id="fs-play">&#9654; Start</button>
+    <button id="fs-speed">1x</button>
+    <button id="fs-loop">&#8635; Loop</button>
+    <button class="fs-reset" id="fs-reset">Reset</button>
+  </div>
+  <div class="fs-steps" id="fs-steps">
+    <div class="fs-steps-title">Flow Steps</div>
+    <div id="fs-steps-container"></div>
+  </div>
+</div>
+<div id="fs-highlight-box" style="display:none;position:fixed;z-index:350;border-radius:10px;pointer-events:none"></div>
+<div id="fs-overlay" onclick="if(event.target===this)window.__flowstory?.closeOverlay()" style="display:none;position:fixed;top:0;left:0;right:380px;bottom:0;z-index:300;background:rgba(0,0,0,0.6)">
+  <div id="fs-overlay-card" style="position:absolute;background:#161b22ee;border:1px solid #30363d;border-radius:14px;max-width:460px;padding:22px 26px;box-shadow:0 12px 40px rgba(0,0,0,0.5);transition:opacity .2s">
+    <button onclick="window.__flowstory?.closeOverlay()" style="position:absolute;top:10px;right:14px;background:none;border:none;color:#8b949e;font-size:18px;cursor:pointer;padding:4px 8px;border-radius:6px">&#10005;</button>
+    <div id="fs-overlay-accent" style="width:4px;height:24px;border-radius:2px;position:absolute;left:0;top:22px"></div>
+    <h2 id="fs-overlay-title" style="margin:0 0 6px;font-size:18px;color:#c9d1d9;font-family:system-ui"></h2>
+    <p id="fs-overlay-desc" style="margin:0 0 14px;font-size:13px;color:#8b949e;line-height:1.5;font-family:system-ui"></p>
+    <div id="fs-overlay-details" style="font-size:12px;font-family:'SF Mono',Menlo,monospace"></div>
+    <button onclick="window.__flowstory?.closeOverlay()" style="margin-top:14px;padding:7px 20px;border:1px solid #3fb950;border-radius:8px;background:transparent;color:#3fb950;font-size:13px;cursor:pointer;font-family:system-ui">&#9654; Resume Flow</button>
+  </div>
+</div>
+<div class="fs-legend" id="fs-legend"></div>
+<canvas id="fs-canvas"></canvas>
+<script type="module">
+import { FlowStory } from 'https://noyitz.github.io/flowstory/src/index.js';
+
+const viz = new FlowStory(document.getElementById('fs-canvas'), {
+  panelElement: document.querySelector('.fs-panel'),
+  flowSelect: document.getElementById('fs-flow-select'),
+  playBtn: document.getElementById('fs-play'),
+  speedBtn: document.getElementById('fs-speed'),
+  loopBtn: document.getElementById('fs-loop'),
+  resetBtn: document.getElementById('fs-reset'),
+  stepsContainer: document.getElementById('fs-steps-container'),
+  overlayElement: document.getElementById('fs-overlay'),
+  overlayCard: document.getElementById('fs-overlay-card'),
+  overlayTitle: document.getElementById('fs-overlay-title'),
+  overlayDesc: document.getElementById('fs-overlay-desc'),
+  overlayDetails: document.getElementById('fs-overlay-details'),
+  overlayAccent: document.getElementById('fs-overlay-accent'),
+  highlightBox: document.getElementById('fs-highlight-box'),
+  brandElement: document.getElementById('fs-brand'),
+  titleElement: document.getElementById('fs-title'),
+  legendElement: document.getElementById('fs-legend'),
+  themeBtn: document.getElementById('fs-theme')
+});
+
+window.__flowstory = viz;
+
+const diagram = {
+  "meta": {
+    "title": "RHOAI MaaS — System Architecture Visualizer",
+    "author": "rhoai-maas-guide",
+    "branding": {
+      "logo": "",
+      "title": "Red Hat OpenShift AI — MaaS"
+    }
+  },
+  "canvas": { "width": 1500, "height": 1060 },
+  "nodes": {
+    "admin":  { "x": -40, "y": 110, "w": 130, "h": 50, "label": "Cluster Admin", "type": "icon" },
+    "caller": { "x": -40, "y": 800, "w": 130, "h": 50, "label": "App / User",    "type": "icon" },
+
+    "cluster": { "x": 110, "y": 20, "w": 1360, "h": 995, "type": "boundary", "label": "OpenShift Cluster · RHOAI 3.5+" },
+
+    "c_olm": { "x": 135, "y": 55, "w": 460, "h": 150, "type": "container", "label": "OLM Operators (cluster-wide)", "color": "#58a6ff" },
+    "op_rhods":   { "x": 155, "y": 90,  "w": 200, "h": 34, "label": "rhods-operator", "sublabel": "redhat-ods-operator ns", "color": "#58a6ff", "fontSize": 12 },
+    "op_rhcl":    { "x": 155, "y": 132, "w": 200, "h": 44, "label": "RHCL (Kuadrant bundle)", "sublabel": "Authorino + Limitador + DNS", "color": "#58a6ff", "fontSize": 12 },
+    "op_certmgr": { "x": 375, "y": 90,  "w": 200, "h": 34, "label": "cert-manager", "sublabel": "+ OpenShift Serverless", "color": "#58a6ff", "fontSize": 12 },
+    "op_lws":     { "x": 375, "y": 132, "w": 200, "h": 44, "label": "LeaderWorkerSet", "sublabel": "+ OpenShift Pipelines", "color": "#58a6ff", "fontSize": 12 },
+
+    "c_dsc": { "x": 615, "y": 55, "w": 340, "h": 150, "type": "container", "label": "Cluster-Scoped Config", "color": "#d2a8ff" },
+    "n_dsci": { "x": 635, "y": 90,  "w": 300, "h": 34, "label": "DSCInitialization", "sublabel": "default-dsci", "color": "#d2a8ff", "fontSize": 12 },
+    "n_dsc":  { "x": 635, "y": 134, "w": 300, "h": 56, "label": "DataScienceCluster", "sublabel": "default-dsc — admin edits spec.components", "color": "#d2a8ff", "fontSize": 13 },
+
+    "n_crdgroups": { "x": 975, "y": 55, "w": 480, "h": 150, "label": "CRD API Groups", "sublabel": "4 API groups \u2014 click for the full list", "color": "#8b949e", "fontSize": 12 },
+
+    "c_modules": { "x": 135, "y": 225, "w": 1335, "h": 240, "type": "container", "label": "Component Modules — reconciled in batches by runlevel", "color": "#ffa657" },
+    "c_batch32": { "x": 160, "y": 265, "w": 460, "h": 170, "type": "container", "label": "runlevel 32 (all-or-nothing batch)", "color": "#f85149" },
+    "m_aigateway": { "x": 180, "y": 300, "w": 420, "h": 44, "label": "aigateway", "sublabel": "→ MaaS control plane", "color": "#ffa657", "fontSize": 13 },
+    "m_mlflow":    { "x": 180, "y": 352, "w": 200, "h": 44, "label": "mlflowoperator", "color": "#ffa657", "fontSize": 13 },
+    "m_ogx":       { "x": 400, "y": 352, "w": 200, "h": 44, "label": "ogx", "sublabel": "→ GenAI Studio / Playground", "color": "#ffa657", "fontSize": 13 },
+
+    "m_kserve":       { "x": 645, "y": 265, "w": 170, "h": 36, "label": "kserve", "color": "#ffa657", "fontSize": 13 },
+    "m_dashboard":    { "x": 645, "y": 308, "w": 170, "h": 36, "label": "dashboard", "color": "#ffa657", "fontSize": 13 },
+    "m_workbenches":  { "x": 645, "y": 351, "w": 170, "h": 36, "label": "workbenches", "color": "#ffa657", "fontSize": 12 },
+    "m_modelregistry":{ "x": 830, "y": 265, "w": 170, "h": 36, "label": "modelregistry", "color": "#ffa657", "fontSize": 12 },
+    "m_trainingray":  { "x": 830, "y": 308, "w": 170, "h": 36, "label": "ray / trainingoperator", "color": "#ffa657", "fontSize": 11 },
+    "m_trustyai":     { "x": 830, "y": 351, "w": 170, "h": 36, "label": "trustyai / feastoperator", "color": "#ffa657", "fontSize": 11 },
+
+    "n_batchnote": { "x": 1015, "y": 265, "w": 440, "h": 170, "label": "\u26a0 Batch semantics", "sublabel": "1 failing module aborts the WHOLE batch \u2014 click for details", "color": "#f85149", "fontSize": 11 },
+
+    "c_maasctrl": { "x": 135, "y": 485, "w": 1335, "h": 240, "type": "container", "label": "MaaS Control Plane", "color": "#39c5cf" },
+    "ns_gwinfra": { "x": 160, "y": 520, "w": 260, "h": 90, "type": "container", "label": "ns: redhat-ai-gateway-infra" },
+    "n_maasapi":  { "x": 175, "y": 555, "w": 230, "h": 44, "label": "maas-api", "sublabel": "/v1/models · /v1/api-keys", "color": "#39c5cf", "fontSize": 13 },
+
+    "ns_odhapps": { "x": 440, "y": 520, "w": 290, "h": 180, "type": "container", "label": "ns: redhat-ods-applications" },
+    "n_maascontroller": { "x": 455, "y": 555, "w": 260, "h": 40, "label": "maas-controller", "sublabel": "reconciles MaaS CRDs", "color": "#39c5cf", "fontSize": 13 },
+    "n_maasui":          { "x": 455, "y": 600, "w": 260, "h": 34, "label": "maas-ui", "color": "#39c5cf", "fontSize": 12 },
+    "n_dashboardpod":    { "x": 455, "y": 640, "w": 260, "h": 34, "label": "rhods-dashboard", "color": "#39c5cf", "fontSize": 12 },
+
+    "ns_maas": { "x": 750, "y": 520, "w": 360, "h": 180, "type": "container", "label": "ns: models-as-a-service" },
+    "n_config":       { "x": 765, "y": 555, "w": 330, "h": 34, "label": "Config / AITenant CR", "sublabel": "auto-created by maas-controller", "color": "#39c5cf", "fontSize": 12 },
+    "n_mmr":          { "x": 765, "y": 595, "w": 155, "h": 44, "label": "MaaSModelRef", "color": "#39c5cf", "fontSize": 12 },
+    "n_authpolicy":   { "x": 935, "y": 595, "w": 160, "h": 44, "label": "MaaSAuthPolicy", "color": "#39c5cf", "fontSize": 12 },
+    "n_subscription": { "x": 765, "y": 645, "w": 330, "h": 34, "label": "MaaSSubscription", "sublabel": "tier + rate limit + priority", "color": "#39c5cf", "fontSize": 12 },
+
+    "n_postgres": { "x": 1130, "y": 555, "w": 200, "h": 60, "label": "PostgreSQL", "sublabel": "API keys · usage", "color": "#39c5cf", "fontSize": 14 },
+
+    "c_dataplane": { "x": 135, "y": 745, "w": 1335, "h": 170, "type": "container", "label": "Data Plane — per inference request", "color": "#3fb950" },
+    "ns_ingress": { "x": 160, "y": 780, "w": 560, "h": 120, "type": "container", "label": "ns: openshift-ingress" },
+    "n_gateway":   { "x": 175, "y": 815, "w": 160, "h": 44, "label": "Gateway (Envoy)", "color": "#3fb950", "fontSize": 13 },
+    "n_authorino": { "x": 350, "y": 815, "w": 160, "h": 44, "label": "Authorino", "color": "#3fb950", "fontSize": 14 },
+    "n_limitador": { "x": 525, "y": 815, "w": 160, "h": 44, "label": "Limitador", "color": "#3fb950", "fontSize": 14 },
+
+    "ns_model": { "x": 750, "y": 780, "w": 280, "h": 120, "type": "container", "label": "ns: llm (example model ns)" },
+    "n_kservepod": { "x": 765, "y": 815, "w": 250, "h": 50, "label": "LLMInferenceService pod", "sublabel": "vLLM", "color": "#3fb950", "fontSize": 13 },
+
+    "c_extras": { "x": 135, "y": 935, "w": 1335, "h": 60, "type": "container", "label": "Optional Extensions (Phases 7-9 — see install-flow.html)", "color": "#6e7681" },
+    "n_obs":   { "x": 155,  "y": 960, "w": 420, "h": 28, "label": "Observability: Tempo · OTel · Loki · COO", "color": "#6e7681", "fontSize": 11 },
+    "n_ext2":  { "x": 590,  "y": 960, "w": 420, "h": 28, "label": "External Models: ExternalProvider (OpenAI/Gemini/Bedrock)", "color": "#6e7681", "fontSize": 11 },
+    "n_oidc2": { "x": 1025, "y": 960, "w": 420, "h": 28, "label": "External OIDC: Keycloak + AITenant patch", "color": "#6e7681", "fontSize": 11 }
+  },
+  "tooltips": {
+    "admin": {
+      "title": "Cluster Admin",
+      "description": "The operator running the installation and day-2 configuration — typically via scripts/setup-maas.sh or the /install-maas skill.",
+      "details": [["Script", "scripts/setup-maas.sh"], ["Access", "cluster-admin"]]
+    },
+    "caller": {
+      "title": "App / End User",
+      "description": "A client application calling the OpenAI-compatible endpoint with an sk-oai-* API key.",
+      "details": [["API", "POST /v1/chat/completions"], ["Auth", "Authorization: Bearer sk-oai-..."]]
+    },
+    "op_rhods": {
+      "title": "rhods-operator",
+      "description": "The Red Hat OpenShift AI operator. Installed via OLM subscription (channel stable-3.x). Owns the DataScienceCluster and DSCInitialization CRDs and reconciles every component listed in spec.components.",
+      "details": [["Namespace", "redhat-ods-operator"], ["Check", "oc get csv -n redhat-ods-operator"]]
+    },
+    "op_rhcl": {
+      "title": "RHCL (Red Hat Connectivity Link)",
+      "description": "Installs the Kuadrant control plane bundle: authorino-operator, limitador-operator, dns-operator, and rhcl-operator itself. Cluster-wide (AllNamespaces) install mode.",
+      "details": [["Deploys", "Kuadrant, Authorino, Limitador"]],
+      "links": [["Kuadrant Docs", "https://docs.kuadrant.io"]]
+    },
+    "op_certmgr": {
+      "title": "cert-manager + OpenShift Serverless",
+      "description": "cert-manager provides TLS automation for Authorino's serving certs and the Gateway. OpenShift Serverless (Knative) backs some KServe serving modes.",
+      "details": [["Manifest", "manifests/01-prerequisites/operators/cert-manager/"]]
+    },
+    "op_lws": {
+      "title": "LeaderWorkerSet + OpenShift Pipelines",
+      "description": "LeaderWorkerSet coordinates multi-pod prefill/decode disaggregated serving. OpenShift Pipelines (Tekton) is a transitive dependency pulled in by the RHCL bundle.",
+      "details": [["Manifest", "manifests/01-prerequisites/operators/leader-worker-set/"]]
+    },
+    "n_dsci": {
+      "title": "DSCInitialization",
+      "description": "Cluster-wide RHOAI initialization object: applications namespace, monitoring stack, trusted CA bundle. Applied once, before the DataScienceCluster.",
+      "details": [["Manifest", "manifests/04-rhoai-config/dscinitialization.yaml"]]
+    },
+    "n_dsc": {
+      "title": "DataScienceCluster (default-dsc)",
+      "description": "The central feature-toggle object. Every entry under spec.components (aigateway, kserve, ogx, mlflowoperator, dashboard, workbenches, ...) tells rhods-operator which Module controllers to run and with what config.",
+      "details": [
+        ["Manifest (3.5)", "manifests/04-rhoai-config/datasciencecluster.yaml"],
+        ["Check Ready", "oc get datasciencecluster default-dsc -o jsonpath='{.status.conditions[?(@.type==\"Ready\")]}'"],
+        ["Gotcha", "Omitted/legacy fields can still default to Managed and silently conflict with new ones — see the Batch Failure flow"]
+      ]
+    },
+    "n_crdgroups": {
+      "title": "CRD API Groups",
+      "description": "Everything MaaS touches lives under one of four CRD groups. These per-component CRDs (components.platform.opendatahub.io) are created dynamically by the operator itself, NOT installed from the CSV by OLM — so they can be legitimately missing until the owning module finishes reconciling.",
+      "details": [
+        ["components.platform.*", "AIGateway, KServe, OGX, MLflowOperator, ... (one CRD per DSC component)"],
+        ["maas.opendatahub.io", "MaaSModelRef, MaaSAuthPolicy, MaaSSubscription, Config, AITenant"],
+        ["services.platform.*", "GatewayConfig, Auth, Monitoring"],
+        ["inference.opendatahub.io", "ExternalProvider (3.5+)"],
+        ["Check installed CRDs", "oc get crd | grep -E 'opendatahub.io|maas'"],
+        ["Symptom if missing", "no matches for kind \"X\" in version \"...opendatahub.io/v1alpha1\""]
+      ]
+    },
+    "m_aigateway": {
+      "title": "aigateway module",
+      "description": "The MaaS modularization path (RHOAI 3.5+), replacing the deprecated kserve.modelsAsService field. When Managed, provisions maas-controller, maas-api, and the governance CRDs.",
+      "details": [
+        ["DSC field", "spec.components.aigateway.modelsAsAService.managementState: Managed"],
+        ["Status condition", "AIGatewayReady / ModelsAsAServiceReady"]
+      ]
+    },
+    "m_mlflow": {
+      "title": "mlflowoperator module",
+      "description": "Provisions MLflow experiment tracking, reconciled in the same runlevel-32 batch as aigateway and ogx.",
+      "details": [["Status condition", "MLflowOperatorReady"]]
+    },
+    "m_ogx": {
+      "title": "ogx module",
+      "description": "Renamed from llamastackoperator in 3.5. Backs the GenAI Studio / AI Playground feature. Must NOT be Managed at the same time as the old llamastackoperator field.",
+      "details": [
+        ["Status condition", "OGXReady"],
+        ["Known failure", "\"LlamaStackOperator is set to Managed; it has been deprecated, set it to Removed before enabling OGX\""]
+      ]
+    },
+    "m_kserve": {
+      "title": "kserve module",
+      "description": "Model-serving controller. Owns InferenceService/LLMInferenceService CRDs and the vLLM runtime pods. Reconciled independently of the runlevel-32 batch.",
+      "details": [["Status condition", "KserveReady"]]
+    },
+    "m_dashboard": {
+      "title": "dashboard module",
+      "description": "The RHOAI web console (odh-dashboard). Reads OdhDashboardConfig flags like modelAsService and externalModels to decide which UI tabs to show.",
+      "details": [["Manifest", "manifests/04-rhoai-config/odh-dashboard-config.yaml"]]
+    },
+    "m_workbenches": {
+      "title": "workbenches module",
+      "description": "Jupyter notebook workbenches for data scientists — unrelated to MaaS serving, listed here for completeness of the DSC component set.",
+      "details": [["Status condition", "WorkbenchesReady"]]
+    },
+    "m_modelregistry": {
+      "title": "modelregistry module",
+      "description": "Central catalog of registered models and versions across the cluster.",
+      "details": [["Status condition", "ModelRegistryReady"]]
+    },
+    "m_trainingray": {
+      "title": "ray / trainingoperator",
+      "description": "Distributed training and batch compute components — not part of the MaaS serving path.",
+      "details": [["Status condition", "RayReady / TrainingOperatorReady"]]
+    },
+    "m_trustyai": {
+      "title": "trustyai / feastoperator",
+      "description": "Model evaluation (TrustyAI: bias, drift, LMEval) and feature store (Feast) components.",
+      "details": [["Status condition", "TrustyAIReady / FeastOperatorReady"]]
+    },
+    "n_batchnote": {
+      "title": "Runlevel batch semantics",
+      "description": "rhods-operator provisions modules in ordered batches by runlevel (e.g. \"32\"). Modules in the same batch are gated together: if BuildModuleCR fails validation for any one of them, the operator returns an error for the whole reconcile pass and none of that batch's CRDs get installed — not just the failing module's.",
+      "details": [
+        ["Observed log", "\"provisioning failed: module provisioning failed: ogx\""],
+        ["Observed log", "\"module CRDs not yet available, requesting requeue\" (repeats forever until fixed)"],
+        ["Practical impact", "aigateway can look completely unconfigured/broken for a reason that has nothing to do with MaaS"]
+      ]
+    },
+    "n_maasapi": {
+      "title": "maas-api",
+      "description": "Control-plane API server. Serves /v1/models, /v1/api-keys, /internal/v1/api-keys/validate, and /health. Watches MaaSModelRef (all namespaces) and MaaSSubscription (models-as-a-service namespace) via informers, and connects to PostgreSQL on startup.",
+      "details": [
+        ["Namespace (3.5+)", "redhat-ai-gateway-infra"],
+        ["Namespace (3.4)", "redhat-ods-applications"],
+        ["Debug", "oc logs -n redhat-ai-gateway-infra deploy/maas-api"]
+      ]
+    },
+    "n_maascontroller": {
+      "title": "maas-controller",
+      "description": "Reconciles the MaaS-specific CRDs (MaaSModelRef, MaaSAuthPolicy, MaaSSubscription) and auto-creates/maintains the Config (3.5+) or Tenant (3.4) CR. Also mirrors the maas-db-config secret to whichever namespace maas-api runs in, converting hostnames to FQDNs.",
+      "details": [["Namespace", "redhat-ods-applications"]]
+    },
+    "n_maasui": {
+      "title": "maas-ui",
+      "description": "Backend serving the MaaS-specific dashboard pages (API key management, model catalog) embedded in the RHOAI console.",
+      "details": [["Namespace", "redhat-ods-applications"]]
+    },
+    "n_dashboardpod": {
+      "title": "rhods-dashboard",
+      "description": "The main RHOAI web console deployment, gated by the dashboard module and OdhDashboardConfig flags.",
+      "details": [["Namespace", "redhat-ods-applications"]]
+    },
+    "n_config": {
+      "title": "Config / AITenant CR",
+      "description": "Auto-created by maas-controller in the models-as-a-service namespace. Replaces the 3.4 Tenant CR. Deleting it is non-destructive — maas-controller recreates it within seconds (self-healing), but maas-api will restart to pick up the fresh config.",
+      "details": [
+        ["Check (3.5+)", "oc get configs.maas.opendatahub.io -n models-as-a-service"],
+        ["Check (3.4)", "oc get tenant default-tenant -n models-as-a-service"]
+      ]
+    },
+    "n_mmr": {
+      "title": "MaaSModelRef",
+      "description": "Registers one model with the MaaS control plane. Stays Pending until BOTH a MaaSAuthPolicy and a MaaSSubscription reference the same model — these are independent CRDs reconciled separately and must be paired manually.",
+      "details": [["Debug", "oc get maasmodelref -A"]]
+    },
+    "n_authpolicy": {
+      "title": "MaaSAuthPolicy",
+      "description": "Defines WHO may call a model — groups, users, or service accounts.",
+      "details": [["Debug", "oc get maasauthpolicy -A"]]
+    },
+    "n_subscription": {
+      "title": "MaaSSubscription",
+      "description": "Defines HOW MUCH a caller may consume — token rate limits and a priority number. When a caller matches multiple subscriptions on the same model, the highest priority wins; limits are never accumulated.",
+      "details": [["Debug", "oc get maassubscription -A"]]
+    },
+    "n_postgres": {
+      "title": "PostgreSQL",
+      "description": "Backing database for maas-api: hashed API keys, subscription bindings, usage. Must exist and be reachable before maas-api starts, or the pod CrashLoopBackOffs.",
+      "details": [["Manifest", "manifests/03-maas-platform/postgres-deployment.yaml"]]
+    },
+    "n_gateway": {
+      "title": "Gateway (Envoy)",
+      "description": "The Gateway API resource (maas-default-gateway) that all model HTTPRoutes attach to. Backed by Istio via OpenShift's built-in Gateway controller.",
+      "details": [["Namespace", "openshift-ingress"]]
+    },
+    "n_authorino": {
+      "title": "Authorino",
+      "description": "Enforces authentication and authorization at the edge, before any request reaches a model. Validates API keys against maas-api and checks MaaSAuthPolicy subjects.",
+      "details": [["Rejects with", "401 Unauthorized / 403 Forbidden"]]
+    },
+    "n_limitador": {
+      "title": "Limitador",
+      "description": "Enforces rate limiting per the resolved MaaSSubscription's token/request budgets.",
+      "details": [["Rejects with", "429 Too Many Requests"]]
+    },
+    "n_kservepod": {
+      "title": "LLMInferenceService pod (vLLM)",
+      "description": "The actual model server. Internal models run as vLLM pods on-cluster via KServe; external models instead proxy through an ExternalProvider to a third-party API.",
+      "details": [["Manifest pattern", "manifests/05-maas-models/<model>/llm/model.yaml"]]
+    },
+    "n_obs": {
+      "title": "Observability (Phase 7, optional)",
+      "description": "Tempo (traces), OTel Collector, Loki (logs), and the Cluster Observability Operator (dashboards). See install-flow.html for the full phase sequence.",
+      "details": [["Manifest area", "manifests/07-observability/"]]
+    },
+    "n_ext2": {
+      "title": "External Models (Phase 8, optional)",
+      "description": "ExternalProvider + ExternalModel CRDs proxy requests to third-party APIs (OpenAI, Gemini, Bedrock) through the same gateway policy stack as on-cluster models.",
+      "details": [["Manifest area", "manifests/08-external-models/"]]
+    },
+    "n_oidc2": {
+      "title": "External OIDC (Phase 9, optional)",
+      "description": "Keycloak (or a corporate IdP) plus an AITenant patch so external group claims map to MaaSAuthPolicy subjects.",
+      "details": [["Manifest area", "manifests/09-external-oidc/"]]
+    }
+  },
+  "flows": {
+    "layers": {
+      "label": "System Architecture (Layers)",
+      "steps": [
+        { "text": "1. Cluster-admin installs OLM operators cluster-wide", "mode": "arrow", "from": "admin", "to": "c_olm", "color": "#58a6ff", "num": 1, "glow": "c_olm" },
+        { "text": "2. rhods-operator installed — provides DataScienceCluster/DSCInitialization CRDs", "mode": "lightup", "target": "op_rhods", "badge": 2 },
+        { "text": "3. RHCL bundle installed — Authorino + Limitador + DNS operator (Kuadrant control plane)", "mode": "lightup", "target": "op_rhcl", "badge": 3 },
+        { "text": "4. cert-manager + OpenShift Serverless installed", "mode": "lightup", "target": "op_certmgr", "badge": 4 },
+        { "text": "5. LeaderWorkerSet + OpenShift Pipelines installed", "mode": "lightup", "target": "op_lws", "badge": 5 },
+        { "text": "6. Admin applies DSCInitialization and DataScienceCluster", "mode": "arrow", "from": "admin", "to": "n_dsc", "color": "#d2a8ff", "num": 6, "glow": "c_dsc" },
+        { "text": "7. DSCInitialization reconciled — namespaces, monitoring, trusted CA", "mode": "lightup", "target": "n_dsci", "badge": 7 },
+        { "text": "8. DataScienceCluster reconciled — spec.components{ aigateway, kserve, ogx, mlflowoperator, ... }", "mode": "lightup", "target": "n_dsc", "badge": 8 },
+        { "text": "9. rhods-operator provisions each component as a Module, batched by runlevel", "mode": "arrow", "from": "n_dsc", "to": "c_modules", "color": "#ffa657", "num": 9, "glow": "c_modules" },
+        { "text": "10. Runlevel 32 batch: aigateway provisions together with...", "mode": "lightup", "target": "m_aigateway", "badge": 10 },
+        { "text": "11. ...mlflowoperator...", "mode": "lightup", "target": "m_mlflow", "badge": 11 },
+        { "text": "12. ...and ogx — all three must succeed together or the whole batch aborts", "mode": "lightup", "target": "m_ogx", "badge": 12 },
+        { "text": "13. Other modules (kserve, dashboard, workbenches, modelregistry, ray, trustyai) reconcile independently, outside that batch", "mode": "lightup", "target": "m_kserve", "badge": 13 },
+        { "text": "14. aigateway module stands up the MaaS control plane", "mode": "arrow", "from": "m_aigateway", "to": "c_maasctrl", "color": "#39c5cf", "num": 14, "glow": "c_maasctrl" },
+        { "text": "15. maas-controller deploys in redhat-ods-applications", "mode": "lightup", "target": "n_maascontroller", "badge": 15 },
+        { "text": "16. maas-controller auto-creates the Config/AITenant CR in models-as-a-service", "mode": "lightup", "target": "n_config", "badge": 16 },
+        { "text": "17. maas-api deploys in redhat-ai-gateway-infra...", "mode": "lightup", "target": "n_maasapi", "badge": 17 },
+        { "text": "18. ...and connects to PostgreSQL for API-key storage", "mode": "arrow", "from": "n_maasapi", "to": "n_postgres", "color": "#39c5cf", "num": 18 },
+        { "text": "19. kserve module + a model manifest create an LLMInferenceService pod (vLLM)", "mode": "arrow", "from": "m_kserve", "to": "n_kservepod", "color": "#3fb950", "num": 19, "glow": "ns_model" },
+        { "text": "20. Kuadrant creates the Gateway, Authorino, and Limitador in openshift-ingress", "mode": "arrow", "from": "op_rhcl", "to": "c_dataplane", "color": "#3fb950", "num": 20, "glow": "c_dataplane" },
+        { "text": "21. MaaSAuthPolicy + MaaSSubscription are paired to the model (governance — full walkthrough in install-flow.html)", "mode": "lightup", "target": "n_authpolicy", "badge": 21 },
+        { "text": "22. MaaSModelRef → Ready. The stack is now serving inference traffic end-to-end", "mode": "lightup", "target": "n_mmr", "badge": "R" },
+        { "text": "23. Caller can now send authenticated inference requests through the gateway", "mode": "arrow", "from": "c_dataplane", "to": "caller", "color": "#3fb950", "num": 23 }
+      ]
+    },
+    "batch-failure": {
+      "label": "Real Incident: Runlevel Batch Failure",
+      "steps": [
+        { "text": "1. Admin enables ogx (Managed) for GenAI Studio / Playground", "mode": "arrow", "from": "admin", "to": "m_ogx", "color": "#58a6ff", "num": 1 },
+        { "text": "2. But a legacy, deprecated field (llamastackoperator, superseded by ogx) is still Managed too — left over, or defaulted elsewhere on the cluster", "mode": "lightup", "target": "m_ogx", "badge": "!", "errColor": "#f85149" },
+        { "text": "3. Operator rejects the ogx module: \"LlamaStackOperator is set to Managed; it has been deprecated, set it to Removed before enabling OGX\"", "mode": "lightup", "target": "m_ogx", "badge": "\u2717", "errColor": "#f85149" },
+        { "text": "4. That validation error aborts the ENTIRE runlevel-32 batch — not just ogx", "mode": "arrow", "from": "m_ogx", "to": "c_batch32", "color": "#f85149", "num": 4, "glow": "c_batch32" },
+        { "text": "5. aigateway never installs its CRDs: \"module CRDs not yet available, requesting requeue\" — forever", "mode": "lightup", "target": "m_aigateway", "badge": "\u2717", "errColor": "#f85149" },
+        { "text": "6. mlflowoperator is stuck the same way", "mode": "lightup", "target": "m_mlflow", "badge": "\u2717", "errColor": "#f85149" },
+        { "text": "7. maas-api deployment never appears — even though modelsAsAService shows Managed", "mode": "lightup", "target": "n_maasapi", "badge": "\u2717", "errColor": "#f85149" },
+        { "text": "8. Applying MaaSModelRef fails: \"no matches for kind MaaSModelRef ... ensure CRDs are installed first\"", "mode": "lightup", "target": "n_mmr", "badge": "\u2717", "errColor": "#f85149" },
+        { "text": "9. Fix: explicitly set the legacy llamastackoperator field to Removed (oc patch datasciencecluster default-dsc ...)", "mode": "arrow", "from": "admin", "to": "m_ogx", "color": "#3fb950", "num": 9 },
+        { "text": "10. Batch succeeds — aigateway, mlflowoperator, and ogx all reconcile within ~60-90s", "mode": "lightup", "target": "m_ogx", "badge": "\u2713" },
+        { "text": "11. maas-api deploys immediately; health endpoint returns 200. See Issue 14 in 10-post-upgrade-troubleshooting.adoc", "mode": "lightup", "target": "n_maasapi", "badge": "\u2713" }
+      ]
+    },
+    "request-path": {
+      "label": "Runtime Request Path (condensed)",
+      "steps": [
+        { "text": "1. Caller sends a request with an sk-oai-* API key", "mode": "arrow", "from": "caller", "to": "n_gateway", "color": "#3fb950", "num": 1 },
+        { "text": "2. Gateway (Envoy) routes to Authorino for auth", "mode": "arrow", "from": "n_gateway", "to": "n_authorino", "color": "#3fb950", "num": 2 },
+        { "text": "3. Authorino calls maas-api to validate the key hash", "mode": "arrow", "from": "n_authorino", "to": "n_maasapi", "color": "#3fb950", "num": 3 },
+        { "text": "4. maas-api looks up the salted hash in PostgreSQL", "mode": "arrow", "from": "n_maasapi", "to": "n_postgres", "color": "#3fb950", "num": 4 },
+        { "text": "5. Authorino checks the MaaSAuthPolicy — is this identity allowed to call this model?", "mode": "lightup", "target": "n_authpolicy", "badge": 5 },
+        { "text": "6. Limitador checks the MaaSSubscription rate limit / token budget", "mode": "arrow", "from": "n_authorino", "to": "n_limitador", "color": "#3fb950", "num": 6 },
+        { "text": "7. Within limits — the priority-resolved subscription applies (see install-flow.html Tiers & Priority)", "mode": "lightup", "target": "n_subscription", "badge": 7 },
+        { "text": "8. Request forwarded to the model pod (vLLM)", "mode": "arrow", "from": "n_limitador", "to": "n_kservepod", "color": "#3fb950", "num": 8 },
+        { "text": "9. Completion streams back to the caller. For the full 33-step version with IPP plugins and external providers, see flow.html", "mode": "arrow", "from": "n_kservepod", "to": "caller", "color": "#3fb950", "num": 9 }
+      ]
+    }
+  },
+  "flowOrder": ["layers", "batch-failure", "request-path"],
+  "defaultFlow": "layers",
+  "legend": [
+    { "color": "#58a6ff", "label": "OLM Operators" },
+    { "color": "#d2a8ff", "label": "Cluster-Scoped Config (DSCI/DSC)" },
+    { "color": "#ffa657", "label": "Component Modules" },
+    { "color": "#f85149", "label": "Runlevel batch / failure" },
+    { "color": "#39c5cf", "label": "MaaS Control Plane" },
+    { "color": "#3fb950", "label": "Data Plane (runtime)" },
+    { "color": "#6e7681", "label": "Optional Extensions" },
+    { "color": "#8b949e", "label": "Reference / CRD groups" }
+  ]
+};
+
+await viz.load(diagram);
+
+const cvs = document.getElementById('fs-canvas');
+cvs.addEventListener('mousemove', e => {
+  const rect = cvs.getBoundingClientRect();
+  const eng = viz._engine;
+  const mx = (e.clientX - rect.left - eng._ox) / eng._sc;
+  const my = (e.clientY - rect.top - eng._oy) / eng._sc;
+  let hit = false;
+  for (const [k, n] of Object.entries(eng.state.nodes)) {
+    if (n.type === 'boundary' || n.type === 'container') continue;
+    if (eng.state.tooltips[k] && mx >= n.x && mx <= n.x + n.w && my >= n.y && my <= n.y + n.h) {
+      hit = true;
+      break;
+    }
+  }
+  cvs.style.cursor = hit ? 'pointer' : 'default';
+});
+
+viz.state.loopMode = true;
+viz.play();
+</script>
+</body>
+</html>

--- a/content/modules/ROOT/assets/attachments/install-flow.html
+++ b/content/modules/ROOT/assets/attachments/install-flow.html
@@ -1,0 +1,484 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>RHOAI MaaS — Install & Configuration Visualizer</title>
+<link rel="stylesheet" href="https://noyitz.github.io/flowstory/templates/style.css">
+</head>
+<body>
+<button class="fs-theme-toggle" id="fs-theme">&#9790;</button>
+<div class="fs-brand" id="fs-brand"></div>
+<div class="fs-title" id="fs-title"></div>
+<div class="fs-panel">
+  <div class="fs-flow-bar">
+    <select id="fs-flow-select"></select>
+    <button class="fs-start" id="fs-play">&#9654; Start</button>
+    <button id="fs-speed">1x</button>
+    <button id="fs-loop">&#8635; Loop</button>
+    <button class="fs-reset" id="fs-reset">Reset</button>
+  </div>
+  <div class="fs-steps" id="fs-steps">
+    <div class="fs-steps-title">Flow Steps</div>
+    <div id="fs-steps-container"></div>
+  </div>
+</div>
+<div id="fs-highlight-box" style="display:none;position:fixed;z-index:350;border-radius:10px;pointer-events:none"></div>
+<div id="fs-overlay" onclick="if(event.target===this)window.__flowstory?.closeOverlay()" style="display:none;position:fixed;top:0;left:0;right:380px;bottom:0;z-index:300;background:rgba(0,0,0,0.6)">
+  <div id="fs-overlay-card" style="position:absolute;background:#161b22ee;border:1px solid #30363d;border-radius:14px;max-width:440px;padding:22px 26px;box-shadow:0 12px 40px rgba(0,0,0,0.5);transition:opacity .2s">
+    <button onclick="window.__flowstory?.closeOverlay()" style="position:absolute;top:10px;right:14px;background:none;border:none;color:#8b949e;font-size:18px;cursor:pointer;padding:4px 8px;border-radius:6px">&#10005;</button>
+    <div id="fs-overlay-accent" style="width:4px;height:24px;border-radius:2px;position:absolute;left:0;top:22px"></div>
+    <h2 id="fs-overlay-title" style="margin:0 0 6px;font-size:18px;color:#c9d1d9;font-family:system-ui"></h2>
+    <p id="fs-overlay-desc" style="margin:0 0 14px;font-size:13px;color:#8b949e;line-height:1.5;font-family:system-ui"></p>
+    <div id="fs-overlay-details" style="font-size:12px;font-family:'SF Mono',Menlo,monospace"></div>
+    <button onclick="window.__flowstory?.closeOverlay()" style="margin-top:14px;padding:7px 20px;border:1px solid #3fb950;border-radius:8px;background:transparent;color:#3fb950;font-size:13px;cursor:pointer;font-family:system-ui">&#9654; Resume Flow</button>
+  </div>
+</div>
+<div class="fs-legend" id="fs-legend"></div>
+<canvas id="fs-canvas"></canvas>
+<script type="module">
+import { FlowStory } from 'https://noyitz.github.io/flowstory/src/index.js';
+
+const viz = new FlowStory(document.getElementById('fs-canvas'), {
+  panelElement: document.querySelector('.fs-panel'),
+  flowSelect: document.getElementById('fs-flow-select'),
+  playBtn: document.getElementById('fs-play'),
+  speedBtn: document.getElementById('fs-speed'),
+  loopBtn: document.getElementById('fs-loop'),
+  resetBtn: document.getElementById('fs-reset'),
+  stepsContainer: document.getElementById('fs-steps-container'),
+  overlayElement: document.getElementById('fs-overlay'),
+  overlayCard: document.getElementById('fs-overlay-card'),
+  overlayTitle: document.getElementById('fs-overlay-title'),
+  overlayDesc: document.getElementById('fs-overlay-desc'),
+  overlayDetails: document.getElementById('fs-overlay-details'),
+  overlayAccent: document.getElementById('fs-overlay-accent'),
+  highlightBox: document.getElementById('fs-highlight-box'),
+  brandElement: document.getElementById('fs-brand'),
+  titleElement: document.getElementById('fs-title'),
+  legendElement: document.getElementById('fs-legend'),
+  themeBtn: document.getElementById('fs-theme')
+});
+
+window.__flowstory = viz;
+
+const diagram = {
+  "meta": {
+    "title": "RHOAI MaaS — Install & Configuration Visualizer",
+    "author": "rhoai-maas-guide",
+    "branding": {
+      "logo": "",
+      "title": "Red Hat OpenShift AI — MaaS"
+    }
+  },
+  "canvas": { "width": 1450, "height": 900 },
+  "nodes": {
+    "admin":  { "x": -40, "y": 130, "w": 120, "h": 50, "label": "Admin / CLI", "type": "icon" },
+    "caller": { "x": -40, "y": 440, "w": 120, "h": 50, "label": "App / User",  "type": "icon" },
+
+    "cluster": { "x": 100, "y": 20, "w": 1320, "h": 760, "type": "boundary", "label": "OpenShift Cluster · RHOAI 3.5 · OCP 4.19+" },
+
+    "c1_prereq":  { "x": 130,  "y": 60, "w": 200, "h": 250, "type": "container", "label": "\u2460 Prerequisites", "color": "#58a6ff" },
+    "c2_platform":{ "x": 345,  "y": 60, "w": 200, "h": 250, "type": "container", "label": "\u2461 Platform Config", "color": "#f0883e" },
+    "c3_db":      { "x": 560,  "y": 60, "w": 195, "h": 250, "type": "container", "label": "\u2462 MaaS Platform", "color": "#3fb950" },
+    "c4_rhoai":   { "x": 770,  "y": 60, "w": 225, "h": 250, "type": "container", "label": "\u2463 RHOAI Config", "color": "#d2a8ff" },
+    "c5_model":   { "x": 1010, "y": 60, "w": 195, "h": 250, "type": "container", "label": "\u2464 Model Deployment", "color": "#79c0ff" },
+    "c6_verify":  { "x": 1220, "y": 60, "w": 170, "h": 250, "type": "container", "label": "\u2465 Verification", "color": "#8b949e" },
+
+    "op_rhoai":   { "x": 150, "y": 98,  "w": 160, "h": 34, "label": "RHOAI Operator", "color": "#58a6ff", "fontSize": 13 },
+    "op_rhcl":    { "x": 150, "y": 138, "w": 160, "h": 34, "label": "RHCL Operator", "sublabel": "Kuadrant", "color": "#58a6ff", "fontSize": 12 },
+    "op_certmgr": { "x": 150, "y": 178, "w": 160, "h": 34, "label": "cert-manager", "color": "#58a6ff", "fontSize": 13 },
+    "op_lws":     { "x": 150, "y": 218, "w": 160, "h": 34, "label": "LeaderWorkerSet", "color": "#58a6ff", "fontSize": 12 },
+
+    "n_uwm":      { "x": 365, "y": 98,  "w": 160, "h": 34, "label": "User Workload Mon.", "color": "#f0883e", "fontSize": 11 },
+    "n_gwclass":  { "x": 365, "y": 138, "w": 160, "h": 34, "label": "GatewayClass", "color": "#f0883e", "fontSize": 13 },
+    "n_gw":       { "x": 365, "y": 178, "w": 160, "h": 44, "label": "Gateway", "sublabel": "maas-default-gateway", "color": "#f0883e", "fontSize": 13 },
+    "n_kuadrant": { "x": 365, "y": 230, "w": 160, "h": 34, "label": "Kuadrant CR", "color": "#f0883e", "fontSize": 13 },
+
+    "n_pg":       { "x": 580, "y": 135, "w": 155, "h": 60, "label": "PostgreSQL", "sublabel": "redhat-ods-applications", "color": "#3fb950", "fontSize": 15 },
+    "n_dbsecret": { "x": 580, "y": 210, "w": 155, "h": 44, "label": "maas-db-config", "sublabel": "Secret", "color": "#3fb950", "fontSize": 13 },
+
+    "n_dsci":     { "x": 790, "y": 98,  "w": 185, "h": 32, "label": "DSCInitialization", "color": "#d2a8ff", "fontSize": 12 },
+    "n_dsc":      { "x": 790, "y": 136, "w": 185, "h": 48, "label": "DataScienceCluster", "sublabel": "aigateway.modelsAsAService", "color": "#d2a8ff", "fontSize": 13 },
+    "n_dash":     { "x": 790, "y": 190, "w": 185, "h": 32, "label": "OdhDashboardConfig", "color": "#d2a8ff", "fontSize": 11 },
+    "n_maasapi":  { "x": 790, "y": 228, "w": 185, "h": 46, "label": "maas-api", "sublabel": "redhat-ai-gateway-infra", "color": "#d2a8ff", "fontSize": 14 },
+
+    "n_lis":      { "x": 1028, "y": 112, "w": 160, "h": 55, "label": "LLMInferenceService", "sublabel": "vLLM", "color": "#79c0ff", "fontSize": 13 },
+    "n_mmr":      { "x": 1028, "y": 182, "w": 160, "h": 55, "label": "MaaSModelRef", "sublabel": "Pending \u2192 Ready", "color": "#79c0ff", "fontSize": 14 },
+
+    "n_verify":   { "x": 1238, "y": 150, "w": 135, "h": 70, "label": "verify.sh", "sublabel": "15-point E2E", "color": "#8b949e", "fontSize": 15 },
+
+    "c_gov": { "x": 770, "y": 340, "w": 460, "h": 205, "type": "container", "label": "Governance Pairing \u00b7 models-as-a-service ns", "color": "#ffa657" },
+    "n_authpolicy":  { "x": 795,  "y": 390, "w": 135, "h": 70, "label": "MaaSAuthPolicy", "sublabel": "WHO may call", "color": "#ffa657", "fontSize": 13 },
+    "n_sub_free":    { "x": 950,  "y": 390, "w": 120, "h": 70, "label": "Subscription", "sublabel": "free \u00b7 pri 10", "color": "#ffa657", "fontSize": 13 },
+    "n_sub_premium": { "x": 1090, "y": 390, "w": 120, "h": 70, "label": "Subscription", "sublabel": "premium \u00b7 pri 20", "color": "#ffa657", "fontSize": 13 },
+    "n_resolved":    { "x": 795,  "y": 475, "w": 415, "h": 50, "label": "Priority Resolver", "sublabel": "highest priority wins \u2014 not accumulated", "color": "#ffa657", "fontSize": 13 },
+
+    "c7_obs":  { "x": 130, "y": 600, "w": 380, "h": 170, "type": "container", "label": "\u2466 Observability (optional)", "color": "#6e7681" },
+    "c8_ext":  { "x": 530, "y": 600, "w": 380, "h": 170, "type": "container", "label": "\u2467 External Models (optional)", "color": "#39c5cf" },
+    "c9_oidc": { "x": 930, "y": 600, "w": 380, "h": 170, "type": "container", "label": "\u2468 External OIDC (optional)", "color": "#db61a2" },
+
+    "n_tempo": { "x": 150, "y": 640, "w": 165, "h": 40, "label": "Tempo", "color": "#6e7681", "fontSize": 13 },
+    "n_otel":  { "x": 330, "y": 640, "w": 165, "h": 40, "label": "OTel Collector", "color": "#6e7681", "fontSize": 12 },
+    "n_loki":  { "x": 150, "y": 695, "w": 165, "h": 40, "label": "Loki", "color": "#6e7681", "fontSize": 13 },
+    "n_coo":   { "x": 330, "y": 695, "w": 165, "h": 40, "label": "Cluster Obs. Operator", "color": "#6e7681", "fontSize": 11 },
+
+    "n_extprov":   { "x": 550, "y": 640, "w": 165, "h": 40, "label": "ExternalProvider", "color": "#39c5cf", "fontSize": 12 },
+    "n_extmodel":  { "x": 730, "y": 640, "w": 165, "h": 40, "label": "ExternalModel", "color": "#39c5cf", "fontSize": 12 },
+    "n_providers": { "x": 550, "y": 695, "w": 345, "h": 40, "label": "OpenAI \u00b7 Gemini \u00b7 Bedrock", "color": "#39c5cf", "fontSize": 12 },
+
+    "n_keycloak": { "x": 950,  "y": 640, "w": 165, "h": 40, "label": "Keycloak", "color": "#db61a2", "fontSize": 13 },
+    "n_aitenant": { "x": 1130, "y": 640, "w": 165, "h": 40, "label": "AITenant", "sublabel": "OIDC patch", "color": "#db61a2", "fontSize": 12 }
+  },
+  "tooltips": {
+    "admin": {
+      "title": "Admin / CLI",
+      "description": "Cluster-admin operator running the guided installation, typically via the single end-to-end script or the AI-assisted /install-maas skill.",
+      "details": [
+        ["Script", "scripts/setup-maas.sh"],
+        ["Flags", "--rhoai-version 3.5|3.4, --with-observability, --with-external-models, --from-phase N"],
+        ["Requires", "OpenShift 4.19+, cluster-admin access"],
+        ["AI-assisted", "/install-maas skill (Claude Code, Cursor, Open Code, Roo Code)"]
+      ]
+    },
+    "caller": {
+      "title": "App / End User",
+      "description": "A client application or team member calling the OpenAI-compatible endpoint with an sk-oai-* API key bound to a specific MaaSSubscription.",
+      "details": [
+        ["API", "POST /v1/chat/completions"],
+        ["Auth", "Authorization: Bearer sk-oai-..."],
+        ["Key \u2192 Subscription", "bound at key-creation time, evaluated server-side"]
+      ]
+    },
+    "op_rhoai": {
+      "title": "RHOAI Operator",
+      "description": "Installs Red Hat OpenShift AI (rhods-operator), providing the DataScienceCluster / DSCInitialization CRDs, KServe, and the dashboard.",
+      "details": [
+        ["Manifest", "manifests/01-prerequisites/operators/rhoai-operator/subscription.yaml"],
+        ["Provides", "DataScienceCluster, DSCInitialization, KServe, Dashboard"]
+      ]
+    },
+    "op_rhcl": {
+      "title": "RHCL Operator (Kuadrant)",
+      "description": "Red Hat Connectivity Link installs the Kuadrant control plane, which in turn deploys Authorino (authZ) and Limitador (rate limiting) once a Kuadrant CR is created.",
+      "details": [
+        ["Manifest", "manifests/01-prerequisites/operators/connectivity-link/subscription.yaml"],
+        ["Deploys", "Kuadrant, Authorino, Limitador"]
+      ],
+      "links": [["Kuadrant Docs", "https://docs.kuadrant.io"]]
+    },
+    "op_certmgr": {
+      "title": "cert-manager",
+      "description": "TLS certificate automation required by Authorino's serving certs and the Gateway.",
+      "details": [
+        ["Manifest", "manifests/01-prerequisites/operators/cert-manager/subscription.yaml"]
+      ]
+    },
+    "op_lws": {
+      "title": "LeaderWorkerSet",
+      "description": "Coordinates distributed, multi-pod inference workloads (used for prefill/decode disaggregated serving).",
+      "details": [
+        ["Manifest", "manifests/01-prerequisites/operators/leader-worker-set/subscription.yaml"]
+      ]
+    },
+    "n_uwm": {
+      "title": "User Workload Monitoring",
+      "description": "Cluster-level Prometheus config enabling scraping of user workloads. Required for Kuadrant/Gateway metrics and the optional Phase 7 observability stack.",
+      "details": [
+        ["Manifest", "manifests/02-platform-config/uwm/cluster-monitoring-config.yaml"]
+      ]
+    },
+    "n_gwclass": {
+      "title": "GatewayClass",
+      "description": "Creating the openshift-default GatewayClass triggers OpenShift's built-in gateway controller to provision the underlying Istio control plane.",
+      "details": [
+        ["Manifest", "manifests/02-platform-config/gatewayclass.yaml"],
+        ["Controller", "openshift-default"]
+      ]
+    },
+    "n_gw": {
+      "title": "Gateway (maas-default-gateway)",
+      "description": "The Gateway API resource that all model HTTPRoutes attach to. Ships with a bumped 2Gi memory limit because loading the Kuadrant Wasm plugin after model deployment can OOM the default 1Gi.",
+      "details": [
+        ["Manifest", "manifests/02-platform-config/gateway.yaml.tmpl + gateway-resources.yaml"],
+        ["Namespace", "openshift-ingress"],
+        ["Common issue", "Default 1Gi memory OOMs once Kuadrant Wasm loads \u2014 fixed via parametersRef"]
+      ]
+    },
+    "n_kuadrant": {
+      "title": "Kuadrant CR",
+      "description": "Cluster-scoped CR that activates the Kuadrant control plane, deploying Authorino and Limitador and wiring policy enforcement onto the Gateway.",
+      "details": [
+        ["Manifest", "manifests/02-platform-config/kuadrant/kuadrant.yaml"],
+        ["Namespace", "kuadrant-system"]
+      ]
+    },
+    "n_pg": {
+      "title": "PostgreSQL",
+      "description": "Backing database for maas-api (API keys, subscriptions, model listings). MUST exist and be reachable before enabling MaaS in the DataScienceCluster \u2014 this is the single most common install-order mistake.",
+      "details": [
+        ["Manifest", "manifests/03-maas-platform/postgres-deployment.yaml"],
+        ["Namespace", "redhat-ods-applications"],
+        ["Critical rule", "Phase 3 (Postgres) must complete before Phase 4 (DSC)"]
+      ]
+    },
+    "n_dbsecret": {
+      "title": "maas-db-config Secret",
+      "description": "Database connection credentials that maas-api reads on startup. If missing when maas-api starts, the pod CrashLoopBackOffs.",
+      "details": [
+        ["Created by", "Phase 3 setup script"],
+        ["Consumed by", "maas-api Deployment (Phase 4)"]
+      ]
+    },
+    "n_dsci": {
+      "title": "DSCInitialization",
+      "description": "Cluster-wide RHOAI initialization object controlling monitoring and service-mesh settings.",
+      "details": [
+        ["Manifest", "manifests/04-rhoai-config/dscinitialization.yaml"]
+      ]
+    },
+    "n_dsc": {
+      "title": "DataScienceCluster",
+      "description": "The central RHOAI feature-toggle object. Setting the MaaS field to Managed enables the whole gateway control plane, including the maas-api rollout.",
+      "details": [
+        ["Manifest (3.5)", "manifests/04-rhoai-config/datasciencecluster.yaml"],
+        ["Manifest (3.4)", "manifests/04-rhoai-config/datasciencecluster-34.yaml"],
+        ["3.5 field", "aigateway.modelsAsAService: Managed"],
+        ["3.4 field", "kserve.modelsAsService: Managed"]
+      ]
+    },
+    "n_dash": {
+      "title": "OdhDashboardConfig",
+      "description": "Enables the modelAsService and externalModels UI flags in the RHOAI dashboard.",
+      "details": [
+        ["Manifest", "manifests/04-rhoai-config/odh-dashboard-config.yaml"]
+      ]
+    },
+    "n_maasapi": {
+      "title": "maas-api",
+      "description": "Control-plane API server managing API keys, subscriptions, and model listings. Rolled out when the DSC enables MaaS \u2014 crash-loops if PostgreSQL / maas-db-config isn't ready yet.",
+      "details": [
+        ["Namespace (3.5)", "redhat-ai-gateway-infra"],
+        ["Namespace (3.4)", "redhat-ods-applications"],
+        ["Endpoints", "/v1/models, /v1/api-keys, /internal/v1/api-keys/validate"],
+        ["Debug: logs", "oc logs -n redhat-ai-gateway-infra deploy/maas-api"]
+      ]
+    },
+    "n_lis": {
+      "title": "LLMInferenceService",
+      "description": "KServe custom resource that runs the vLLM model server and attaches to the shared Gateway.",
+      "details": [
+        ["Manifest pattern", "manifests/05-maas-models/<model>/llm/model.yaml"],
+        ["Models", "simulator, granite-tiny-gpu, gemma, gpt-oss-20b, qwen3-06b"]
+      ]
+    },
+    "n_mmr": {
+      "title": "MaaSModelRef",
+      "description": "Registers a model with the MaaS control plane. Stays Pending until BOTH a MaaSAuthPolicy and a MaaSSubscription reference the same model \u2014 they are independent CRDs that must be paired manually.",
+      "details": [
+        ["Manifest pattern", "manifests/05-maas-models/<model>/maas/maas-model.yaml"],
+        ["Pending reason", "\"No active subscription and auth policy pairing found\""],
+        ["Debug", "oc get maasmodelref -A"]
+      ]
+    },
+    "n_verify": {
+      "title": "verify.sh",
+      "description": "Automated 15-point end-to-end check covering API key issuance, inference, and rate limiting.",
+      "details": [
+        ["Script", "scripts/verify-maas.sh \u2192 manifests/06-verification/verify.sh"]
+      ]
+    },
+    "n_authpolicy": {
+      "title": "MaaSAuthPolicy",
+      "description": "Defines WHO may call a model \u2014 subjects such as groups, users, or service accounts. Reconciles independently of MaaSSubscription; editing one does not resync the other.",
+      "details": [
+        ["Manifest pattern", "manifests/05-maas-models/<model>/maas/maas-auth-policy.yaml"],
+        ["Debug", "oc get maasauthpolicy -A"]
+      ]
+    },
+    "n_sub_free": {
+      "title": "MaaSSubscription (free)",
+      "description": "Defines HOW MUCH a caller may consume \u2014 token rate limits and priority. Example free tier: priority 10, ~100 tokens/min.",
+      "details": [
+        ["Manifest", "manifests/05-maas-models/<model>/maas/maas-subscription-free.yaml"]
+      ]
+    },
+    "n_sub_premium": {
+      "title": "MaaSSubscription (premium)",
+      "description": "Higher-priority tier \u2014 example priority 20, ~100k tokens/min. Wins over the free subscription when a caller matches both.",
+      "details": [
+        ["Manifest", "manifests/05-maas-models/<model>/maas/maas-subscription-premium.yaml"],
+        ["Demo", "demo/subscription-priority/README.md"]
+      ]
+    },
+    "n_resolved": {
+      "title": "Priority Resolver",
+      "description": "When a caller matches multiple subscriptions on the same model, the platform selects the single highest-priority entitlement \u2014 limits are never accumulated across matching subscriptions.",
+      "details": [
+        ["Concept", "Selection, not accumulation"],
+        ["Demo", "demo/subscription-priority/README.md"],
+        ["Related", "demo/user-level-rate-limiting/README.md"]
+      ]
+    },
+    "n_tempo": {
+      "title": "Tempo",
+      "description": "Distributed tracing backend for gateway request traces.",
+      "details": [["Manifest area", "manifests/07-observability/"]]
+    },
+    "n_otel": {
+      "title": "OpenTelemetry Collector",
+      "description": "Collects and forwards traces/metrics emitted by the Gateway and IPP filters.",
+      "details": [["Manifest area", "manifests/07-observability/"]]
+    },
+    "n_loki": {
+      "title": "Loki",
+      "description": "Log aggregation backend (RHOAI 3.5+) for gateway and control-plane logs.",
+      "details": [["Manifest area", "manifests/07-observability/"]]
+    },
+    "n_coo": {
+      "title": "Cluster Observability Operator",
+      "description": "Manages the UIPlugin and dashboards that surface Tempo/Loki data in the OpenShift console.",
+      "details": [["Manifest area", "manifests/07-observability/"]]
+    },
+    "n_extprov": {
+      "title": "ExternalProvider",
+      "description": "Configures a third-party inference API endpoint (RHOAI 3.5 split from ExternalModel).",
+      "details": [["Manifest", "manifests/08-external-models/openai/model/external-provider.yaml"]]
+    },
+    "n_extmodel": {
+      "title": "ExternalModel",
+      "description": "Maps a specific model name (e.g. gpt-4o-mini) to an ExternalProvider and registers it with MaaS.",
+      "details": [["Manifest", "manifests/08-external-models/openai/model/external-model.yaml"]]
+    },
+    "n_providers": {
+      "title": "Supported External Providers",
+      "description": "OpenAI, Google Gemini, and AWS Bedrock are supported as external model backends, proxied through the same gateway policy stack as on-cluster models.",
+      "details": [["Manifest area", "manifests/08-external-models/"]]
+    },
+    "n_keycloak": {
+      "title": "Keycloak",
+      "description": "Deployed by the OIDC setup script to act as (or front) a corporate identity provider for external OIDC authentication.",
+      "details": [["Script", "manifests/09-external-oidc/setup-keycloak.sh"]]
+    },
+    "n_aitenant": {
+      "title": "AITenant (OIDC patch)",
+      "description": "Patches the tenant CR with the OIDC issuer and client ID so group claims from the IdP map to MaaSAuthPolicy subjects.",
+      "details": [["Manifest", "manifests/09-external-oidc/maas-oidc/aitenant-oidc-patch.yaml"]]
+    }
+  },
+  "flows": {
+    "full": {
+      "label": "Full Install (Phases 0-9)",
+      "steps": [
+        { "text": "1. Run ./scripts/setup-maas.sh \u2014 Phase 1: Prerequisites", "mode": "arrow", "from": "admin", "to": "c1_prereq", "color": "#58a6ff", "num": 1, "glow": "c1_prereq" },
+        { "text": "2. Subscribe RHOAI operator (rhods-operator)", "mode": "lightup", "target": "op_rhoai", "badge": 1 },
+        { "text": "3. Subscribe RHCL operator \u2014 installs Kuadrant, Authorino, Limitador", "mode": "lightup", "target": "op_rhcl", "badge": 2 },
+        { "text": "4. Subscribe cert-manager", "mode": "lightup", "target": "op_certmgr", "badge": 3 },
+        { "text": "5. Subscribe LeaderWorkerSet (for P/D disaggregated serving)", "mode": "lightup", "target": "op_lws", "badge": 4 },
+        { "text": "6. Phase 2: Platform Configuration begins", "mode": "arrow", "from": "c1_prereq", "to": "c2_platform", "color": "#f0883e", "num": 6, "glow": "c2_platform" },
+        { "text": "7. Enable User Workload Monitoring", "mode": "lightup", "target": "n_uwm", "badge": 7 },
+        { "text": "8. Create Kuadrant CR \u2014 deploys Authorino + Limitador", "mode": "lightup", "target": "n_kuadrant", "badge": 8 },
+        { "text": "9. Create GatewayClass openshift-default \u2014 provisions Istio", "mode": "lightup", "target": "n_gwclass", "badge": 9 },
+        { "text": "10. Create Gateway maas-default-gateway (2Gi memory)", "mode": "lightup", "target": "n_gw", "badge": 10 },
+        { "text": "11. Phase 3: MaaS Platform begins", "mode": "arrow", "from": "c2_platform", "to": "c3_db", "color": "#3fb950", "num": 11, "glow": "c3_db" },
+        { "text": "12. Deploy PostgreSQL in redhat-ods-applications", "mode": "lightup", "target": "n_pg", "badge": 12 },
+        { "text": "13. Create maas-db-config Secret \u2014 REQUIRED before Phase 4", "mode": "lightup", "target": "n_dbsecret", "badge": 13 },
+        { "text": "14. Phase 4: RHOAI Configuration begins (PostgreSQL ready \u2713)", "mode": "arrow", "from": "c3_db", "to": "c4_rhoai", "color": "#d2a8ff", "num": 14, "glow": "c4_rhoai" },
+        { "text": "15. Apply DSCInitialization", "mode": "lightup", "target": "n_dsci", "badge": 15 },
+        { "text": "16. Apply DataScienceCluster \u2014 aigateway.modelsAsAService: Managed", "mode": "lightup", "target": "n_dsc", "badge": 16 },
+        { "text": "17. Enable dashboard flags (modelAsService, externalModels)", "mode": "lightup", "target": "n_dash", "badge": 17 },
+        { "text": "18. maas-api starts and connects to PostgreSQL successfully", "mode": "lightup", "target": "n_maasapi", "badge": 18 },
+        { "text": "19. Phase 5: Model Deployment begins", "mode": "arrow", "from": "c4_rhoai", "to": "c5_model", "color": "#79c0ff", "num": 19, "glow": "c5_model" },
+        { "text": "20. Deploy LLMInferenceService (vLLM)", "mode": "lightup", "target": "n_lis", "badge": 20 },
+        { "text": "21. Create MaaSModelRef \u2014 status: Pending", "mode": "lightup", "target": "n_mmr", "badge": "P" },
+        { "text": "22. Create MaaSAuthPolicy (who may call this model)", "mode": "arrow", "from": "c5_model", "to": "n_authpolicy", "color": "#ffa657", "num": 22, "glow": "c_gov" },
+        { "text": "23. Create MaaSSubscription (free tier, priority 10)", "mode": "lightup", "target": "n_sub_free", "badge": 23 },
+        { "text": "24. Governance pairing satisfied \u2014 MaaSModelRef: Ready", "mode": "lightup", "target": "n_mmr", "badge": "R" },
+        { "text": "25. Phase 6: Verification \u2014 run verify.sh (15 checks)", "mode": "arrow", "from": "c5_model", "to": "c6_verify", "color": "#8b949e", "num": 25, "glow": "c6_verify" },
+        { "text": "26. 15/15 checks passed", "mode": "lightup", "target": "n_verify", "badge": 26 },
+        { "text": "27. Optional: Phase 7 Observability (Tempo, OTel, Loki)", "mode": "arrow", "from": "c6_verify", "to": "c7_obs", "color": "#6e7681", "num": 27, "glow": "c7_obs" },
+        { "text": "28. Optional: Phase 8 External Models (OpenAI, Gemini, Bedrock)", "mode": "arrow", "from": "c6_verify", "to": "c8_ext", "color": "#39c5cf", "num": 28, "glow": "c8_ext" },
+        { "text": "29. Optional: Phase 9 External OIDC (Keycloak)", "mode": "arrow", "from": "c6_verify", "to": "c9_oidc", "color": "#db61a2", "num": 29, "glow": "c9_oidc" },
+        { "text": "30. Install complete \u2014 ready to serve inference traffic", "mode": "arrow", "from": "c6_verify", "to": "caller", "color": "#3fb950", "num": 30 }
+      ]
+    },
+    "mistake": {
+      "label": "Common Mistake: Wrong Phase Order",
+      "steps": [
+        { "text": "1. Admin jumps ahead and applies Phase 4 before Phase 3", "mode": "arrow", "from": "admin", "to": "c4_rhoai", "color": "#f85149", "num": 1, "glow": "c4_rhoai" },
+        { "text": "2. DataScienceCluster created \u2014 aigateway.modelsAsAService: Managed", "mode": "lightup", "target": "n_dsc", "badge": 2 },
+        { "text": "3. maas-api pod starts and tries to connect to PostgreSQL...", "mode": "lightup", "target": "n_maasapi", "badge": 3 },
+        { "text": "4. PostgreSQL / maas-db-config Secret not found \u2014 maas-api CrashLoopBackOff", "mode": "lightup", "target": "n_maasapi", "badge": "\u2717", "errColor": "#f85149" },
+        { "text": "5. MaaSModelRef registration fails \u2014 depends on a healthy maas-api", "mode": "lightup", "target": "n_mmr", "badge": "\u2717", "errColor": "#f85149" },
+        { "text": "6. Admin sees CrashLoopBackOff and must fix the phase order", "mode": "arrow", "from": "n_maasapi", "to": "admin", "color": "#f85149", "num": 6 },
+        { "text": "7. Correct order: run Phase 3 first", "mode": "arrow", "from": "admin", "to": "c3_db", "color": "#3fb950", "num": 7, "glow": "c3_db" },
+        { "text": "8. Deploy PostgreSQL", "mode": "lightup", "target": "n_pg", "badge": 8 },
+        { "text": "9. Create maas-db-config Secret", "mode": "lightup", "target": "n_dbsecret", "badge": 9 },
+        { "text": "10. Now re-apply Phase 4 \u2014 DataScienceCluster reconciles", "mode": "arrow", "from": "c3_db", "to": "c4_rhoai", "color": "#3fb950", "num": 10, "glow": "c4_rhoai" },
+        { "text": "11. maas-api restarts cleanly and connects to PostgreSQL", "mode": "lightup", "target": "n_maasapi", "badge": 11 }
+      ]
+    },
+    "governance": {
+      "label": "Governance Pairing",
+      "steps": [
+        { "text": "1. Admin applies MaaSModelRef for the model", "mode": "arrow", "from": "admin", "to": "n_mmr", "color": "#79c0ff", "num": 1 },
+        { "text": "2. Status: Pending \u2014 \"no active subscription and auth policy pairing found\"", "mode": "lightup", "target": "n_mmr", "badge": "P" },
+        { "text": "3. Admin applies MaaSAuthPolicy referencing the model", "mode": "arrow", "from": "admin", "to": "n_authpolicy", "color": "#ffa657", "num": 3, "glow": "c_gov" },
+        { "text": "4. MaaSAuthPolicy created \u2014 defines WHO may call (groups/users/service accounts)", "mode": "lightup", "target": "n_authpolicy", "badge": 4 },
+        { "text": "5. Still Pending \u2014 the subscription half of the pairing is still missing", "mode": "lightup", "target": "n_mmr", "badge": "P" },
+        { "text": "6. Admin applies MaaSSubscription (free tier)", "mode": "arrow", "from": "admin", "to": "n_sub_free", "color": "#ffa657", "num": 6 },
+        { "text": "7. MaaSSubscription created \u2014 defines HOW MUCH (tokenRateLimits, priority)", "mode": "lightup", "target": "n_sub_free", "badge": 7 },
+        { "text": "8. Both halves found \u2014 MaaSModelRef transitions to Ready", "mode": "lightup", "target": "n_mmr", "badge": "R" },
+        { "text": "9. Note: editing one CRD later does not resync the other \u2014 they reconcile independently", "mode": "lightup", "target": "n_authpolicy", "badge": "i" }
+      ]
+    },
+    "tiers": {
+      "label": "Tiers & Priority",
+      "steps": [
+        { "text": "1. Two users call the same model with different API keys", "mode": "arrow", "from": "caller", "to": "n_mmr", "color": "#79c0ff", "num": 1 },
+        { "text": "2. User A's key is bound to the 'free' subscription \u2014 priority 10, ~100 tokens/min", "mode": "lightup", "target": "n_sub_free", "badge": 10 },
+        { "text": "3. User B's key is bound to the 'premium' subscription \u2014 priority 20, ~100k tokens/min", "mode": "lightup", "target": "n_sub_premium", "badge": 20 },
+        { "text": "4. Premium entitlement resolves for User B", "mode": "arrow", "from": "n_sub_premium", "to": "n_resolved", "color": "#ffa657", "num": 4 },
+        { "text": "5. Free entitlement resolves for User A", "mode": "arrow", "from": "n_sub_free", "to": "n_resolved", "color": "#ffa657", "num": 5 },
+        { "text": "6. Result: the highest matching priority is selected, never accumulated", "mode": "lightup", "target": "n_resolved", "badge": 6 }
+      ]
+    }
+  },
+  "flowOrder": ["full", "mistake", "governance", "tiers"],
+  "defaultFlow": "full",
+  "legend": [
+    { "color": "#58a6ff", "label": "Prerequisites (Phase 1)" },
+    { "color": "#f0883e", "label": "Platform Config (Phase 2)" },
+    { "color": "#3fb950", "label": "MaaS Platform / DB (Phase 3)" },
+    { "color": "#d2a8ff", "label": "RHOAI Config (Phase 4)" },
+    { "color": "#79c0ff", "label": "Model Deployment (Phase 5)" },
+    { "color": "#8b949e", "label": "Verification (Phase 6)" },
+    { "color": "#ffa657", "label": "Governance CRDs" },
+    { "color": "#f85149", "label": "Failure / CrashLoopBackOff" }
+  ]
+};
+
+await viz.load(diagram);
+
+const cvs = document.getElementById('fs-canvas');
+cvs.addEventListener('mousemove', e => {
+  const rect = cvs.getBoundingClientRect();
+  const eng = viz._engine;
+  const mx = (e.clientX - rect.left - eng._ox) / eng._sc;
+  const my = (e.clientY - rect.top - eng._oy) / eng._sc;
+  let hit = false;
+  for (const [k, n] of Object.entries(eng.state.nodes)) {
+    if (n.type === 'boundary' || n.type === 'container') continue;
+    if (eng.state.tooltips[k] && mx >= n.x && mx <= n.x + n.w && my >= n.y && my <= n.y + n.h) {
+      hit = true;
+      break;
+    }
+  }
+  cvs.style.cursor = hit ? 'pointer' : 'default';
+});
+
+viz.state.loopMode = true;
+viz.play();
+</script>
+</body>
+</html>

--- a/content/modules/ROOT/pages/05-maas-models.adoc
+++ b/content/modules/ROOT/pages/05-maas-models.adoc
@@ -119,6 +119,8 @@ These two CRDs are intentionally separate - they serve different purposes (acces
 However, *updating one does NOT auto-update the other*. If you add a model to a `MaaSSubscription` (via CLI or UI), you must also add it to a `MaaSAuthPolicy`. The controller does not sync them automatically.
 ====
 
+NOTE: link:{attachmentsdir}/install-flow.html[*Open the Install & Configuration Visualizer*^] (opens in a new tab) to see governance pairing, tiers/priority, and the full phase sequence animated end-to-end.
+
 == Deploying a Model
 
 [NOTE]

--- a/content/modules/ROOT/pages/10-post-upgrade-troubleshooting.adoc
+++ b/content/modules/ROOT/pages/10-post-upgrade-troubleshooting.adoc
@@ -782,6 +782,55 @@ After deletion, internal DNS resolves immediately via the wildcard `*.apps.*` re
 
 NOTE: This only affects clusters where the gateway service type was changed from LoadBalancer to ClusterIP. Fresh ClusterIP deployments (where LoadBalancer was never used) are not affected.
 
+[[issue-14]]
+== Issue 14: LlamaStackOperator/OGX Conflict Blocks the Entire AIGateway Module
+
+Reproduced live on a RHOAI 3.5.0 cluster (`stable-3.x` channel) during a fresh {maas} install: `aigateway.modelsAsAService` showed `Managed` in the DSC spec, but `maas-api` never deployed, `ModelsAsAServiceReady` stayed `False`, and applying `MaaSModelRef` failed with `no matches for kind "MaaSModelRef" in version "maas.opendatahub.io/v1alpha1"` - even though the health check, gateway, and PostgreSQL all looked fine. `setup-maas.sh` timed out waiting 300s for the `maas-api` deployment to appear.
+
+The root cause has nothing to do with {maas} itself: the DSC also had `llamastackoperator.managementState: Managed` (either left over from a previous state, or defaulted by the CRD schema when the field is omitted). The opendatahub-operator provisions modules in batches by runlevel, and `aigateway`, `mlflowoperator`, and `ogx` are all provisioned together at runlevel 32. Having both `llamastackoperator: Managed` and `ogx: Managed` set makes the operator reject the `ogx` module outright, which aborts that entire batch - so `aigateway`'s CRDs (`maasmodelrefs.maas.opendatahub.io`, `configs.maas.opendatahub.io`, etc.) and `mlflowoperator`'s CRD never get installed either, even though nothing in the DSC spec or status message mentions `llamastackoperator` at all.
+
+=== Symptoms
+
+* `oc get datasciencecluster default-dsc -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'` shows `"Some modules are not ready: aigateway, mlflowoperator, ogx"`
+* `AIGatewayReady` condition: `Failed to get module status: no matches for kind "AIGateway" in version "components.platform.opendatahub.io/v1alpha1"`
+* `oc get crd | grep maas.opendatahub.io` returns nothing - the MaaS CRDs were never installed
+* `maas-api` deployment does not exist in `redhat-ai-gateway-infra` (or `redhat-ods-applications` on 3.4-style layouts), even 5+ minutes after the DSC was applied
+* `oc apply -f manifests/05-maas-models/.../maas-model.yaml` (or any `MaaSModelRef`) fails with `no matches for kind "MaaSModelRef" ... ensure CRDs are installed first`
+* `rhods-operator` logs (`oc logs -n redhat-ods-operator deployment/rhods-operator`) repeat `"module CRDs not yet available, requesting requeue"` for `aigateway, mlflowoperator, ogx` in an endless loop, interleaved with an ERROR: `"BuildModuleCR failed"` / `error":"LlamaStackOperator is set to Managed; it has been deprecated, set it to Removed before enabling OGX"` and `"provisioning failed: module provisioning failed: ogx"`
+
+=== Diagnosis
+
+[source,bash]
+----
+# Confirm the DSC is not Ready and which modules are stuck
+oc get datasciencecluster default-dsc -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
+
+# Check both fields - this is the smoking gun if both show Managed
+oc get datasciencecluster default-dsc -o jsonpath='{.spec.components.llamastackoperator}{"\n"}'
+oc get datasciencecluster default-dsc -o jsonpath='{.spec.components.ogx}{"\n"}'
+
+# Confirm via operator logs
+oc logs -n redhat-ods-operator deployment/rhods-operator --tail=500 \
+  | grep -i "LlamaStackOperator is set to Managed"
+----
+
+=== Workaround
+
+Set `llamastackoperator` to `Removed` explicitly (it is superseded by `ogx` in 3.5 and does not need to stay `Managed` for anything, including 3.4 compatibility):
+
+[source,bash]
+----
+oc patch datasciencecluster default-dsc --type=merge \
+  -p '{"spec":{"components":{"llamastackoperator":{"managementState":"Removed"}}}}'
+
+# Should flip to True within ~60-90s
+oc wait datasciencecluster default-dsc --for=condition=Ready --timeout=180s
+----
+
+Once `Ready=True`, the `aigateway`, `mlflowoperator`, and MaaS CRDs install automatically and `maas-api`/`maas-controller` deploy without any further action. Re-run the phase that timed out (for example `./scripts/setup-maas.sh --from-phase 4`) to finish deploying models and governance resources.
+
+IMPORTANT: `manifests/04-rhoai-config/datasciencecluster.yaml` in this guide now sets `llamastackoperator: Removed` explicitly alongside `ogx: Managed`, so fresh installs following xref:04-rhoai-config.adoc[Phase 4] as written should not hit this. This issue is most likely to surface on clusters where the DSC already existed (e.g. a prior 3.4 install, or a partially-completed 3.5 attempt) before `setup-maas.sh` ran - the script detects `modelsAsAService: Managed` and skips re-applying the DSC, so a pre-existing `llamastackoperator: Managed` value is never corrected. See xref:12-platform-upgrade.adoc[Step 3] for the equivalent guidance during a 3.4 -> 3.5 upgrade.
+
 == Quick Reference: Triage Order
 
 When you hit problems after upgrading from 3.4 to 3.5, check in this order:
@@ -841,6 +890,10 @@ When you hit problems after upgrading from 3.4 to 3.5, check in this order:
 | 13
 | Changed gateway from LoadBalancer to ClusterIP and DNS broken? (`oc get dnsrecord -n openshift-ingress`)
 | Delete stale dnsrecord (<<issue-13,Issue 13>>)
+
+| 14
+| `maas-api` never appears / `MaaSModelRef` CRD missing, but `modelsAsAService: Managed`? (`oc get datasciencecluster default-dsc -o jsonpath='{.spec.components.llamastackoperator}'`)
+| Set `llamastackoperator` to `Removed` (<<issue-14,Issue 14>>)
 |===
 
 == References
@@ -859,4 +912,5 @@ When you hit problems after upgrading from 3.4 to 3.5, check in this order:
 * link:https://redhat.atlassian.net/browse/RHOAIENG-91640[RHOAIENG-91640 - OTEL collector proxy interception breaks observability]
 * link:https://redhat.atlassian.net/browse/RHOAIENG-93709[RHOAIENG-93709 - HTTPRoute rule name collision in multi-model gateway]
 * link:https://redhat.atlassian.net/browse/RHOAIENG-93962[RHOAIENG-93962 - Stale DNSRecord after gateway service type change]
+* Issue 14 (LlamaStackOperator/OGX conflict) - no Jira ticket filed yet; reproduced live and documented in this guide
 * link:https://redhat.atlassian.net/browse/RHOAIENG-80360[RHOAIENG-80360 - Gateway route hijacking security fix]

--- a/content/modules/ROOT/pages/12-platform-upgrade.adoc
+++ b/content/modules/ROOT/pages/12-platform-upgrade.adoc
@@ -97,21 +97,21 @@ oc get datasciencecluster default-dsc \
 
 == Step 3: Add ogx Component (AI Playground)
 
-The `llamastackoperator` DSC component was renamed to `ogx` in 3.5. Add the new component:
+The `llamastackoperator` DSC component was renamed to `ogx` in 3.5. Add the new component *and* explicitly remove the old one in the same patch:
 
 [source,bash]
 ----
 oc patch datasciencecluster default-dsc --type=merge \
-  -p '{"spec":{"components":{"ogx":{"managementState":"Managed"}}}}'
+  -p '{"spec":{"components":{"ogx":{"managementState":"Managed"},"llamastackoperator":{"managementState":"Removed"}}}}'
 ----
 
-NOTE: Without `ogx`, the AI Playground section will not appear in the Dashboard. The old `llamastackoperator` field can be left as-is in the DSC - it is ignored in 3.5.
+IMPORTANT: Do *not* leave `llamastackoperator` as `Managed` (and do not just omit it - on some clusters the field already defaults to `Managed`). Reproduced and confirmed on a live 3.5.0 cluster: having both `llamastackoperator: Managed` and `ogx: Managed` at the same time causes the operator to reject the `ogx` module with `"LlamaStackOperator is set to Managed; it has been deprecated, set it to Removed before enabling OGX"`. That error aborts the *entire* module-provisioning batch at runlevel 32 - which also includes `aigateway` and `mlflowoperator`. The practical symptom is not just a missing Playground tab: `aigateway`'s CRDs never get installed, `maas-api` never deploys, `ModelsAsAServiceReady` stays `False`, and applying `MaaSModelRef` fails with `no matches for kind "MaaSModelRef"` even though `modelsAsAService` shows `Managed`. See xref:10-post-upgrade-troubleshooting.adoc#issue-14[Issue 14] for the full diagnosis and fix if you already hit this.
 
-WARNING: On some RHOAI 3.5.0 installations, the OGX CRD may not be available yet. If the DSC reports `OGXReady: False` with `no matches for kind "OGX"` after this step, set ogx back to `Removed` to unblock the DSC. This does not affect {maas} functionality - only the AI Playground feature.
+WARNING: On some RHOAI 3.5.0 installations, the OGX CRD may still not be available after removing `llamastackoperator`. If the DSC reports `OGXReady: False` with `no matches for kind "OGX"`, set `ogx` back to `Removed` to unblock the DSC - this one genuinely only affects the AI Playground feature, not {maas}.
 
 [source,bash]
 ----
-# Only if OGX is blocking DSC Ready:
+# Only if OGX is still blocking DSC Ready after removing llamastackoperator:
 oc patch datasciencecluster default-dsc --type=merge \
   -p '{"spec":{"components":{"ogx":{"managementState":"Removed"}}}}'
 ----

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -10,6 +10,13 @@ Requires OpenShift 4.19+ with cluster-admin access.
 
 IMPORTANT: This guide is not a replacement for the official {rhoai} {maas} documentation (link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5/html/govern_llm_access_with_models-as-a-service/index[3.5] | link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/index[3.4]). It is a companion resource with opinionated Kustomize manifests and automation scripts to accelerate deployment.
 
+[NOTE]
+====
+link:{attachmentsdir}/install-flow.html[*Open the Install & Configuration Visualizer*^] (opens in a new tab) +
+_4 Flows | 9 Phases | Governance Pairing | Tiers & Priority | 30+ Components_ +
+An animated, click-to-inspect walkthrough of the full install sequence, the most common ordering mistake, and how MaaSModelRef/MaaSAuthPolicy/MaaSSubscription pair up. Handy for explaining the moving parts to a customer before you touch a cluster.
+====
+
 == Getting Started
 
 Clone the repository and work from its root directory. All commands and file paths in this guide are relative to the cloned repo.

--- a/manifests/04-rhoai-config/datasciencecluster.yaml
+++ b/manifests/04-rhoai-config/datasciencecluster.yaml
@@ -34,6 +34,16 @@ spec:
     # -- OGX (required for GenAI Studio / Playground) --
     ogx:
       managementState: Managed
+    # -- LlamaStack Operator: DEPRECATED, replaced by ogx above. Must be explicitly
+    #    Removed - leaving it Managed (or unset, if the DSC already exists with the
+    #    field defaulted to Managed) makes the operator reject the ogx module with
+    #    "LlamaStackOperator is set to Managed; it has been deprecated, set it to
+    #    Removed before enabling OGX". That failure aborts the entire module-provisioning
+    #    batch at runlevel 32, which also blocks aigateway/mlflowoperator from ever
+    #    installing their CRDs - so maas-api never deploys and MaaSModelRef/etc. CRDs
+    #    never appear, even though modelsAsAService shows Managed. --
+    llamastackoperator:
+      managementState: Removed
     # -- MLflow Operator --
     mlflowoperator:
       managementState: Managed


### PR DESCRIPTION
…conflict

- Add content/modules/ROOT/assets/attachments/install-flow.html: animated FlowStory visualizer covering the full install sequence (Phases 0-9), the Postgres-before-DSC ordering mistake, governance pairing, and tiers/priority resolution.
- Add content/modules/ROOT/assets/attachments/architecture-flow.html: animated visualizer covering the overall MaaS system architecture - OLM operators, DSC/DSCI, component modules (runlevel batching), the MaaS control plane, and the runtime request path.
- Link both visualizers from index.adoc, 05-maas-models.adoc, and README.md.

- manifests/04-rhoai-config/datasciencecluster.yaml: explicitly set llamastackoperator to Removed alongside ogx: Managed. Reproduced live on a RHOAI 3.5.0 cluster - having both Managed causes the operator to reject the ogx module ("LlamaStackOperator is set to Managed; it has been deprecated, set it to Removed before enabling OGX"), which aborts the entire runlevel-32 provisioning batch (aigateway + mlflowoperator + ogx together) - so maas-api never deploys and MaaSModelRef/etc. CRDs never install, even though modelsAsAService shows Managed.
- 10-post-upgrade-troubleshooting.adoc: add Issue 14 documenting this failure mode (symptoms, diagnosis, workaround) plus a new triage-table row.
- 12-platform-upgrade.adoc: correct guidance that previously claimed leaving llamastackoperator Managed is harmless/ignored in 3.5 - it is not; update Step 3 to remove it in the same patch that adds ogx.